### PR TITLE
fix(events): repair events get — /getEvent retired, use /getEventInfo

### DIFF
--- a/src/commands/events.js
+++ b/src/commands/events.js
@@ -103,11 +103,11 @@ export function registerEventsCommands(program) {
         const payload = makePayload(config, { eventId });
 
         if (globalOpts.dryRun) {
-          jsonOutput({ dryRun: true, endpoint: '/getEvent', payload });
+          jsonOutput({ dryRun: true, endpoint: '/getEventInfo', payload });
           return;
         }
 
-        const result = await apiRequest('POST', '/getEvent', token, payload, globalOpts.verbose);
+        const result = await apiRequest('POST', '/getEventInfo', token, payload, globalOpts.verbose);
         const event = result.result?.data?.event;
 
         if (!event) {
@@ -393,7 +393,7 @@ export function registerEventsCommands(program) {
         // 1. Fetch source event
         let sourceEvent;
         try {
-          const result = await apiRequest('POST', '/getEvent', token, makePayload(config, { eventId }), globalOpts.verbose);
+          const result = await apiRequest('POST', '/getEventInfo', token, makePayload(config, { eventId }), globalOpts.verbose);
           sourceEvent = result.result?.data?.event;
         } catch (e) {
           if (!globalOpts.dryRun) throw e;
@@ -498,7 +498,7 @@ export function registerEventsCommands(program) {
 
         // Confirm unless --yes or --force
         if (!globalOpts.yes && !globalOpts.force) {
-          const eventResult = await apiRequest('POST', '/getEvent', token, makePayload(config, { eventId }), globalOpts.verbose);
+          const eventResult = await apiRequest('POST', '/getEventInfo', token, makePayload(config, { eventId }), globalOpts.verbose);
           const event = eventResult.result?.data?.event;
           if (event) {
             const going = event.guestStatusCounts?.GOING || 0;

--- a/src/commands/guests.js
+++ b/src/commands/guests.js
@@ -58,7 +58,7 @@ export function registerGuestsCommands(program) {
         let counts = {};
         let eventTitle = 'Unknown Event';
         try {
-          const eventResult = await apiRequest('POST', '/getEvent', token, eventPayload, globalOpts.verbose);
+          const eventResult = await apiRequest('POST', '/getEventInfo', token, eventPayload, globalOpts.verbose);
           const event = eventResult.result?.data?.event;
           if (event) {
             eventTitle = event.title;

--- a/src/helpers/clone.js
+++ b/src/helpers/clone.js
@@ -31,7 +31,7 @@ export function registerCloneHelper(program) {
           }),
         };
 
-        const getResult = await apiRequest('POST', '/getEvent', token, getPayload, globalOpts.verbose);
+        const getResult = await apiRequest('POST', '/getEventInfo', token, getPayload, globalOpts.verbose);
         const source = getResult.result?.data?.event;
 
         if (!source) {

--- a/src/helpers/export.js
+++ b/src/helpers/export.js
@@ -31,7 +31,7 @@ export function registerExportHelper(program) {
           }),
         };
 
-        const result = await apiRequest('POST', '/getEvent', token, payload, globalOpts.verbose);
+        const result = await apiRequest('POST', '/getEventInfo', token, payload, globalOpts.verbose);
         const event = result.result?.data?.event;
 
         if (!event) {

--- a/src/helpers/share.js
+++ b/src/helpers/share.js
@@ -27,7 +27,7 @@ export function registerShareHelper(program) {
           }),
         };
 
-        const result = await apiRequest('POST', '/getEvent', token, payload, globalOpts.verbose);
+        const result = await apiRequest('POST', '/getEventInfo', token, payload, globalOpts.verbose);
         const event = result.result?.data?.event;
 
         const title = event?.title || 'Unknown Event';

--- a/tests/events-integration.test.js
+++ b/tests/events-integration.test.js
@@ -20,7 +20,7 @@ describe('events integration', () => {
       const out = run(['events', 'get', 'test-event-123', '--dry-run']);
       expect(out.status).toBe('success');
       expect(out.data.dryRun).toBe(true);
-      expect(out.data.endpoint).toBe('/getEvent');
+      expect(out.data.endpoint).toBe('/getEventInfo');
     });
 
     it('events create --dry-run', () => {


### PR DESCRIPTION
## Summary

Closes #57.

`partiful events get` — and every helper that fetches a single event (`+clone`, `+share`, `+export`, the `guests list` header, and the `events cancel` confirmation) — returned **404 for every event**. Partiful retired the `/getEvent` API endpoint. The current endpoint is `/getEventInfo`.

## Root cause

Diagnosed empirically (not guessed): probing the live API, `/getEvent` 404s for all event IDs, while `/getEventInfo` returns `200` with the **identical response envelope** the CLI already consumes — `result.data.event` with `title`, `startDate`, `endDate`, `status`, `timezone`, `guestStatusCounts`, `displaySettings`, `description`, etc. Verified for both hosted and guest events.

## Changes

Endpoint string `/getEvent` → `/getEventInfo` at all 8 live call sites:

- `src/commands/events.js` (get, +clone source-fetch, cancel confirmation) + the `events get --dry-run` label
- `src/commands/guests.js` (event header)
- `src/helpers/share.js`, `src/helpers/clone.js`, `src/helpers/export.js`

No consumer logic changed — only the endpoint. (Historical `docs/plans/*.md` references are intentionally left as-is.)

## Testing

- Suite green (106); updated the one integration assertion on the dry-run endpoint label.
- **Live-verified** after the fix: `events get` returns real data on both a hosted and a guest event (both previously 404'd), and the dependent `+export` path succeeds.

## Known follow-up (out of scope)

For **guest** events (ones you don't host), `/getEventInfo` returns location as a nested `locationInfo` object rather than the flat `location`/`address` fields — so `events get` on a guest event currently shows `location: null` even when an approximate location exists. This is **not a regression** (the endpoint 404'd entirely before) and there's no crash — the existing `|| null` defaults absorb it. A flat-field mapping would need to be consumer-specific (e.g. `+clone` should *not* inherit a vague "Seattle, WA" approximation), so it belongs in its own change. Tracked in #60.
