### PR TITLE
ci(pages): add pull request previews

### DIFF
--- a/.github/workflows/pages-preview.yml
+++ b/.github/workflows/pages-preview.yml
@@ -1,0 +1,45 @@
+name: Deploy PR preview
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+    paths:
+      - docs/**
+      - .github/workflows/pages.yml
+      - .github/workflows/pages-preview.yml
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: pages-publish
+  cancel-in-progress: false
+
+jobs:
+  deploy-preview:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Deploy preview
+        id: preview
+        uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1
+        with:
+          source-dir: docs
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          wait-for-pages-deployment: true
+          comment: true
+          qr-code: false
+
+      - name: Add preview URL to job summary
+        if: steps.preview.outputs.deployment-action == 'deploy'
+        run: |
+          echo "Preview: ${{ steps.preview.outputs.preview-url }}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/pages-preview.yml
+++ b/.github/workflows/pages-preview.yml
@@ -7,10 +7,6 @@ on:
       - reopened
       - synchronize
       - closed
-    paths:
-      - docs/**
-      - .github/workflows/pages.yml
-      - .github/workflows/pages-preview.yml
 
 permissions:
   contents: write
@@ -19,6 +15,7 @@ permissions:
 concurrency:
   group: pages-publish
   cancel-in-progress: false
+  queue: max
 
 jobs:
   deploy-preview:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -15,6 +15,7 @@ permissions:
 concurrency:
   group: pages-publish
   cancel-in-progress: false
+  queue: max
 
 jobs:
   deploy:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -10,32 +10,23 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 concurrency:
-  group: pages
-  cancel-in-progress: true
+  group: pages-publish
+  cancel-in-progress: false
 
 jobs:
   deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+      - name: Deploy production site
+        uses: JamesIves/github-pages-deploy-action@fa24774553152dd7873cd16ebd8d959b010c5445 # v4
         with:
-          path: ./docs
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          branch: gh-pages
+          folder: docs
+          clean-exclude: pr-preview
+          force: false


### PR DESCRIPTION
## What changed

- publish production Pages content to the root of `gh-pages`
- deploy each same-repository PR to `/pr-preview/pr-<number>/`
- add a sticky PR comment with the preview URL
- delete the preview when the PR closes
- serialize all production, preview, and cleanup deployments with a FIFO queue
- pin all third-party actions to commit SHAs

## Hosting migration

Bootstrapped `gh-pages` from the exact `main/docs` tree, then changed the Pages source from `main/docs` to `gh-pages:/`. The live HTML SHA-256 stayed identical before and after the switch.

## Verification

- `npm test` (321 passed, 6 skipped)
- `npm run typecheck`
- `actionlint` v1.7.12, ignoring only its false positive for GitHub’s May 2026 `queue` property
- GitHub Actions completed both the preview and production workflows from this branch
- production and PR preview URLs return HTTP 200
- Pages source reports `gh-pages:/` and status `built`
