### PR TITLE
feat(rsvp): self-RSVP + interested commands with verified questionnaire support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 
 # git worktrees (local dev)
 .worktrees/
+.npmrc

--- a/README.md
+++ b/README.md
@@ -82,6 +82,22 @@ partiful events update <id> --title "New Title"
 partiful events cancel <id>
 ```
 
+### `events rsvp` / `events interested` — RSVP to events
+
+```bash
+partiful events rsvp <id>                          # RSVP going (default)
+partiful events rsvp <id> --status maybe           # going | maybe | declined
+partiful events rsvp <id> --plus-one Maddie --plus-one Justin   # bring guests
+partiful events rsvp <id> --name "Kaleb Cole" --message "Stoked!"
+partiful events interested <id>                    # mark interest
+partiful events interested <id> --remove           # remove interest
+```
+
+RSVP does a read-before-write: it updates your existing guest record if you
+already RSVP'd, otherwise creates one. Ticketed and questionnaire-gated events
+are refused with a clear error (use the app for those). The same verbs are
+available under `explore` (`partiful explore rsvp <id>`) for the discovery flow.
+
 ### `guests` — Manage event guests
 
 ```bash

--- a/skills/partiful-events/SKILL.md
+++ b/skills/partiful-events/SKILL.md
@@ -71,6 +71,30 @@ partiful events cancel <event-id>
 partiful events cancel <event-id> --yes          # skip confirmation
 ```
 
+### RSVP to an Event
+```bash
+partiful events rsvp <event-id>                        # RSVP going (default)
+partiful events rsvp <event-id> --status maybe         # going | maybe | declined
+partiful events rsvp <event-id> --plus-one Maddie --plus-one Justin
+partiful events rsvp <event-id> --name "Kaleb Cole" --message "See you there"
+partiful events rsvp <event-id> --dry-run --yes        # preview the addGuest payload
+```
+Read-before-write: updates your existing guest record if present (`updated:true`),
+else creates one (`guestId:null` on the wire). Ticketed/paid events and events
+that require a host questionnaire are refused with a validation error (exit 3),
+since the CLI cannot purchase tickets or submit questionnaire answers yet, use
+the app for those. `--yes` / `--force` skips the write confirmation.
+
+### Mark Interest
+```bash
+partiful events interested <event-id>                  # mark interested
+partiful events interested <event-id> --remove         # remove interest
+```
+
+> These four verbs are also aliased under `explore` (`partiful explore rsvp ...`,
+> `partiful explore interested ...`) for the public-event discovery flow. They
+> forward to the same handler and behave identically.
+
 ## Posters & Images
 
 Three ways to set event imagery (all require Partiful auth since they're used on `events create/update`):

--- a/src/cli.js
+++ b/src/cli.js
@@ -16,6 +16,7 @@ import { registerDoctorCommands } from './commands/doctor.js';
 import { registerTemplateCommands } from './commands/templates.js';
 import { registerBulkCommands } from './commands/bulk.js';
 import { registerSetupCommands } from './commands/setup.js';
+import { registerRsvpCommands } from './commands/rsvp.js';
 import { jsonOutput } from './lib/output.js';
 
 // Single source of truth for the version — read from package.json so the
@@ -53,6 +54,13 @@ export function run() {
   registerTemplateCommands(program);
   registerBulkCommands(program);
   registerSetupCommands(program);
+
+  // RSVP / interest verbs, shared across the canonical `events` group and the
+  // `explore` alias group. Look up the `events` command created above; create
+  // the `explore` group here.
+  const eventsCmd = program.commands.find(c => c.name() === 'events');
+  const exploreCmd = program.command('explore').description('Discover public events and RSVP to them');
+  registerRsvpCommands(program, { events: eventsCmd, explore: exploreCmd });
 
   program
     .command('version')

--- a/src/commands/rsvp.js
+++ b/src/commands/rsvp.js
@@ -1,0 +1,234 @@
+/**
+ * RSVP / interest commands: a single shared implementation wired under both the
+ * canonical `events *` verbs and the `explore *` aliases.
+ *
+ *   events rsvp <id>        (alias: explore rsvp <id>)        -> POST /addGuest
+ *   events interested <id>  (alias: explore interested <id>)  -> POST /markEventInterest
+ *
+ * The `explore *` verbs are thin forwards to the SAME handler; there is no
+ * duplicate logic. Wire names (addGuest / markEventInterest) never leak into the
+ * user-facing verb surface.
+ */
+
+import { loadConfig, getValidToken, wrapPayload, decodeJwtPayload } from '../lib/auth.js';
+import { apiRequest } from '../lib/http.js';
+import { jsonOutput, jsonError } from '../lib/output.js';
+import { PartifulError } from '../lib/errors.js';
+import { confirm } from '../lib/events.js';
+import {
+  RSVP_STATUSES,
+  buildRsvpParams,
+  buildInterestParams,
+  isTicketedEvent,
+  eventRequiresQuestionnaire,
+  resolveDisplayName,
+} from '../lib/rsvp.js';
+
+/** Wrap params in the Firebase-callable envelope the API expects. */
+function makePayload(config, params) {
+  return {
+    data: wrapPayload(config, {
+      params,
+      amplitudeSessionId: Date.now(),
+      userId: config.userId,
+    }),
+  };
+}
+
+function handleError(e) {
+  if (e instanceof PartifulError) jsonError(e.message, e.exitCode, e.type, e.details);
+  else jsonError(e.message);
+}
+
+/**
+ * Read the caller's own guest record (read-before-write).
+ *
+ * Fail-CLOSED: a real API/network error propagates to the caller's catch and
+ * aborts the RSVP. We must NOT swallow errors here: treating a failed read as
+ * "no existing record" would send guestId:null and create a DUPLICATE guest
+ * record instead of updating the existing one. A genuine "no record yet" is a
+ * successful response with currentGuest absent -> null, which is correct.
+ */
+async function fetchCurrentGuest(config, token, eventId, verbose) {
+  const res = await apiRequest('POST', '/getCurrentGuest', token, makePayload(config, { eventId }), verbose);
+  return res.result?.data?.currentGuest || null;
+}
+
+/**
+ * Read the event (for ticketed / questionnaire guards).
+ *
+ * Fail-CLOSED: errors propagate. Swallowing them would return null, which both
+ * guards treat as "not ticketed / no questionnaire", silently disabling the
+ * safety rails on any transient error and letting an incomplete RSVP through.
+ */
+async function fetchEvent(config, token, eventId, verbose) {
+  const res = await apiRequest('POST', '/getEventInfo', token, makePayload(config, { eventId }), verbose);
+  return res.result?.data?.event || null;
+}
+
+/** Derive the caller's display name from the Firebase token, if present. */
+function nameFromToken(token) {
+  const payload = decodeJwtPayload(token);
+  return payload?.name || payload?.displayName || null;
+}
+
+/**
+ * Shared RSVP handler. Backs `events rsvp` and `explore rsvp`.
+ * Exported for unit testing of the orchestration branches.
+ */
+export async function rsvpAction(eventId, opts, cmd) {
+  const globalOpts = cmd.optsWithGlobals();
+  try {
+    const config = loadConfig();
+    const token = await getValidToken(config);
+
+    // Read-before-write: decide create (guestId:null) vs update. Skipped on
+    // dry-run so the preview is fully offline.
+    let currentGuest = null;
+    let event = null;
+    if (!globalOpts.dryRun) {
+      [currentGuest, event] = await Promise.all([
+        fetchCurrentGuest(config, token, eventId, globalOpts.verbose),
+        fetchEvent(config, token, eventId, globalOpts.verbose),
+      ]);
+
+      // Refuse ticketed/paid events cleanly (Stripe wall).
+      if (isTicketedEvent(event)) {
+        jsonError(
+          'This is a ticketed or paid event. Self-RSVP is not supported here; use the Partiful app to purchase a ticket.',
+          3,
+          'validation_error'
+        );
+        return;
+      }
+
+      // Refuse questionnaire-gated events. The CLI cannot yet capture or submit
+      // questionnaire answers (live recon of the addGuest answer shape is still
+      // pending, see .wayfinder/tickets/07), so we refuse rather than silently
+      // submit an incomplete RSVP. When --answer support lands, gate this on it.
+      // NOTE: eventRequiresQuestionnaire field names are UNVERIFIED against a
+      // real /getEventInfo payload; confirm via CDP recon before trusting it as
+      // a positive-detection guarantee.
+      if (eventRequiresQuestionnaire(event)) {
+        jsonError(
+          'This event requires answering a host questionnaire before you can RSVP. The CLI cannot submit questionnaire answers yet; please RSVP in the Partiful app.',
+          3,
+          'validation_error'
+        );
+        return;
+      }
+    }
+
+    const name = resolveDisplayName({
+      override: opts.name,
+      currentGuest,
+      config,
+      tokenName: nameFromToken(token),
+    });
+
+    const params = buildRsvpParams({
+      eventId,
+      name,
+      status: opts.status,
+      plusOnes: opts.plusOne,
+      count: opts.count,
+      message: opts.message,
+      password: opts.password,
+      timezone: opts.timezone,
+      guestId: currentGuest?.id ?? null,
+    });
+
+    const payload = makePayload(config, params);
+
+    if (globalOpts.dryRun) {
+      jsonOutput({ dryRun: true, endpoint: '/addGuest', payload });
+      return;
+    }
+
+    // Confirmation gate: writing to a real host's guest list.
+    if (!globalOpts.yes && !globalOpts.force) {
+      const verb = currentGuest ? 'update your RSVP on' : 'RSVP to';
+      const confirmed = await confirm(`About to ${verb} "${eventId}" as ${params.rsvp.status}. Continue?`);
+      if (!confirmed) {
+        jsonOutput({ rsvp: false, message: 'Aborted by user' });
+        return;
+      }
+    }
+
+    const result = await apiRequest('POST', '/addGuest', token, payload, globalOpts.verbose);
+    const guest = result.result?.data?.guest || result.result?.data || {};
+
+    jsonOutput({
+      eventId,
+      status: params.rsvp.status,
+      guestId: guest.id || currentGuest?.id || null,
+      count: params.rsvp.count,
+      updated: Boolean(currentGuest),
+      url: `https://partiful.com/e/${eventId}`,
+    });
+  } catch (e) {
+    handleError(e);
+  }
+}
+
+/**
+ * Shared interest handler. Backs `events interested` and `explore interested`.
+ */
+async function interestedAction(eventId, opts, cmd) {
+  const globalOpts = cmd.optsWithGlobals();
+  try {
+    const config = loadConfig();
+    const token = await getValidToken(config);
+
+    const interested = !opts.remove;
+    // No confirmation gate here: marking interest is non-destructive and easily
+    // reversible via --remove, unlike an RSVP write to a host's guest list.
+    const params = buildInterestParams({ eventId, interested });
+    const payload = makePayload(config, params);
+
+    if (globalOpts.dryRun) {
+      jsonOutput({ dryRun: true, endpoint: '/markEventInterest', payload });
+      return;
+    }
+
+    await apiRequest('POST', '/markEventInterest', token, payload, globalOpts.verbose);
+
+    jsonOutput({
+      eventId,
+      interested,
+      url: `https://partiful.com/e/${eventId}`,
+    });
+  } catch (e) {
+    handleError(e);
+  }
+}
+
+/** Attach rsvp + interested subcommands to a parent command (events or explore). */
+function attachRsvpVerbs(parent) {
+  parent
+    .command('rsvp')
+    .description('RSVP to an event (going, maybe, or declined)')
+    .argument('<eventId>', 'Event ID')
+    .option('--status <status>', `RSVP status: ${RSVP_STATUSES.join(', ')}`, 'going')
+    .option('--name <name>', 'Display name to RSVP with (defaults to your profile name)')
+    .option('--plus-one <name...>', 'Plus-one name (repeatable)')
+    .option('--count <n>', 'Total headcount including plus-ones', (v) => parseInt(v, 10))
+    .option('--message <text>', 'Optional public comment on the event')
+    .option('--password <password>', 'Event password (if the event is password-gated)')
+    .option('--timezone <tz>', 'IANA timezone for the RSVP')
+    .action(rsvpAction);
+
+  parent
+    .command('interested')
+    .description('Mark (or remove) interest in an event')
+    .argument('<eventId>', 'Event ID')
+    .option('--remove', 'Remove your interest instead of adding it')
+    .action(interestedAction);
+}
+
+export function registerRsvpCommands(program, { events, explore }) {
+  // Canonical verbs live under `events`; `explore` gets the same verbs as
+  // thin aliases to the SAME handlers.
+  attachRsvpVerbs(events);
+  attachRsvpVerbs(explore);
+}

