### PR TITLE
fix(pages): comment on preview backfills

### DIFF
--- a/.github/workflows/pages-preview.yml
+++ b/.github/workflows/pages-preview.yml
@@ -44,8 +44,17 @@ jobs:
           preview-branch: gh-pages
           umbrella-dir: pr-preview
           wait-for-pages-deployment: true
-          comment: true
+          comment: ${{ github.event_name != 'workflow_dispatch' }}
           qr-code: false
+
+      - name: Comment on manually deployed preview
+        if: github.event_name == 'workflow_dispatch' && steps.preview.outputs.deployment-action == 'deploy'
+        uses: marocchino/sticky-pull-request-comment@67d0dec7b07ed060a405f9b2a64b8ab319fdd7db
+        with:
+          number: ${{ inputs.pr-number }}
+          header: pr-preview
+          message: |
+            Preview ready: ${{ steps.preview.outputs.preview-url }}
 
       - name: Add preview URL to job summary
         if: steps.preview.outputs.deployment-action == 'deploy'


### PR DESCRIPTION
Manual preview deployments do not populate `github.event.number`, so the wrapped sticky-comment action silently skipped the PR comment. Pass the requested PR number to an explicit bot-comment step for manual backfills. Regular pull request events keep the wrapper’s existing comment behavior.

Observed failure: `no pull request numbers given: skip step` in run 31404543103.