### PR TITLE
docs: update skill files and add blasts skill

### DIFF
--- a/skills/partiful-blasts/SKILL.md
+++ b/skills/partiful-blasts/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: partiful-blasts
+description: Send text blasts to event guests via Partiful
+---
+
+# Partiful CLI — Text Blasts
+
+> ⚠️ **Real SMS messages.** Blasts send actual text messages to real people's phones. Partiful prepends: *"The host of {Event} sent a Text Blast —"* before your message.
+
+## Commands
+
+### Send a Text Blast
+```bash
+partiful blasts send <eventId> --message "See you tonight! Parking is on the left." --to GOING,MAYBE
+partiful blasts send <eventId> --message "Updated address: 123 Main St" --to GOING --show-on-event-page
+```
+
+| Flag | Description |
+|------|-------------|
+| `--message <text>` | Message body (**max 480 characters**) |
+| `--to <statuses>` | Comma-separated guest statuses to target (see below) |
+| `--show-on-event-page` | Also display the blast on the event page |
+| `--yes` | Skip the safety confirmation prompt |
+| `--dry-run` | Preview recipients and message without sending |
+
+### Valid `--to` Values
+
+| Status | Description |
+|--------|-------------|
+| `GOING` | Confirmed guests |
+| `MAYBE` | Tentative guests |
+| `DECLINED` | Guests who declined |
+| `SENT` | Invited but no response |
+| `INTERESTED` | Expressed interest |
+| `WAITLIST` | On the waitlist |
+| `APPROVED` | Approved from waitlist |
+| `RESPONDED_TO_FIND_A_TIME` | Responded to scheduling poll |
+
+## Tips
+
+- **Always use `--dry-run` first** to verify the recipient list and message.
+- The 480-character limit is enforced by Partiful's API — the CLI will reject longer messages before sending.
+- Without `--yes`, the CLI shows a confirmation prompt with the recipient count and message preview.
+- Combine with `partiful guests list <eventId> --status going` to preview who will receive the blast.

--- a/skills/partiful-shared/SKILL.md
+++ b/skills/partiful-shared/SKILL.md
@@ -9,9 +9,19 @@ description: Shared auth, global flags, and security rules for the Partiful CLI
 
 ### Login
 ```bash
-partiful auth login
+partiful auth login <phone>
+partiful auth login +15551234567
 ```
-Opens a bookmarklet-based flow to capture your Partiful session token.
+Phone-based authentication. Phone number must be in **E.164 format** (e.g. `+15551234567`).
+
+1. Sends an SMS verification code to the provided number.
+2. **On macOS:** Automatically retrieves the code from iMessage (via `imsg`). No manual input needed.
+3. **Fallback:** If auto-retrieval fails, prompts you to enter the code manually.
+
+| Flag | Description |
+|------|-------------|
+| `--code <code>` | Provide the verification code directly (skip SMS wait) |
+| `--no-auto` | Disable automatic SMS retrieval; always prompt manually |
 
 ### Check Status
 ```bash


### PR DESCRIPTION
Updates SKILL.md files to reflect current CLI state:

- **partiful-shared**: Replaced bookmarklet auth with phone-based auth (`partiful auth login <phone>`). Documented auto SMS retrieval on macOS (via imsg), manual fallback, `--code` and `--no-auto` flags, E.164 format.
- **partiful-blasts**: New skill for text blast command — documents `--to` statuses, 480 char limit, `--dry-run`, safety confirmation, and the SMS warning.
- **partiful-events** and **partiful-guests**: Reviewed — already current, no changes needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guide for partiful-blasts SMS text-sending commands with available flags and operational tips.
  * Updated authentication documentation for partiful auth login to reflect phone-based verification flow with new `--code` and `--no-auto` flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->