### PR TITLE
feat(#8,#10): Event templates + bulk create/update + series creation

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -11,6 +11,8 @@ import { registerShareHelper } from './helpers/share.js';
 import { registerSchemaCommand } from './commands/schema.js';
 import { registerPosterCommands } from './commands/posters.js';
 import { registerDoctorCommands } from './commands/doctor.js';
+import { registerTemplateCommands } from './commands/templates.js';
+import { registerBulkCommands } from './commands/bulk.js';
 import { jsonOutput } from './lib/output.js';
 
 export function run() {
@@ -40,6 +42,8 @@ export function run() {
   registerSchemaCommand(program);
   registerPosterCommands(program);
   registerDoctorCommands(program);
+  registerTemplateCommands(program);
+  registerBulkCommands(program);
 
   program
     .command('version')

--- a/src/commands/bulk.js
+++ b/src/commands/bulk.js
@@ -1,0 +1,315 @@
+/**
+ * Bulk commands — create/update multiple events from JSON/CSV or repeat pattern.
+ */
+
+import fs from 'fs';
+import { loadConfig, getValidToken, wrapPayload } from '../lib/auth.js';
+import { parseDateTime } from '../lib/dates.js';
+import { jsonOutput, jsonError } from '../lib/output.js';
+import { apiRequest, firestoreRequest } from '../lib/http.js';
+
+const DEFAULT_DELAY = 1000; // ms between API calls
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Parse a CSV string into an array of objects (first row = headers).
+ */
+function parseCsv(text) {
+  const lines = text.split('\n').filter(l => l.trim());
+  if (lines.length < 2) return [];
+  const headers = lines[0].split(',').map(h => h.trim());
+  return lines.slice(1).map(line => {
+    const values = [];
+    let current = '';
+    let inQuotes = false;
+    for (const ch of line) {
+      if (ch === '"') { inQuotes = !inQuotes; continue; }
+      if (ch === ',' && !inQuotes) { values.push(current.trim()); current = ''; continue; }
+      current += ch;
+    }
+    values.push(current.trim());
+    const obj = {};
+    headers.forEach((h, i) => { if (values[i] !== undefined && values[i] !== '') obj[h] = values[i]; });
+    return obj;
+  });
+}
+
+/**
+ * Normalize a row from JSON/CSV into the shape events create expects.
+ */
+function normalizeRow(row) {
+  return {
+    title: row.title,
+    date: row.date || row.startDate,
+    endDate: row.endDate || row.end_date || row['end-date'],
+    location: row.location,
+    address: row.address,
+    description: row.description,
+    capacity: row.capacity ? parseInt(row.capacity) : undefined,
+    private: row.private === true || row.private === 'true',
+    timezone: row.timezone || 'America/Los_Angeles',
+    theme: row.theme || 'oxblood',
+    effect: row.effect || 'sunbeams',
+    poster: row.poster,
+    posterSearch: row.posterSearch || row['poster-search'],
+  };
+}
+
+/**
+ * Build event payload (shared with events create — duplicated here to avoid circular imports).
+ */
+function buildEventPayload(opts) {
+  const startDate = parseDateTime(opts.date, opts.timezone);
+  const endDate = opts.endDate ? parseDateTime(opts.endDate, opts.timezone) : null;
+
+  const event = {
+    title: opts.title,
+    startDate: startDate.toISOString(),
+    timezone: opts.timezone || 'America/Los_Angeles',
+    displaySettings: {
+      theme: opts.theme || 'oxblood',
+      effect: opts.effect || 'sunbeams',
+      titleFont: 'display',
+    },
+    showHostList: true,
+    showGuestCount: true,
+    showGuestList: true,
+    showActivityTimestamps: true,
+    displayInviteButton: true,
+    visibility: opts.private ? 'private' : 'public',
+    allowGuestPhotoUpload: true,
+    enableGuestReminders: true,
+    rsvpsEnabled: true,
+    allowGuestsToInviteMutuals: true,
+    rsvpButtonGlyphType: 'emojis',
+    status: 'UNSAVED',
+    guestStatusCounts: {
+      READY_TO_SEND: 0, SENDING: 0, SENT: 0, SEND_ERROR: 0,
+      DELIVERY_ERROR: 0, INTERESTED: 0, MAYBE: 0, GOING: 0,
+      DECLINED: 0, WAITLIST: 0, PENDING_APPROVAL: 0, APPROVED: 0,
+      WITHDRAWN: 0, RESPONDED_TO_FIND_A_TIME: 0,
+      WAITLISTED_FOR_APPROVAL: 0, REJECTED: 0,
+    },
+  };
+
+  if (endDate) event.endDate = endDate.toISOString();
+  if (opts.location) event.location = opts.location;
+  if (opts.address) event.address = opts.address;
+  if (opts.description) event.description = opts.description;
+  if (opts.capacity) { event.guestLimit = opts.capacity; event.enableWaitlist = true; }
+
+  return event;
+}
+
+/**
+ * Generate a series of dates: weekly, biweekly, monthly from a start date.
+ */
+function generateSeries(startDateStr, repeat, count, timezone) {
+  const dates = [];
+  const start = parseDateTime(startDateStr, timezone);
+  for (let i = 0; i < count; i++) {
+    const d = new Date(start);
+    switch (repeat) {
+      case 'daily': d.setDate(d.getDate() + i); break;
+      case 'weekly': d.setDate(d.getDate() + (i * 7)); break;
+      case 'biweekly': d.setDate(d.getDate() + (i * 14)); break;
+      case 'monthly': d.setMonth(d.getMonth() + i); break;
+      default: throw new Error(`Unknown repeat interval: ${repeat}. Use: daily, weekly, biweekly, monthly`);
+    }
+    dates.push(d.toISOString());
+  }
+  return dates;
+}
+
+export function registerBulkCommands(program) {
+  const bulk = program.command('bulk').description('Bulk create or update events');
+
+  bulk
+    .command('create <file>')
+    .description('Create multiple events from a JSON or CSV file')
+    .option('--delay <ms>', 'Delay between API calls (ms)', parseInt, DEFAULT_DELAY)
+    .action(async (file, opts, cmd) => {
+      const globalOpts = cmd.optsWithGlobals();
+      try {
+        if (!fs.existsSync(file)) {
+          jsonError(`File not found: ${file}`, 3, 'validation_error');
+          return;
+        }
+
+        const raw = fs.readFileSync(file, 'utf8');
+        const isCsv = file.endsWith('.csv');
+        let rows;
+
+        if (isCsv) {
+          rows = parseCsv(raw);
+        } else {
+          rows = JSON.parse(raw);
+          if (!Array.isArray(rows)) {
+            jsonError('JSON file must contain an array of event objects.', 3, 'validation_error');
+            return;
+          }
+        }
+
+        if (rows.length === 0) {
+          jsonError('No events found in file.', 3, 'validation_error');
+          return;
+        }
+
+        // Validate all rows before starting
+        const normalized = rows.map((row, i) => {
+          const n = normalizeRow(row);
+          if (!n.title) throw new Error(`Row ${i + 1}: missing "title"`);
+          if (!n.date) throw new Error(`Row ${i + 1}: missing "date"`);
+          return n;
+        });
+
+        if (globalOpts.dryRun) {
+          jsonOutput(normalized.map(n => buildEventPayload(n)), {
+            total: normalized.length,
+            action: 'dry_run',
+            hint: 'Remove --dry-run to create these events',
+          }, globalOpts);
+          return;
+        }
+
+        const config = loadConfig();
+        const token = await getValidToken(config);
+        const results = [];
+
+        for (let i = 0; i < normalized.length; i++) {
+          const event = buildEventPayload(normalized[i]);
+          const payload = { data: wrapPayload(config, { event }) };
+
+          try {
+            const resp = await apiRequest('POST', '/createEvent', token, payload, globalOpts.verbose);
+            results.push({ index: i + 1, status: 'created', title: normalized[i].title, eventId: resp.result?.data || resp.result?.eventId });
+            process.stderr.write(`[${i + 1}/${normalized.length}] Created: ${normalized[i].title}\n`);
+          } catch (e) {
+            results.push({ index: i + 1, status: 'error', title: normalized[i].title, error: e.message });
+            process.stderr.write(`[${i + 1}/${normalized.length}] Failed: ${normalized[i].title} — ${e.message}\n`);
+          }
+
+          if (i < normalized.length - 1) await sleep(opts.delay);
+        }
+
+        jsonOutput(results, {
+          total: results.length,
+          created: results.filter(r => r.status === 'created').length,
+          errors: results.filter(r => r.status === 'error').length,
+        }, globalOpts);
+      } catch (e) {
+        jsonError(e.message);
+      }
+    });
+
+  // Series creation: --repeat weekly --count 4
+  const events = program.commands.find(c => c.name() === 'events');
+  if (events) {
+    const create = events.commands.find(c => c.name() === 'create');
+    if (create) {
+      create
+        .option('--repeat <interval>', 'Create a series: daily, weekly, biweekly, monthly')
+        .option('--count <n>', 'Number of events in series', parseInt);
+    }
+  }
+
+  bulk
+    .command('update')
+    .description('Update multiple events matching a filter')
+    .requiredOption('--filter <query>', 'Filter events (format: "title contains <text>")')
+    .option('--capacity <n>', 'New guest limit', parseInt)
+    .option('--location <location>', 'New location')
+    .option('--description <desc>', 'New description')
+    .option('--delay <ms>', 'Delay between API calls (ms)', parseInt, DEFAULT_DELAY)
+    .action(async (opts, cmd) => {
+      const globalOpts = cmd.optsWithGlobals();
+      try {
+        const config = loadConfig();
+        const token = await getValidToken(config);
+
+        // Fetch upcoming events
+        const listPayload = {
+          data: wrapPayload(config, {
+            params: {},
+            amplitudeSessionId: Date.now(),
+            userId: config.userId,
+          }),
+        };
+        const listResp = await apiRequest('POST', '/getMyUpcomingEventsForHomePage', token, listPayload, globalOpts.verbose);
+        const allEvents = listResp.result?.data?.upcomingEvents || [];
+
+        // Parse filter: "title contains <text>"
+        const filterMatch = opts.filter.match(/^title\s+contains\s+(.+)$/i);
+        if (!filterMatch) {
+          jsonError('Filter format: "title contains <text>". More filters coming soon.', 3, 'validation_error');
+          return;
+        }
+        const filterText = filterMatch[1].toLowerCase();
+        const matched = allEvents.filter(e => e.title && e.title.toLowerCase().includes(filterText));
+
+        if (matched.length === 0) {
+          jsonOutput([], { total: 0, filter: opts.filter, hint: 'No events matched the filter' }, globalOpts);
+          return;
+        }
+
+        // Build update fields
+        const updates = {};
+        if (opts.capacity) updates.guestLimit = opts.capacity;
+        if (opts.location) updates.location = opts.location;
+        if (opts.description) updates.description = opts.description;
+
+        if (Object.keys(updates).length === 0) {
+          jsonError('No update fields provided. Use --capacity, --location, or --description.', 3, 'validation_error');
+          return;
+        }
+
+        if (globalOpts.dryRun) {
+          jsonOutput(matched.map(e => ({
+            eventId: e.id,
+            title: e.title,
+            updates,
+          })), { total: matched.length, action: 'dry_run' }, globalOpts);
+          return;
+        }
+
+        const results = [];
+        for (let i = 0; i < matched.length; i++) {
+          const e = matched[i];
+          try {
+            // Build Firestore update
+            const fields = {};
+            const updateFields = [];
+            for (const [key, val] of Object.entries(updates)) {
+              if (typeof val === 'number') {
+                fields[key] = { integerValue: val };
+              } else {
+                fields[key] = { stringValue: val };
+              }
+              updateFields.push(key);
+            }
+
+            await firestoreRequest('PATCH', e.id, { fields }, token, updateFields, globalOpts.verbose);
+            results.push({ eventId: e.id, title: e.title, status: 'updated' });
+            process.stderr.write(`[${i + 1}/${matched.length}] Updated: ${e.title}\n`);
+          } catch (err) {
+            results.push({ eventId: e.id, title: e.title, status: 'error', error: err.message });
+            process.stderr.write(`[${i + 1}/${matched.length}] Failed: ${e.title} — ${err.message}\n`);
+          }
+
+          if (i < matched.length - 1) await sleep(opts.delay);
+        }
+
+        jsonOutput(results, {
+          total: results.length,
+          updated: results.filter(r => r.status === 'updated').length,
+          errors: results.filter(r => r.status === 'error').length,
+        }, globalOpts);
+      } catch (e) {
+        if (e instanceof (await import('../lib/errors.js')).PartifulError) jsonError(e.message, e.exitCode, e.type, e.details);
+        else jsonError(e.message);
+      }
+    });
+}

--- a/src/commands/events.js
+++ b/src/commands/events.js
@@ -165,8 +165,8 @@ export function registerEventsCommands(program) {
   events
     .command('create')
     .description('Create a new event')
-    .requiredOption('--title <title>', 'Event title')
-    .requiredOption('--date <date>', 'Start date/time (e.g. "2026-04-01 7pm")')
+    .option('--title <title>', 'Event title (required unless using --template)')
+    .option('--date <date>', 'Start date/time (required unless using --template with date)')
     .option('--end-date <endDate>', 'End date/time')
     .option('--location <location>', 'Location name')
     .option('--address <address>', 'Street address')
@@ -181,9 +181,44 @@ export function registerEventsCommands(program) {
     .option('--image <path>', 'Custom image file to upload')
     .option('--link <url...>', 'Link URL (repeatable)')
     .option('--link-text <text...>', 'Display text for link (paired with --link by position)')
+    .option('--template <name>', 'Create from a saved template')
+    .option('--var <vars...>', 'Template variables (key=value)')
     .action(async (opts, cmd) => {
       const globalOpts = cmd.optsWithGlobals();
       try {
+        // Template merging
+        if (opts.template) {
+          const { loadTemplates, applyVariables, mergeTemplateOpts } = await import('../lib/templates.js');
+          const templates = loadTemplates();
+          if (!templates[opts.template]) {
+            jsonError(`Template "${opts.template}" not found. Use "partiful template list" to see available templates.`, 4, 'not_found');
+            return;
+          }
+          let tpl = templates[opts.template];
+          // Parse --var key=value pairs
+          if (opts.var) {
+            const vars = {};
+            for (const v of opts.var) {
+              const eq = v.indexOf('=');
+              if (eq > 0) vars[v.slice(0, eq)] = v.slice(eq + 1);
+            }
+            tpl = applyVariables(tpl, vars);
+          }
+          // Merge: CLI opts override template
+          const merged = mergeTemplateOpts(tpl, opts);
+          Object.assign(opts, merged);
+        }
+
+        // Validate required fields after template merge
+        if (!opts.title) {
+          jsonError('--title is required (provide directly or via --template).', 3, 'validation_error');
+          return;
+        }
+        if (!opts.date) {
+          jsonError('--date is required (provide directly or via --template).', 3, 'validation_error');
+          return;
+        }
+
         const config = loadConfig();
         const token = await getValidToken(config);
 
@@ -305,7 +340,42 @@ export function registerEventsCommands(program) {
         };
 
         if (globalOpts.dryRun) {
-          jsonOutput({ dryRun: true, endpoint: '/createEvent', payload });
+          jsonOutput({ dryRun: true, endpoint: '/createEvent', payload, ...(opts.repeat ? { series: { repeat: opts.repeat, count: opts.count } } : {}) });
+          return;
+        }
+
+        // Series creation: --repeat weekly --count 4
+        if (opts.repeat && opts.count && opts.count > 1) {
+          const results = [];
+          const intervals = { daily: 1, weekly: 7, biweekly: 14 };
+          for (let i = 0; i < opts.count; i++) {
+            const d = new Date(startDate);
+            if (opts.repeat === 'monthly') {
+              d.setMonth(d.getMonth() + i);
+            } else {
+              const days = intervals[opts.repeat];
+              if (!days) { jsonError(`Unknown repeat: ${opts.repeat}. Use: daily, weekly, biweekly, monthly`, 3, 'validation_error'); return; }
+              d.setDate(d.getDate() + (i * days));
+            }
+            const seriesEvent = { ...event, startDate: d.toISOString() };
+            const seriesPayload = {
+              data: wrapPayload(config, {
+                params: { event: seriesEvent, cohostIds: [] },
+                amplitudeSessionId: Date.now(),
+                userId: config.userId,
+              }),
+            };
+            try {
+              const res = await apiRequest('POST', '/createEvent', token, seriesPayload, globalOpts.verbose);
+              const id = res.result?.data || res.result?.eventId;
+              results.push({ index: i + 1, status: 'created', title: opts.title, date: d.toISOString(), id, url: `https://partiful.com/e/${id}` });
+              process.stderr.write(`[${i + 1}/${opts.count}] Created: ${opts.title} (${d.toLocaleDateString()})\n`);
+            } catch (err) {
+              results.push({ index: i + 1, status: 'error', title: opts.title, date: d.toISOString(), error: err.message });
+            }
+            if (i < opts.count - 1) await new Promise(r => setTimeout(r, 1000));
+          }
+          jsonOutput(results, { total: results.length, repeat: opts.repeat });
           return;
         }
 

--- a/src/commands/templates.js
+++ b/src/commands/templates.js
@@ -1,0 +1,142 @@
+/**
+ * Template commands — save, list, show, edit, delete event templates.
+ */
+
+import { loadTemplates, saveTemplates, extractTemplate, applyVariables } from '../lib/templates.js';
+import { jsonOutput, jsonError } from '../lib/output.js';
+
+export function registerTemplateCommands(program) {
+  const template = program.command('template').description('Manage event templates');
+
+  template
+    .command('list')
+    .description('List saved templates')
+    .action((opts, cmd) => {
+      const globalOpts = cmd.optsWithGlobals();
+      const templates = loadTemplates();
+      const names = Object.keys(templates);
+      if (names.length === 0) {
+        jsonOutput([], { total: 0, hint: 'Save a template with: partiful template save <eventId> --name <name>' }, globalOpts);
+        return;
+      }
+      const items = names.map(name => ({
+        name,
+        title: templates[name].title || '(no title)',
+        location: templates[name].location || '',
+        fields: Object.keys(templates[name]).length,
+      }));
+      jsonOutput(items, { total: items.length }, globalOpts);
+    });
+
+  template
+    .command('show <name>')
+    .description('Show template details')
+    .action((name, opts, cmd) => {
+      const globalOpts = cmd.optsWithGlobals();
+      const templates = loadTemplates();
+      if (!templates[name]) {
+        jsonError(`Template "${name}" not found. Use "partiful template list" to see available templates.`, 4, 'not_found');
+        return;
+      }
+      jsonOutput(templates[name], { name }, globalOpts);
+    });
+
+  template
+    .command('save')
+    .description('Save current CLI options as a template (or extract from an existing event)')
+    .requiredOption('--name <name>', 'Template name')
+    .option('--title <title>', 'Event title')
+    .option('--location <location>', 'Location name')
+    .option('--address <address>', 'Street address')
+    .option('--description <desc>', 'Event description')
+    .option('--capacity <n>', 'Guest limit', parseInt)
+    .option('--private', 'Make event private')
+    .option('--timezone <tz>', 'Timezone')
+    .option('--theme <theme>', 'Color theme')
+    .option('--effect <effect>', 'Visual effect')
+    .option('--poster <posterId>', 'Built-in poster ID')
+    .option('--poster-search <query>', 'Poster search query')
+    .option('--link <url...>', 'Link URL (repeatable)')
+    .option('--link-text <text...>', 'Display text for link')
+    .option('--force', 'Overwrite existing template')
+    .action((opts, cmd) => {
+      const globalOpts = cmd.optsWithGlobals();
+      const templates = loadTemplates();
+      const name = opts.name;
+
+      if (templates[name] && !opts.force && !globalOpts.force) {
+        jsonError(`Template "${name}" already exists. Use --force to overwrite.`, 3, 'validation_error');
+        return;
+      }
+
+      const tpl = extractTemplate(opts);
+      if (Object.keys(tpl).length === 0) {
+        jsonError('No template fields provided. Use --title, --location, etc.', 3, 'validation_error');
+        return;
+      }
+
+      templates[name] = tpl;
+      saveTemplates(templates);
+      jsonOutput(tpl, { name, action: 'saved' }, globalOpts);
+    });
+
+  template
+    .command('edit <name>')
+    .description('Edit a saved template')
+    .option('--title <title>', 'Event title')
+    .option('--location <location>', 'Location name')
+    .option('--address <address>', 'Street address')
+    .option('--description <desc>', 'Event description')
+    .option('--capacity <n>', 'Guest limit', parseInt)
+    .option('--private', 'Make event private')
+    .option('--timezone <tz>', 'Timezone')
+    .option('--theme <theme>', 'Color theme')
+    .option('--effect <effect>', 'Visual effect')
+    .option('--poster <posterId>', 'Built-in poster ID')
+    .option('--poster-search <query>', 'Poster search query')
+    .option('--link <url...>', 'Link URL (repeatable)')
+    .option('--link-text <text...>', 'Display text for link')
+    .option('--rename <newName>', 'Rename template')
+    .action((name, opts, cmd) => {
+      const globalOpts = cmd.optsWithGlobals();
+      const templates = loadTemplates();
+
+      if (!templates[name]) {
+        jsonError(`Template "${name}" not found.`, 4, 'not_found');
+        return;
+      }
+
+      // Apply edits
+      const edits = extractTemplate(opts);
+      const updated = { ...templates[name], ...edits };
+
+      if (opts.rename) {
+        delete templates[name];
+        templates[opts.rename] = updated;
+        saveTemplates(templates);
+        jsonOutput(updated, { name: opts.rename, renamedFrom: name, action: 'edited' }, globalOpts);
+      } else {
+        templates[name] = updated;
+        saveTemplates(templates);
+        jsonOutput(updated, { name, action: 'edited' }, globalOpts);
+      }
+    });
+
+  template
+    .command('delete <name>')
+    .description('Delete a saved template')
+    .action((name, opts, cmd) => {
+      const globalOpts = cmd.optsWithGlobals();
+      const templates = loadTemplates();
+
+      if (!templates[name]) {
+        jsonError(`Template "${name}" not found.`, 4, 'not_found');
+        return;
+      }
+
+      const deleted = templates[name];
+      delete templates[name];
+      saveTemplates(templates);
+      jsonOutput(deleted, { name, action: 'deleted' }, globalOpts);
+    });
+}

--- a/src/lib/templates.js
+++ b/src/lib/templates.js
@@ -1,0 +1,93 @@
+/**
+ * Template storage — saves/loads event templates from ~/.config/partiful/templates.json
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+function templatesPath() {
+  return process.env.PARTIFUL_TEMPLATES_FILE
+    || path.join(process.env.HOME, '.config/partiful/templates.json');
+}
+
+export function loadTemplates() {
+  const p = templatesPath();
+  if (!fs.existsSync(p)) return {};
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+export function saveTemplates(templates) {
+  const p = templatesPath();
+  const dir = path.dirname(p);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(p, JSON.stringify(templates, null, 2));
+}
+
+/** Fields we save from an event into a template */
+const TEMPLATE_FIELDS = [
+  'title', 'location', 'address', 'description', 'timezone',
+  'capacity', 'private', 'theme', 'effect', 'poster', 'posterSearch',
+  'link', 'linkText',
+];
+
+/**
+ * Extract template-worthy fields from CLI opts or an API event object.
+ */
+export function extractTemplate(source) {
+  const tpl = {};
+  for (const key of TEMPLATE_FIELDS) {
+    if (source[key] !== undefined && source[key] !== null) {
+      tpl[key] = source[key];
+    }
+  }
+  // Map API event fields to CLI option names
+  if (source.guestLimit && !tpl.capacity) tpl.capacity = source.guestLimit;
+  if (source.visibility === 'private' && !tpl.private) tpl.private = true;
+  if (source.displaySettings) {
+    if (source.displaySettings.theme && !tpl.theme) tpl.theme = source.displaySettings.theme;
+    if (source.displaySettings.effect && !tpl.effect) tpl.effect = source.displaySettings.effect;
+  }
+  if (source.links && !tpl.link) {
+    tpl.link = source.links.map(l => l.url);
+    tpl.linkText = source.links.map(l => l.text || l.url);
+  }
+  return tpl;
+}
+
+/**
+ * Apply variable substitution: {{varName}} → value
+ */
+export function applyVariables(template, vars) {
+  if (!vars || Object.keys(vars).length === 0) return { ...template };
+  const result = {};
+  for (const [key, value] of Object.entries(template)) {
+    if (typeof value === 'string') {
+      result[key] = value.replace(/\{\{(\w+)\}\}/g, (match, name) => {
+        return vars[name] !== undefined ? vars[name] : match;
+      });
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+/**
+ * Merge template with CLI overrides. CLI opts win.
+ */
+export function mergeTemplateOpts(template, opts) {
+  const merged = { ...template };
+  for (const key of TEMPLATE_FIELDS) {
+    if (opts[key] !== undefined && opts[key] !== null) {
+      merged[key] = opts[key];
+    }
+  }
+  // Date is always from CLI
+  if (opts.date) merged.date = opts.date;
+  if (opts.endDate) merged.endDate = opts.endDate;
+  return merged;
+}

--- a/tests/bulk.test.js
+++ b/tests/bulk.test.js
@@ -1,0 +1,144 @@
+/**
+ * Tests for bulk commands and series creation.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { run, runRaw } from './helpers.js';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+let tmpDir;
+
+describe('bulk create', () => {
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'partiful-bulk-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('--dry-run previews events from JSON file', () => {
+    const events = [
+      { title: 'Event 1', date: '2026-04-15 7pm', location: 'Place A' },
+      { title: 'Event 2', date: '2026-04-22 7pm', location: 'Place B' },
+    ];
+    const jsonFile = path.join(tmpDir, 'events.json');
+    fs.writeFileSync(jsonFile, JSON.stringify(events));
+
+    const out = run(['bulk', 'create', jsonFile, '--dry-run']);
+    expect(out.status).toBe('success');
+    expect(out.data.length).toBe(2);
+    expect(out.data[0].title).toBe('Event 1');
+    expect(out.data[1].title).toBe('Event 2');
+    expect(out.metadata.action).toBe('dry_run');
+  });
+
+  it('--dry-run previews events from CSV file', () => {
+    const csv = 'title,date,location,capacity\nParty A,2026-05-01 8pm,Venue X,20\nParty B,2026-05-08 8pm,Venue Y,30';
+    const csvFile = path.join(tmpDir, 'events.csv');
+    fs.writeFileSync(csvFile, csv);
+
+    const out = run(['bulk', 'create', csvFile, '--dry-run']);
+    expect(out.status).toBe('success');
+    expect(out.data.length).toBe(2);
+    expect(out.data[0].title).toBe('Party A');
+    expect(out.data[0].location).toBe('Venue X');
+  });
+
+  it('rejects empty JSON array', () => {
+    const jsonFile = path.join(tmpDir, 'empty.json');
+    fs.writeFileSync(jsonFile, '[]');
+
+    const { stdout } = runRaw(['bulk', 'create', jsonFile, '--dry-run']);
+    const out = JSON.parse(stdout.trim());
+    expect(out.status).toBe('error');
+  });
+
+  it('rejects missing file', () => {
+    const { stdout } = runRaw(['bulk', 'create', '/tmp/nonexistent-xyz-12345.json', '--dry-run']);
+    const out = JSON.parse(stdout.trim());
+    expect(out.status).toBe('error');
+    expect(out.error.message).toContain('not found');
+  });
+
+  it('validates rows have required fields', () => {
+    const events = [{ title: 'No Date Event' }];
+    const jsonFile = path.join(tmpDir, 'bad.json');
+    fs.writeFileSync(jsonFile, JSON.stringify(events));
+
+    const { stdout } = runRaw(['bulk', 'create', jsonFile, '--dry-run']);
+    const out = JSON.parse(stdout.trim());
+    expect(out.status).toBe('error');
+    expect(out.error.message).toContain('missing "date"');
+  });
+});
+
+describe('events create --repeat (series)', () => {
+  it('--dry-run with --repeat and --count shows series info', () => {
+    const out = run(['events', 'create', '--title', 'Weekly Game Night', '--date', '2026-04-15 7pm', '--repeat', 'weekly', '--count', '4', '--dry-run']);
+    expect(out.status).toBe('success');
+    expect(out.data.dryRun).toBe(true);
+    expect(out.data.series.repeat).toBe('weekly');
+    expect(out.data.series.count).toBe(4);
+  });
+});
+
+describe('events create --template', () => {
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'partiful-tpl-create-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('--template fills in fields from saved template', () => {
+    // Save a template
+    run(['template', 'save', '--name', 'game-night', '--title', 'Game Night', '--location', 'My Place', '--capacity', '10'], {
+      env: { PARTIFUL_TEMPLATES_FILE: path.join(tmpDir, 'templates.json') },
+    });
+
+    // Create event using template
+    const out = run(['events', 'create', '--template', 'game-night', '--date', '2026-04-15 7pm', '--dry-run'], {
+      env: { PARTIFUL_TEMPLATES_FILE: path.join(tmpDir, 'templates.json') },
+    });
+    expect(out.status).toBe('success');
+    expect(out.data.dryRun).toBe(true);
+    expect(out.data.payload.data.params.event.title).toBe('Game Night');
+    expect(out.data.payload.data.params.event.location).toBe('My Place');
+  });
+
+  it('CLI opts override template values', () => {
+    run(['template', 'save', '--name', 'game-night', '--title', 'Game Night', '--location', 'My Place'], {
+      env: { PARTIFUL_TEMPLATES_FILE: path.join(tmpDir, 'templates.json') },
+    });
+
+    const out = run(['events', 'create', '--template', 'game-night', '--title', 'Custom Title', '--date', '2026-04-15 7pm', '--dry-run'], {
+      env: { PARTIFUL_TEMPLATES_FILE: path.join(tmpDir, 'templates.json') },
+    });
+    expect(out.data.payload.data.params.event.title).toBe('Custom Title');
+  });
+
+  it('--template with missing template returns error', () => {
+    const { stdout } = runRaw(['events', 'create', '--template', 'nonexistent', '--date', '2026-04-15 7pm'], {
+      env: { PARTIFUL_TEMPLATES_FILE: path.join(tmpDir, 'templates.json') },
+    });
+    const out = JSON.parse(stdout.trim());
+    expect(out.status).toBe('error');
+    expect(out.error.type).toBe('not_found');
+  });
+
+  it('--template with --var substitutes variables', () => {
+    run(['template', 'save', '--name', 'weekly', '--title', 'Game Night Week {{week}}', '--location', '{{venue}}'], {
+      env: { PARTIFUL_TEMPLATES_FILE: path.join(tmpDir, 'templates.json') },
+    });
+
+    const out = run(['events', 'create', '--template', 'weekly', '--date', '2026-04-15 7pm', '--var', 'week=15', '--var', 'venue=My House', '--dry-run'], {
+      env: { PARTIFUL_TEMPLATES_FILE: path.join(tmpDir, 'templates.json') },
+    });
+    expect(out.data.payload.data.params.event.title).toBe('Game Night Week 15');
+    expect(out.data.payload.data.params.event.location).toBe('My House');
+  });
+});

--- a/tests/templates.test.js
+++ b/tests/templates.test.js
@@ -1,0 +1,137 @@
+/**
+ * Tests for template commands and library.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { run, runRaw } from './helpers.js';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+let tmpDir;
+
+function tplRun(args, extraEnv = {}) {
+  return run(args, {
+    env: {
+      PARTIFUL_TEMPLATES_FILE: path.join(tmpDir, 'templates.json'),
+      ...extraEnv,
+    },
+  });
+}
+
+function tplRunRaw(args, extraEnv = {}) {
+  return runRaw(args, {
+    env: {
+      PARTIFUL_TEMPLATES_FILE: path.join(tmpDir, 'templates.json'),
+      ...extraEnv,
+    },
+  });
+}
+
+describe('template commands', () => {
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'partiful-tpl-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('template list returns empty array when no templates', () => {
+    const out = tplRun(['template', 'list']);
+    expect(out.status).toBe('success');
+    expect(out.data).toEqual([]);
+    expect(out.metadata.total).toBe(0);
+  });
+
+  it('template save creates a template', () => {
+    const out = tplRun(['template', 'save', '--name', 'game-night', '--title', 'Game Night', '--location', 'My Place', '--capacity', '10']);
+    expect(out.status).toBe('success');
+    expect(out.data.title).toBe('Game Night');
+    expect(out.data.location).toBe('My Place');
+    expect(out.data.capacity).toBe(10);
+    expect(out.metadata.name).toBe('game-night');
+  });
+
+  it('template list shows saved templates', () => {
+    tplRun(['template', 'save', '--name', 'game-night', '--title', 'Game Night', '--location', 'My Place']);
+    const out = tplRun(['template', 'list']);
+    expect(out.data.length).toBe(1);
+    expect(out.data[0].name).toBe('game-night');
+    expect(out.data[0].title).toBe('Game Night');
+  });
+
+  it('template show returns template details', () => {
+    tplRun(['template', 'save', '--name', 'game-night', '--title', 'Game Night', '--capacity', '10']);
+    const out = tplRun(['template', 'show', 'game-night']);
+    expect(out.status).toBe('success');
+    expect(out.data.title).toBe('Game Night');
+    expect(out.data.capacity).toBe(10);
+  });
+
+  it('template show returns error for missing template', () => {
+    const { stdout, exitCode } = tplRunRaw(['template', 'show', 'nonexistent']);
+    const out = JSON.parse(stdout.trim());
+    expect(out.status).toBe('error');
+    expect(out.error.type).toBe('not_found');
+  });
+
+  it('template edit updates fields', () => {
+    tplRun(['template', 'save', '--name', 'game-night', '--title', 'Game Night', '--capacity', '10']);
+    const out = tplRun(['template', 'edit', 'game-night', '--capacity', '20', '--location', 'New Place']);
+    expect(out.data.capacity).toBe(20);
+    expect(out.data.location).toBe('New Place');
+    expect(out.data.title).toBe('Game Night'); // preserved
+  });
+
+  it('template edit --rename works', () => {
+    tplRun(['template', 'save', '--name', 'old-name', '--title', 'Test']);
+    const out = tplRun(['template', 'edit', 'old-name', '--rename', 'new-name']);
+    expect(out.metadata.name).toBe('new-name');
+    expect(out.metadata.renamedFrom).toBe('old-name');
+
+    const list = tplRun(['template', 'list']);
+    expect(list.data.length).toBe(1);
+    expect(list.data[0].name).toBe('new-name');
+  });
+
+  it('template delete removes template', () => {
+    tplRun(['template', 'save', '--name', 'game-night', '--title', 'Game Night']);
+    const out = tplRun(['template', 'delete', 'game-night']);
+    expect(out.metadata.action).toBe('deleted');
+
+    const list = tplRun(['template', 'list']);
+    expect(list.data.length).toBe(0);
+  });
+
+  it('template save --force overwrites', () => {
+    tplRun(['template', 'save', '--name', 'game-night', '--title', 'V1']);
+    const out = tplRun(['template', 'save', '--name', 'game-night', '--title', 'V2', '--force']);
+    expect(out.data.title).toBe('V2');
+  });
+
+  it('template save without --force rejects duplicate', () => {
+    tplRun(['template', 'save', '--name', 'game-night', '--title', 'V1']);
+    const { stdout } = tplRunRaw(['template', 'save', '--name', 'game-night', '--title', 'V2']);
+    const out = JSON.parse(stdout.trim());
+    expect(out.status).toBe('error');
+    expect(out.error.type).toBe('validation_error');
+  });
+});
+
+describe('template variable substitution', () => {
+  it('replaces {{variables}} in template fields', async () => {
+    const { applyVariables } = await import('../src/lib/templates.js');
+    const tpl = { title: 'Game Night Week {{week_number}}', location: '{{venue}}' };
+    const result = applyVariables(tpl, { week_number: '15', venue: 'My Place' });
+    expect(result.title).toBe('Game Night Week 15');
+    expect(result.location).toBe('My Place');
+  });
+
+  it('preserves unmatched variables', async () => {
+    const { applyVariables } = await import('../src/lib/templates.js');
+    const tpl = { title: '{{greeting}} {{unknown}}' };
+    const result = applyVariables(tpl, { greeting: 'Hi' });
+    expect(result.title).toBe('Hi {{unknown}}');
+  });
+});


### PR DESCRIPTION
Closes #8, closes #10

## What

### Event Templates (#8)
- `partiful template save --name "game-night" --title "Game Night" --location "My Place"`
- `partiful template list/show/edit/delete`
- `partiful events create --template "game-night" --date "Apr 15 7pm"`
- Variable substitution: `--var week=15` replaces `{{week}}` in template fields
- CLI opts always override template values
- Templates stored in `~/.config/partiful/templates.json`

### Bulk Operations (#10)
- **From file:** `partiful bulk create events.json` (or `.csv`)
- **Series:** `partiful events create --title "Game Night" --date "Apr 15 7pm" --repeat weekly --count 4`
- **Bulk update:** `partiful bulk update --filter "title contains Game" --capacity 20`
- `--dry-run` on everything
- Rate limiting with `--delay <ms>` (default 1s between calls)
- Progress output on stderr

### CSV Format
```csv
title,date,location,capacity
Party A,2026-05-01 8pm,Venue X,20
Party B,2026-05-08 8pm,Venue Y,30
```

## Testing
- 22 new tests (12 template, 10 bulk/series)
- 101 total, all passing
- No regressions