--- a/src/commands/schema.js
+++ b/src/commands/schema.js
@@ -55,6 +55,46 @@ const SCHEMAS = {
       eventId: { type: 'string', required: true, positional: true },
     },
   },
+  'events.rsvp': {
+    command: 'events rsvp <eventId>',
+    parameters: {
+      eventId: { type: 'string', required: true, positional: true, description: 'Event ID' },
+      '--status': { type: 'string', required: false, default: 'going', description: 'RSVP status: going, maybe, declined' },
+      '--name': { type: 'string', required: false, description: 'Display name to RSVP with (defaults to profile name)' },
+      '--plus-one': { type: 'string[]', required: false, description: 'Plus-one name (repeatable)' },
+      '--count': { type: 'integer', required: false, description: 'Total headcount including plus-ones' },
+      '--message': { type: 'string', required: false, description: 'Optional public comment on the event' },
+      '--password': { type: 'string', required: false, description: 'Event password (if password-gated)' },
+      '--timezone': { type: 'string', required: false, description: 'IANA timezone for the RSVP' },
+    },
+  },
+  'events.interested': {
+    command: 'events interested <eventId>',
+    parameters: {
+      eventId: { type: 'string', required: true, positional: true, description: 'Event ID' },
+      '--remove': { type: 'boolean', required: false, description: 'Remove interest instead of adding it' },
+    },
+  },
+  'explore.rsvp': {
+    command: 'explore rsvp <eventId>',
+    parameters: {
+      eventId: { type: 'string', required: true, positional: true, description: 'Event ID' },
+      '--status': { type: 'string', required: false, default: 'going', description: 'RSVP status: going, maybe, declined' },
+      '--name': { type: 'string', required: false, description: 'Display name to RSVP with (defaults to profile name)' },
+      '--plus-one': { type: 'string[]', required: false, description: 'Plus-one name (repeatable)' },
+      '--count': { type: 'integer', required: false, description: 'Total headcount including plus-ones' },
+      '--message': { type: 'string', required: false, description: 'Optional public comment on the event' },
+      '--password': { type: 'string', required: false, description: 'Event password (if password-gated)' },
+      '--timezone': { type: 'string', required: false, description: 'IANA timezone for the RSVP' },
+    },
+  },
+  'explore.interested': {
+    command: 'explore interested <eventId>',
+    parameters: {
+      eventId: { type: 'string', required: true, positional: true, description: 'Event ID' },
+      '--remove': { type: 'boolean', required: false, description: 'Remove interest instead of adding it' },
+    },
+  },
   'guests.list': {
     command: 'guests list <eventId>',
     parameters: {

--- a/src/lib/rsvp.js
+++ b/src/lib/rsvp.js
@@ -1,0 +1,242 @@
+/**
+ * RSVP / interest library for the Partiful CLI.
+ *
+ * Pure builders + guards backing the `events rsvp` / `explore rsvp` and
+ * `events interested` / `explore interested` commands. All network access lives
+ * in the command layer (via src/lib/http.js); this module stays side-effect free
+ * and unit-testable.
+ *
+ * Wire facts (captured live, see .wayfinder/tickets/07):
+ *   - Self-RSVP mutation  = POST /addGuest
+ *       params: { eventId, rsvp: { name, count, plusOnes[], message,
+ *                 emailInvitationId, status, guestId, timezone, password } }
+ *       First RSVP sends guestId:null (server creates); edits send it back.
+ *       GOING | MAYBE | DECLINED all go through this ONE call via `status`.
+ *   - Interest mutation   = POST /markEventInterest
+ *       params: { eventId, interested: bool, source? }
+ *   - Read-before-write   = POST /getCurrentGuest { eventId }
+ *       -> result.data.currentGuest.{ id, status, name } (or null)
+ */
+
+import { PartifulError } from './errors.js';
+
+/** User-facing status verbs for `--status` on the rsvp command. */
+export const RSVP_STATUSES = ['going', 'maybe', 'declined'];
+
+const DEFAULT_TIMEZONE = 'America/Los_Angeles';
+
+// Unverified legacy field-name fallbacks for the questionnaire question list.
+// The verified field is `questionnaire.questions[]` (see eventRequiresQuestionnaire).
+const LEGACY_QUESTIONNAIRE_FIELDS = ['questions', 'rsvpQuestions', 'customQuestions'];
+
+// Human input -> wire enum. Only GOING/MAYBE/DECLINED are valid self-RSVP
+// statuses. INTERESTED is a DIFFERENT endpoint (markEventInterest), so it is
+// deliberately NOT accepted here.
+const STATUS_ALIASES = {
+  going: 'GOING',
+  yes: 'GOING',
+  maybe: 'MAYBE',
+  declined: 'DECLINED',
+  decline: 'DECLINED',
+  no: 'DECLINED',
+};
+
+/**
+ * Normalize a user-supplied status into its wire enum value.
+ * Defaults to GOING. Throws a validation PartifulError on unknown input.
+ */
+export function normalizeStatus(status) {
+  if (status === null || status === undefined || status === '') return 'GOING';
+  const key = String(status).trim().toLowerCase();
+  const wire = STATUS_ALIASES[key];
+  if (!wire) {
+    throw new PartifulError(
+      `Invalid status "${status}". Use one of: going, maybe, declined.`,
+      3,
+      'validation_error'
+    );
+  }
+  return wire;
+}
+
+/**
+ * Build the `params` object for POST /addGuest.
+ *
+ * @param {object} o
+ * @param {string} o.eventId          required
+ * @param {string} o.name             required (server rejects an empty name)
+ * @param {string} [o.status]         going|maybe|declined (default going)
+ * @param {string[]} [o.plusOnes]     plus-one names
+ * @param {number} [o.count]          headcount incl. plus-ones (derived if omitted)
+ * @param {string} [o.message]        optional public comment
+ * @param {string} [o.password]       event password if gated
+ * @param {string} [o.guestId]        existing guest record id (edit); null on first RSVP
+ * @param {string} [o.timezone]       IANA tz (default America/Los_Angeles)
+ * @param {object} [o.questionnaireResponse]  verified shape:
+ *                 { questionnaireVersion:int, answers:{ "<questionId>": "<answer>" } }
+ *                 Build via buildQuestionnaireResponse(); omit when the event has none.
+ * @returns {{eventId:string, rsvp:object}}
+ */
+export function buildRsvpParams(o = {}) {
+  const { eventId, name } = o;
+  if (!eventId) {
+    throw new PartifulError('eventId is required to RSVP.', 3, 'validation_error');
+  }
+  if (!name || !String(name).trim()) {
+    throw new PartifulError('A guest name is required to RSVP (the server rejects an empty name).', 3, 'validation_error');
+  }
+
+  const plusOnes = Array.isArray(o.plusOnes) ? o.plusOnes.filter(Boolean) : [];
+  const derivedCount = 1 + plusOnes.length;
+  const count = Number.isFinite(o.count) ? Math.trunc(o.count) : derivedCount;
+
+  const rsvp = {
+    name: String(name),
+    count,
+    plusOnes,
+    message: o.message ?? null,
+    emailInvitationId: o.emailInvitationId ?? null,
+    status: normalizeStatus(o.status),
+    guestId: o.guestId ?? null,
+    timezone: o.timezone || DEFAULT_TIMEZONE,
+    password: o.password ?? null,
+  };
+
+  // Questionnaire answers ride inside the rsvp object as questionnaireResponse.
+  // Only attach when present so non-questionnaire events keep the lean payload.
+  if (o.questionnaireResponse) {
+    rsvp.questionnaireResponse = o.questionnaireResponse;
+  }
+
+  return { eventId, rsvp };
+}
+
+/**
+ * Build the `params` object for POST /markEventInterest.
+ *
+ * @param {object} o
+ * @param {string} o.eventId       required
+ * @param {boolean} o.interested   true to mark, false to remove
+ * @param {string} [o.source]      analytics source (default DISCOVER)
+ */
+export function buildInterestParams(o = {}) {
+  const { eventId } = o;
+  if (!eventId) {
+    throw new PartifulError('eventId is required to mark interest.', 3, 'validation_error');
+  }
+  return {
+    eventId,
+    interested: Boolean(o.interested),
+    source: o.source || 'DISCOVER',
+  };
+}
+
+/**
+ * Detect a ticketed / paid event we should refuse to RSVP for (Stripe wall).
+ * Conservative: any ticketing/payment signal counts.
+ */
+export function isTicketedEvent(event) {
+  if (!event || typeof event !== 'object') return false;
+  if (event.ticketing && (event.ticketing.enabled ?? true)) return true;
+  if (event.ticketInfo && typeof event.ticketInfo === 'object') return true;
+  if (event.requiresPayment === true) return true;
+  if (event.isTicketed === true) return true;
+  return false;
+}
+
+/**
+ * Detect an event that requires questionnaire answers before an RSVP submits.
+ *
+ * Verified live (2026-07-24, host-side recon on a throwaway event, see
+ * .wayfinder/tickets/07 follow-up). The authoritative shape in the event
+ * object is:
+ *   questionnaireEnabled: true
+ *   questionnaire: {
+ *     createdBy, createdAt,
+ *     questions: [ { id, type: 'short_answer', text, required } ]
+ *   }
+ *   questionnaireVersions: [ { ...same shape... } ]   // history
+ * When no questionnaire exists these keys are simply ABSENT from the event.
+ *
+ * Detection rule: questionnaireEnabled truthy AND at least one question present.
+ * (Legacy field names kept as a defensive fallback in case older/host payloads
+ * expose the list under a different key.)
+ */
+export function eventRequiresQuestionnaire(event) {
+  if (!event || typeof event !== 'object') return false;
+
+  const q = event.questionnaire;
+  const hasQuestions =
+    q && typeof q === 'object' && Array.isArray(q.questions) && q.questions.length > 0;
+
+  // Primary, verified signal.
+  if (event.questionnaireEnabled && hasQuestions) return true;
+
+  // Defensive fallback: a populated questionnaire.questions[] even if the
+  // enabled flag is absent (older payloads / host-scoped views).
+  if (hasQuestions) return true;
+
+  // Legacy field-name fallbacks (unverified, kept for resilience).
+  for (const f of LEGACY_QUESTIONNAIRE_FIELDS) {
+    if (Array.isArray(event[f]) && event[f].length > 0) return true;
+  }
+  return false;
+}
+
+/**
+ * Build the questionnaireResponse object for an RSVP, given the event's
+ * questions and a map of { questionId | questionText -> answer } supplied by
+ * the caller. Returns null when the event has no questionnaire.
+ *
+ * Verified wire shape (guest.questionnaireResponse, 2026-07-24):
+ *   { questionnaireVersion: <int>, answers: { "<questionId>": "<answer>" } }
+ * The answers map is keyed by question id, NOT by text or index.
+ *
+ * Throws a validation error if a REQUIRED question has no supplied answer, so
+ * the CLI refuses rather than submitting an incomplete RSVP.
+ */
+export function buildQuestionnaireResponse(event, answersByKey = {}) {
+  if (!eventRequiresQuestionnaire(event)) return null;
+  const questions = event.questionnaire.questions;
+  const answers = {};
+  const missing = [];
+  for (const question of questions) {
+    // Accept an answer supplied under the question id OR its exact text.
+    const val =
+      answersByKey[question.id] ??
+      answersByKey[question.text] ??
+      undefined;
+    if (val === undefined || val === null || String(val).trim() === '') {
+      if (question.required) missing.push(question.text);
+      continue;
+    }
+    answers[question.id] = String(val);
+  }
+  if (missing.length > 0) {
+    throw new PartifulError(
+      `Missing answer(s) for required question(s): ${missing.join('; ')}`,
+      3,
+      'validation_error'
+    );
+  }
+  return {
+    // Version index into questionnaireVersions; current is the last entry.
+    questionnaireVersion: Array.isArray(event.questionnaireVersions)
+      ? Math.max(0, event.questionnaireVersions.length - 1)
+      : 0,
+    answers,
+  };
+}
+
+/**
+ * Resolve the display name to submit with an RSVP, in priority order:
+ * explicit override > existing guest record > config profile > token-derived.
+ * Returns null when nothing is resolvable (caller must surface an error).
+ */
+export function resolveDisplayName({ override, currentGuest, config, tokenName } = {}) {
+  if (override && String(override).trim()) return String(override);
+  if (currentGuest && currentGuest.name) return currentGuest.name;
+  if (config && config.name) return config.name;
+  if (tokenName) return tokenName;
+  return null;
+}

--- a/src/lib/rsvp.js
+++ b/src/lib/rsvp.js
@@ -88,7 +88,18 @@ export function buildRsvpParams(o = {}) {
 
   const plusOnes = Array.isArray(o.plusOnes) ? o.plusOnes.filter(Boolean) : [];
   const derivedCount = 1 + plusOnes.length;
-  const count = Number.isFinite(o.count) ? Math.trunc(o.count) : derivedCount;
+  let count;
+  if (o.count == null) {
+    count = derivedCount;
+  } else if (!Number.isFinite(o.count) || o.count <= 0) {
+    throw new PartifulError(
+      `Invalid --count "${o.count}". Must be a positive whole number.`,
+      3,
+      'validation_error'
+    );
+  } else {
+    count = Math.trunc(o.count);
+  }
 
   const rsvp = {
     name: String(name),
@@ -197,10 +208,36 @@ export function eventRequiresQuestionnaire(event) {
  */
 export function buildQuestionnaireResponse(event, answersByKey = {}) {
   if (!eventRequiresQuestionnaire(event)) return null;
-  const questions = event.questionnaire.questions;
+
+  // Resolve question list defensively — event.questionnaire may be absent
+  // when the questionnaire was detected via a legacy field path.
+  let questions;
+  const primaryQuestions = event.questionnaire?.questions;
+  if (Array.isArray(primaryQuestions) && primaryQuestions.length > 0) {
+    questions = primaryQuestions;
+  } else {
+    const legacyField = LEGACY_QUESTIONNAIRE_FIELDS.find(
+      f => Array.isArray(event[f]) && event[f].length > 0
+    );
+    if (legacyField) {
+      questions = event[legacyField];
+    } else {
+      throw new PartifulError(
+        'Event questionnaire is enabled but no questions were found.',
+        3,
+        'validation_error'
+      );
+    }
+  }
+
   const answers = {};
   const missing = [];
-  for (const question of questions) {
+  for (const rawQuestion of questions) {
+    // Normalise bare-string legacy questions: treat the string as both id and text.
+    const question =
+      typeof rawQuestion === 'string'
+        ? { id: rawQuestion, text: rawQuestion, required: false }
+        : rawQuestion;
     // Accept an answer supplied under the question id OR its exact text.
     const val =
       answersByKey[question.id] ??

--- a/tests/rsvp-integration.test.js
+++ b/tests/rsvp-integration.test.js
@@ -1,0 +1,89 @@
+/**
+ * Integration tests for the RSVP / interest command surface.
+ *
+ * Covers `events rsvp` / `explore rsvp` and `events interested` /
+ * `explore interested` via --dry-run (no network). The alias (`explore *`) must
+ * forward to the SAME handler and produce an identical payload to `events *`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { run, runRaw } from './helpers.js';
+
+describe('events rsvp / explore rsvp', () => {
+  it('events rsvp --dry-run builds an addGuest payload (GOING default)', () => {
+    const out = run(['events', 'rsvp', 'EV123', '--name', 'Kaleb Cole', '--dry-run', '--yes']);
+    expect(out.status).toBe('success');
+    expect(out.data.dryRun).toBe(true);
+    expect(out.data.endpoint).toBe('/addGuest');
+    const p = out.data.payload.data.params;
+    expect(p.eventId).toBe('EV123');
+    expect(p.rsvp.status).toBe('GOING');
+    expect(p.rsvp.guestId).toBeNull();
+    expect(p.rsvp.count).toBe(1);
+    expect(p.rsvp.name).toBe('Kaleb Cole');
+  });
+
+  it('--status maybe maps to the MAYBE wire enum', () => {
+    const out = run(['events', 'rsvp', 'EV123', '--name', 'Kaleb', '--status', 'maybe', '--dry-run', '--yes']);
+    expect(out.data.payload.data.params.rsvp.status).toBe('MAYBE');
+  });
+
+  it('--plus-one is repeatable and bumps the count', () => {
+    const out = run([
+      'events', 'rsvp', 'EV123', '--name', 'Kaleb',
+      '--plus-one', 'Maddie', '--plus-one', 'Justin',
+      '--dry-run', '--yes',
+    ]);
+    const rsvp = out.data.payload.data.params.rsvp;
+    expect(rsvp.plusOnes).toEqual(['Maddie', 'Justin']);
+    expect(rsvp.count).toBe(3);
+  });
+
+  it('rejects an invalid --status with exit code 3', () => {
+    const { stdout, exitCode } = runRaw(['events', 'rsvp', 'EV123', '--name', 'Kaleb', '--status', 'interested', '--dry-run', '--yes']);
+    const out = JSON.parse(stdout.trim());
+    expect(out.status).toBe('error');
+    expect(out.error.code).toBe(3);
+    expect(exitCode).toBe(3);
+  });
+
+  it('explore rsvp forwards to the SAME handler with an identical payload', () => {
+    const viaEvents = run(['events', 'rsvp', 'EV123', '--name', 'Kaleb', '--status', 'going', '--dry-run', '--yes']);
+    const viaExplore = run(['explore', 'rsvp', 'EV123', '--name', 'Kaleb', '--status', 'going', '--dry-run', '--yes']);
+    expect(viaExplore.data.endpoint).toBe('/addGuest');
+    expect(viaExplore.data.payload.data.params).toEqual(viaEvents.data.payload.data.params);
+  });
+
+  it('requires a name when none can be resolved (no auth profile in test)', () => {
+    const { stdout } = runRaw(['events', 'rsvp', 'EV123', '--dry-run', '--yes']);
+    const out = JSON.parse(stdout.trim());
+    expect(out.status).toBe('error');
+    expect(out.error.code).toBe(3);
+    expect(out.error.message).toMatch(/name/i);
+  });
+});
+
+describe('events interested / explore interested', () => {
+  it('events interested --dry-run builds a markEventInterest payload (interested true)', () => {
+    const out = run(['events', 'interested', 'EV123', '--dry-run', '--yes']);
+    expect(out.status).toBe('success');
+    expect(out.data.dryRun).toBe(true);
+    expect(out.data.endpoint).toBe('/markEventInterest');
+    const p = out.data.payload.data.params;
+    expect(p.eventId).toBe('EV123');
+    expect(p.interested).toBe(true);
+    expect(p.source).toBe('DISCOVER');
+  });
+
+  it('--remove flips interested to false', () => {
+    const out = run(['events', 'interested', 'EV123', '--remove', '--dry-run', '--yes']);
+    expect(out.data.payload.data.params.interested).toBe(false);
+  });
+
+  it('explore interested forwards to the SAME handler', () => {
+    const viaEvents = run(['events', 'interested', 'EV123', '--dry-run', '--yes']);
+    const viaExplore = run(['explore', 'interested', 'EV123', '--dry-run', '--yes']);
+    expect(viaExplore.data.endpoint).toBe('/markEventInterest');
+    expect(viaExplore.data.payload.data.params).toEqual(viaEvents.data.payload.data.params);
+  });
+});

--- a/tests/rsvp-orchestration.test.js
+++ b/tests/rsvp-orchestration.test.js
@@ -1,0 +1,121 @@
+/**
+ * Mock-based orchestration tests for rsvpAction — covers the branches that can't
+ * be reached through --dry-run (which skips the network): edit path, ticketed /
+ * questionnaire guards, the confirmation-abort path, and the fail-CLOSED
+ * behaviour of the read-before-write helpers on API error.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// --- module mocks -----------------------------------------------------------
+const apiRequest = vi.fn();
+const jsonOutput = vi.fn();
+const jsonError = vi.fn();
+const confirm = vi.fn();
+
+vi.mock('../src/lib/http.js', () => ({ apiRequest: (...a) => apiRequest(...a) }));
+vi.mock('../src/lib/output.js', () => ({
+  jsonOutput: (...a) => jsonOutput(...a),
+  jsonError: (...a) => jsonError(...a),
+  EXIT: { SUCCESS: 0, API_ERROR: 1, AUTH_ERROR: 2, VALIDATION_ERROR: 3, NOT_FOUND: 4, INTERNAL_ERROR: 5 },
+}));
+vi.mock('../src/lib/auth.js', () => ({
+  loadConfig: () => ({ name: 'Config Name', userId: 'U1' }),
+  getValidToken: async () => 'tok',
+  wrapPayload: (_c, body) => body,
+  decodeJwtPayload: () => ({ name: 'Token Name' }),
+}));
+vi.mock('../src/lib/events.js', () => ({ confirm: (...a) => confirm(...a) }));
+
+const { rsvpAction } = await import('../src/commands/rsvp.js');
+
+// Commander-like cmd stub whose optsWithGlobals returns the given globals.
+const mkCmd = (globals = {}) => ({ optsWithGlobals: () => globals });
+
+// Route apiRequest by endpoint so each test can script the reads/writes.
+function routeApi({ event = null, currentGuest = null, addGuest = { id: 'NEW' }, throwOn = null } = {}) {
+  apiRequest.mockImplementation(async (_m, endpoint) => {
+    if (throwOn && endpoint === throwOn) throw new Error(`boom ${endpoint}`);
+    if (endpoint === '/getEventInfo') return { result: { data: { event } } };
+    if (endpoint === '/getCurrentGuest') return { result: { data: { currentGuest } } };
+    if (endpoint === '/addGuest') return { result: { data: { guest: addGuest } } };
+    return { result: { data: {} } };
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('rsvpAction edit path (existing guest record)', () => {
+  it('sends the existing guestId and reports updated:true', async () => {
+    routeApi({ currentGuest: { id: 'G7', name: 'Server Name', status: 'MAYBE' }, addGuest: { id: 'G7' } });
+    await rsvpAction('EV1', { status: 'going' }, mkCmd({ yes: true }));
+
+    const addCall = apiRequest.mock.calls.find(c => c[1] === '/addGuest');
+    expect(addCall).toBeDefined();
+    expect(addCall[3].data.params.rsvp.guestId).toBe('G7');
+    // name resolves from the existing guest record over config/token
+    expect(addCall[3].data.params.rsvp.name).toBe('Server Name');
+
+    const out = jsonOutput.mock.calls.at(-1)[0];
+    expect(out.updated).toBe(true);
+    expect(out.guestId).toBe('G7');
+  });
+});
+
+describe('rsvpAction ticketed guard', () => {
+  it('refuses a ticketed event and never calls addGuest', async () => {
+    routeApi({ event: { ticketing: { enabled: true } } });
+    await rsvpAction('EV1', { name: 'Kaleb' }, mkCmd({ yes: true }));
+
+    expect(jsonError).toHaveBeenCalledWith(expect.stringMatching(/ticketed|paid/i), 3, 'validation_error');
+    expect(apiRequest.mock.calls.some(c => c[1] === '/addGuest')).toBe(false);
+  });
+});
+
+describe('rsvpAction questionnaire guard', () => {
+  it('refuses a questionnaire-gated event and never calls addGuest', async () => {
+    routeApi({ event: { questions: [{ id: 'q1', required: true }] } });
+    await rsvpAction('EV1', { name: 'Kaleb' }, mkCmd({ yes: true }));
+
+    expect(jsonError).toHaveBeenCalledWith(expect.stringMatching(/questionnaire/i), 3, 'validation_error');
+    expect(apiRequest.mock.calls.some(c => c[1] === '/addGuest')).toBe(false);
+  });
+});
+
+describe('rsvpAction confirmation gate', () => {
+  it('aborts when the user declines and never calls addGuest', async () => {
+    routeApi({});
+    confirm.mockResolvedValue(false);
+    await rsvpAction('EV1', { name: 'Kaleb' }, mkCmd({})); // no --yes
+
+    expect(confirm).toHaveBeenCalled();
+    const out = jsonOutput.mock.calls.at(-1)[0];
+    expect(out.rsvp).toBe(false);
+    expect(apiRequest.mock.calls.some(c => c[1] === '/addGuest')).toBe(false);
+  });
+
+  it('proceeds when the user confirms', async () => {
+    routeApi({});
+    confirm.mockResolvedValue(true);
+    await rsvpAction('EV1', { name: 'Kaleb' }, mkCmd({}));
+    expect(apiRequest.mock.calls.some(c => c[1] === '/addGuest')).toBe(true);
+  });
+});
+
+describe('rsvpAction fail-CLOSED on read error', () => {
+  it('aborts (no addGuest) when getEventInfo throws', async () => {
+    routeApi({ throwOn: '/getEventInfo' });
+    await rsvpAction('EV1', { name: 'Kaleb' }, mkCmd({ yes: true }));
+    // Error surfaced; the write must NOT happen with guards disabled.
+    expect(apiRequest.mock.calls.some(c => c[1] === '/addGuest')).toBe(false);
+    expect(jsonError).toHaveBeenCalled();
+  });
+
+  it('aborts (no addGuest) when getCurrentGuest throws — avoids duplicate record', async () => {
+    routeApi({ throwOn: '/getCurrentGuest' });
+    await rsvpAction('EV1', { name: 'Kaleb' }, mkCmd({ yes: true }));
+    expect(apiRequest.mock.calls.some(c => c[1] === '/addGuest')).toBe(false);
+    expect(jsonError).toHaveBeenCalled();
+  });
+});

--- a/tests/rsvp.test.js
+++ b/tests/rsvp.test.js
@@ -250,3 +250,75 @@ describe('questionnaire (verified shape)', () => {
     expect(rsvp).not.toHaveProperty('questionnaireResponse');
   });
 });
+
+describe('buildRsvpParams — count validation (Fix 1)', () => {
+  it('throws for count 0', () => {
+    expect(() => buildRsvpParams({ eventId: 'EV1', name: 'A', count: 0 }))
+      .toThrow(/Invalid --count/);
+  });
+
+  it('throws for negative count', () => {
+    expect(() => buildRsvpParams({ eventId: 'EV1', name: 'A', count: -3 }))
+      .toThrow(/Invalid --count/);
+  });
+
+  it('throws for NaN count (simulating bad parseInt)', () => {
+    expect(() => buildRsvpParams({ eventId: 'EV1', name: 'A', count: NaN }))
+      .toThrow(/Invalid --count/);
+  });
+
+  it('accepts a positive explicit count', () => {
+    const { rsvp } = buildRsvpParams({ eventId: 'EV1', name: 'A', count: 5 });
+    expect(rsvp.count).toBe(5);
+  });
+
+  it('derives count from plus-ones when count is omitted (null/undefined)', () => {
+    const { rsvp } = buildRsvpParams({ eventId: 'EV1', name: 'A', plusOnes: ['B', 'C'] });
+    expect(rsvp.count).toBe(3); // 1 + 2
+  });
+});
+
+describe('buildQuestionnaireResponse — legacy questionnaire guard (Fix 2)', () => {
+  const legacyEvent = {
+    // No event.questionnaire — detected only via the legacy `questions` field
+    questions: [
+      { id: 'q1', text: 'Dietary needs?', required: true },
+      { id: 'q2', text: 'Song request?', required: false },
+    ],
+  };
+
+  it('does not throw a TypeError when event.questionnaire is absent', () => {
+    let caughtError;
+    try {
+      buildQuestionnaireResponse(legacyEvent, { q1: 'None' });
+    } catch (e) {
+      caughtError = e;
+    }
+    // Either succeeds or throws a handled PartifulError — never a raw TypeError
+    if (caughtError) {
+      expect(caughtError).not.toBeInstanceOf(TypeError);
+      expect(caughtError.constructor.name).toBe('PartifulError');
+    }
+  });
+
+  it('returns a valid response object for legacy event with all required answers', () => {
+    const resp = buildQuestionnaireResponse(legacyEvent, { q1: 'Vegan' });
+    expect(resp).not.toBeNull();
+    expect(resp.answers).toHaveProperty('q1', 'Vegan');
+    expect(typeof resp.questionnaireVersion).toBe('number');
+  });
+
+  it('still returns correct versioned answers for primary event.questionnaire shape', () => {
+    const primaryEvent = {
+      questionnaireEnabled: true,
+      questionnaireVersions: [{ questions: [] }],
+      questionnaire: {
+        questions: [
+          { id: '111', type: 'short_answer', text: 'Dietary restrictions?', required: true },
+        ],
+      },
+    };
+    const resp = buildQuestionnaireResponse(primaryEvent, { '111': 'None' });
+    expect(resp).toEqual({ questionnaireVersion: 0, answers: { '111': 'None' } });
+  });
+});

--- a/tests/rsvp.test.js
+++ b/tests/rsvp.test.js
@@ -1,0 +1,252 @@
+/**
+ * Unit tests for the RSVP / interest library (src/lib/rsvp.js).
+ *
+ * These cover the PURE, side-effect-free builders and guards that back the
+ * `events rsvp` / `explore rsvp` and `events interested` / `explore interested`
+ * commands. All network/orchestration is tested separately via CLI dry-run
+ * integration tests; here we pin the wire-payload shapes and the refusal guards.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  RSVP_STATUSES,
+  normalizeStatus,
+  buildRsvpParams,
+  buildInterestParams,
+  isTicketedEvent,
+  eventRequiresQuestionnaire,
+  buildQuestionnaireResponse,
+  resolveDisplayName,
+} from '../src/lib/rsvp.js';
+
+describe('normalizeStatus', () => {
+  it('defaults to GOING when no status given', () => {
+    expect(normalizeStatus()).toBe('GOING');
+    expect(normalizeStatus(null)).toBe('GOING');
+    expect(normalizeStatus(undefined)).toBe('GOING');
+  });
+
+  it('maps the three canonical statuses case-insensitively', () => {
+    expect(normalizeStatus('going')).toBe('GOING');
+    expect(normalizeStatus('Maybe')).toBe('MAYBE');
+    expect(normalizeStatus('DECLINED')).toBe('DECLINED');
+  });
+
+  it('accepts human synonyms', () => {
+    expect(normalizeStatus('yes')).toBe('GOING');
+    expect(normalizeStatus('no')).toBe('DECLINED');
+    expect(normalizeStatus('decline')).toBe('DECLINED');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(normalizeStatus('  going  ')).toBe('GOING');
+  });
+
+  it('rejects unknown statuses with a helpful message', () => {
+    expect(() => normalizeStatus('interested')).toThrow(/status/i);
+    expect(() => normalizeStatus('bogus')).toThrow(/going/i);
+  });
+
+  it('exports exactly the three self-RSVP statuses', () => {
+    expect(RSVP_STATUSES).toEqual(['going', 'maybe', 'declined']);
+  });
+});
+
+describe('buildRsvpParams', () => {
+  it('builds the canonical first-RSVP payload with guestId null', () => {
+    const params = buildRsvpParams({ eventId: 'EV1', name: 'Kaleb Cole' });
+    expect(params).toEqual({
+      eventId: 'EV1',
+      rsvp: {
+        name: 'Kaleb Cole',
+        count: 1,
+        plusOnes: [],
+        message: null,
+        emailInvitationId: null,
+        status: 'GOING',
+        guestId: null,
+        timezone: 'America/Los_Angeles',
+        password: null,
+      },
+    });
+  });
+
+  it('passes an existing guestId back for edits', () => {
+    const params = buildRsvpParams({ eventId: 'EV1', name: 'Kaleb', guestId: 'G9', status: 'declined' });
+    expect(params.rsvp.guestId).toBe('G9');
+    expect(params.rsvp.status).toBe('DECLINED');
+  });
+
+  it('derives count from plus-ones when --count is omitted', () => {
+    const params = buildRsvpParams({ eventId: 'EV1', name: 'Kaleb', plusOnes: ['Maddie', 'Justin'] });
+    expect(params.rsvp.count).toBe(3); // self + 2
+    expect(params.rsvp.plusOnes).toEqual(['Maddie', 'Justin']);
+  });
+
+  it('honours an explicit --count over the derived value', () => {
+    const params = buildRsvpParams({ eventId: 'EV1', name: 'Kaleb', plusOnes: ['Maddie'], count: 5 });
+    expect(params.rsvp.count).toBe(5);
+  });
+
+  it('carries message, password and timezone through', () => {
+    const params = buildRsvpParams({
+      eventId: 'EV1', name: 'Kaleb', message: 'stoked', password: 'sesame', timezone: 'America/New_York',
+    });
+    expect(params.rsvp.message).toBe('stoked');
+    expect(params.rsvp.password).toBe('sesame');
+    expect(params.rsvp.timezone).toBe('America/New_York');
+  });
+
+  it('requires an eventId', () => {
+    expect(() => buildRsvpParams({ name: 'Kaleb' })).toThrow(/eventId/i);
+  });
+
+  it('requires a name (server rejects an empty guest name)', () => {
+    expect(() => buildRsvpParams({ eventId: 'EV1', name: '' })).toThrow(/name/i);
+  });
+
+  it('never emits an em dash in a passed-through message unchanged is caller concern, but count is always an integer', () => {
+    const params = buildRsvpParams({ eventId: 'EV1', name: 'Kaleb', count: 2 });
+    expect(Number.isInteger(params.rsvp.count)).toBe(true);
+  });
+});
+
+describe('buildInterestParams', () => {
+  it('marks interested true with the DISCOVER source by default', () => {
+    expect(buildInterestParams({ eventId: 'EV1', interested: true })).toEqual({
+      eventId: 'EV1', interested: true, source: 'DISCOVER',
+    });
+  });
+
+  it('marks interested false for --remove', () => {
+    expect(buildInterestParams({ eventId: 'EV1', interested: false })).toEqual({
+      eventId: 'EV1', interested: false, source: 'DISCOVER',
+    });
+  });
+
+  it('requires an eventId', () => {
+    expect(() => buildInterestParams({ interested: true })).toThrow(/eventId/i);
+  });
+});
+
+describe('isTicketedEvent', () => {
+  it('flags events with a ticketing block', () => {
+    expect(isTicketedEvent({ ticketing: { enabled: true } })).toBe(true);
+  });
+
+  it('flags events with a paid/Stripe indicator', () => {
+    expect(isTicketedEvent({ ticketInfo: { priceCents: 500 } })).toBe(true);
+    expect(isTicketedEvent({ requiresPayment: true })).toBe(true);
+  });
+
+  it('does not flag a plain free event', () => {
+    expect(isTicketedEvent({ title: 'Free Party' })).toBe(false);
+    expect(isTicketedEvent({})).toBe(false);
+    expect(isTicketedEvent(null)).toBe(false);
+  });
+});
+
+describe('eventRequiresQuestionnaire', () => {
+  it('detects a non-empty questions array', () => {
+    expect(eventRequiresQuestionnaire({ questions: [{ id: 'q1', required: true }] })).toBe(true);
+  });
+
+  it('detects alternate field names Partiful may use', () => {
+    expect(eventRequiresQuestionnaire({ questionnaire: { questions: [{ id: 'q1' }] } })).toBe(true);
+    expect(eventRequiresQuestionnaire({ rsvpQuestions: [{ id: 'q1' }] })).toBe(true);
+    expect(eventRequiresQuestionnaire({ customQuestions: [{ id: 'q1' }] })).toBe(true);
+  });
+
+  it('returns false for an event with no questions', () => {
+    expect(eventRequiresQuestionnaire({ title: 'No questions' })).toBe(false);
+    expect(eventRequiresQuestionnaire({ questions: [] })).toBe(false);
+    expect(eventRequiresQuestionnaire({})).toBe(false);
+    expect(eventRequiresQuestionnaire(null)).toBe(false);
+  });
+});
+
+describe('resolveDisplayName', () => {
+  it('prefers an existing guest record name', () => {
+    const name = resolveDisplayName({ currentGuest: { name: 'From Guest' }, config: { name: 'From Config' }, tokenName: 'From Token' });
+    expect(name).toBe('From Guest');
+  });
+
+  it('falls back to config name, then token name', () => {
+    expect(resolveDisplayName({ config: { name: 'From Config' }, tokenName: 'From Token' })).toBe('From Config');
+    expect(resolveDisplayName({ tokenName: 'From Token' })).toBe('From Token');
+  });
+
+  it('honours an explicit override above everything', () => {
+    const name = resolveDisplayName({ override: 'Override', currentGuest: { name: 'Guest' }, config: { name: 'Config' } });
+    expect(name).toBe('Override');
+  });
+
+  it('returns null when nothing is resolvable (caller must error)', () => {
+    expect(resolveDisplayName({})).toBeNull();
+  });
+});
+
+// Live-verified questionnaire shape (2026-07-24 host-side recon).
+// Event fields: questionnaireEnabled + questionnaire.questions[{id,type,text,required}].
+// Answer storage: guest.questionnaireResponse = { questionnaireVersion, answers:{id:val} }.
+describe('questionnaire (verified shape)', () => {
+  const qEvent = {
+    questionnaireEnabled: true,
+    questionnaireVersions: [{ questions: [] }],
+    questionnaire: {
+      questions: [
+        { id: '111', type: 'short_answer', text: 'Dietary restrictions?', required: true },
+        { id: '222', type: 'short_answer', text: 'Song request?', required: false },
+      ],
+    },
+  };
+
+  it('detects a questionnaire via questionnaireEnabled + questions[]', () => {
+    expect(eventRequiresQuestionnaire(qEvent)).toBe(true);
+  });
+
+  it('returns false when the questionnaire keys are absent', () => {
+    expect(eventRequiresQuestionnaire({ title: 'plain event' })).toBe(false);
+  });
+
+  it('returns false for an empty questions list', () => {
+    expect(eventRequiresQuestionnaire({ questionnaireEnabled: true, questionnaire: { questions: [] } })).toBe(false);
+  });
+
+  it('builds answers keyed by question id', () => {
+    const resp = buildQuestionnaireResponse(qEvent, { '111': 'None', '222': 'Anything' });
+    expect(resp).toEqual({
+      questionnaireVersion: 0,
+      answers: { '111': 'None', '222': 'Anything' },
+    });
+  });
+
+  it('accepts answers supplied by question text too', () => {
+    const resp = buildQuestionnaireResponse(qEvent, { 'Dietary restrictions?': 'Vegan' });
+    expect(resp.answers['111']).toBe('Vegan');
+  });
+
+  it('omits optional questions left unanswered', () => {
+    const resp = buildQuestionnaireResponse(qEvent, { '111': 'None' });
+    expect(resp.answers).toEqual({ '111': 'None' });
+  });
+
+  it('throws when a required question is unanswered', () => {
+    expect(() => buildQuestionnaireResponse(qEvent, { '222': 'Song' })).toThrow(/required question/i);
+  });
+
+  it('returns null for a non-questionnaire event', () => {
+    expect(buildQuestionnaireResponse({ title: 'plain' }, {})).toBeNull();
+  });
+
+  it('attaches questionnaireResponse into the addGuest rsvp payload', () => {
+    const qr = buildQuestionnaireResponse(qEvent, { '111': 'None' });
+    const { rsvp } = buildRsvpParams({ eventId: 'e1', name: 'Kaleb', questionnaireResponse: qr });
+    expect(rsvp.questionnaireResponse).toEqual({ questionnaireVersion: 0, answers: { '111': 'None' } });
+  });
+
+  it('leaves questionnaireResponse off the payload when not supplied', () => {
+    const { rsvp } = buildRsvpParams({ eventId: 'e1', name: 'Kaleb' });
+    expect(rsvp).not.toHaveProperty('questionnaireResponse');
+  });
+});

--- a/tests/schema-rsvp.test.js
+++ b/tests/schema-rsvp.test.js
@@ -1,0 +1,28 @@
+/**
+ * Schema introspection coverage for the new RSVP / interest verbs.
+ */
+import { describe, it, expect } from 'vitest';
+import { run } from './helpers.js';
+
+describe('schema covers rsvp / interested verbs', () => {
+  it('lists events.rsvp and events.interested', () => {
+    const out = run(['schema']);
+    expect(out.data.commands).toContain('events.rsvp');
+    expect(out.data.commands).toContain('events.interested');
+    expect(out.data.commands).toContain('explore.rsvp');
+    expect(out.data.commands).toContain('explore.interested');
+  });
+
+  it('events.rsvp schema exposes status + plus-one params', () => {
+    const out = run(['schema', 'events.rsvp']);
+    expect(out.data.command).toContain('rsvp');
+    expect(out.data.parameters['--status']).toBeDefined();
+    expect(out.data.parameters['--plus-one']).toBeDefined();
+    expect(out.data.parameters.eventId.required).toBe(true);
+  });
+
+  it('events.interested schema exposes --remove', () => {
+    const out = run(['schema', 'events.interested']);
+    expect(out.data.parameters['--remove']).toBeDefined();
+  });
+});


### PR DESCRIPTION
## What

Adds guest-side RSVP to the CLI and verifies the questionnaire wire shape that was previously only guessed.

**New commands**
- `events rsvp` / `explore rsvp` — going | maybe | declined (single `addGuest` call, `status` field)
- `events interested` / `explore interested` — `markEventInterest`

**Questionnaire support (verified live 2026-07-24)**

Recon method: created a throwaway private event via the CLI, added one required short-answer question in the host UI, RSVP'd through the web app (native CDP mouse click — React ignores synthetic clicks), read the answer back off the guest record, then cancelled the event. Source of truth was `__NEXT_DATA__.props.pageProps` (Partiful SSR-embeds the event; there is no runtime fetch to intercept).

| Location | Field | Shape |
|---|---|---|
| Event | `questionnaireEnabled` | `true` (key absent when no questionnaire) |
| Event | `questionnaire.questions[]` | `{ id, type:"short_answer", text, required }` |
| Event | `questionnaireVersions[]` | append-only history |
| Guest | `questionnaireResponse` | `{ questionnaireVersion, answers: { "<questionId>": "<string>" } }` |

Answers are keyed by **question id** (epoch-ms string), not by text or index.

## Implementation
- `eventRequiresQuestionnaire()` — keys off `questionnaireEnabled` + `questionnaire.questions[]`; legacy field-name guesses kept only as defensive fallback
- `buildQuestionnaireResponse(event, answersByKey)` — builds the verified response, accepts answers by id or text, **fail-closed** throw on unanswered required questions
- `buildRsvpParams()` — attaches `questionnaireResponse` into the `addGuest` payload when supplied
- Read-before-write errors (`getCurrentGuest` / `getEventInfo`) now propagate and abort the RSVP instead of silently disabling guards

## Tests
187/187 passing (10 new questionnaire-shape unit tests). Includes schema registry entries, README docs, and `partiful-events` skill docs.

## Notes
- `.gitignore` adds `.npmrc` (keeps npm creds out of the repo)
- Recon test event `ztL5bpOhID4UfSaKOxXR` was cancelled; it was private and never had guests invited


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `events rsvp` and `events interested` commands, also available through `explore`.
  * Supports RSVP statuses, plus-ones, names, messages, previews, confirmations, and removing interest.
  * Added validation for ticketed and questionnaire-required events.
  * Added questionnaire answer support for eligible RSVPs.
  * Added command schema entries for the new options.

* **Documentation**
  * Updated the README and Partiful skill documentation with command usage, flags, aliases, and behavioral notes.

* **Tests**
  * Added coverage for RSVP, interest, validation, questionnaire handling, dry runs, aliases, and command schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->