### PR TITLE
docs(spec): reconstruct remote API contract

### DIFF
--- a/docs/REMOTE-API-CONTRACT.md
+++ b/docs/REMOTE-API-CONTRACT.md
@@ -1,18 +1,19 @@
 # Remote API contract
 
-`spec/partiful.openapi.json` is revision `2026-08-10.1` of the reviewed remote
-transport snapshot. It describes only network operations and wire shapes. It
-does not prescribe commands, output, credentials, mutation safeguards, or
-implementation architecture.
+`spec/partiful.openapi.json` is proposed revision `2026-08-10.1` of the remote
+transport snapshot. It is pending explicit owner approval. It describes only
+network operations and wire shapes. It does not prescribe commands, output,
+credentials, mutation safeguards, or implementation architecture.
 
 ## Authority and change process
 
-Live, privacy-safe observations outrank this snapshot. The owner must review a
-proposed change, update the contract and `spec/partiful.api-evidence.json`, and
-run `npm test -- tests/remote-api-contract.test.js`. TypeScript, historical
-drafts, tests, and endpoint notes are research evidence, never automatic
-authority. The CLI product contract is separate and remains the authority for
-user-facing behavior.
+Live, privacy-safe observations outrank this proposed snapshot. The owner must
+explicitly approve it before it becomes a reviewed contract. A proposed change
+must update the contract and `spec/partiful.api-evidence.json`, then run
+`npm test -- tests/remote-api-contract.test.js`. TypeScript, historical drafts,
+tests, and endpoint notes are research evidence, never automatic authority.
+The CLI product contract is separate and remains the authority for user-facing
+behavior.
 
 The evidence ledger records the classification and source for each operation,
 each request/response claim, and each component schema. `explicit-unknown`

--- a/docs/REMOTE-API-CONTRACT.md
+++ b/docs/REMOTE-API-CONTRACT.md
@@ -25,9 +25,10 @@ human-readable companion to the machine-readable ledger.
 ## Historical provenance
 
 The 27-operation historical draft in commit
-`17e9800753ada577408074bbbcadbae8cc8eacf0` was recovered as research input;
-it was not copied as an approved contract. Its product extensions were
-excluded. The nested `createTextBlast.message` object comes instead from the
-dated observation recorded in
+`17e9800753ada577408074bbbcadbae8cc8eacf0` is preserved at
+`spec/research/historical-27-operation-draft.json` as a non-authoritative,
+stable research artifact. It was not copied as an approved contract and its
+product extensions are excluded from the canonical contract. The nested
+`createTextBlast.message` object comes instead from the dated observation recorded in
 `docs/research/2026-03-24-text-blast-endpoint.md`; the historical string
 message/`recipientStatuses` representation is superseded.

--- a/docs/REMOTE-API-CONTRACT.md
+++ b/docs/REMOTE-API-CONTRACT.md
@@ -1,15 +1,15 @@
 # Remote API contract
 
-`spec/partiful.openapi.json` is proposed revision `2026-08-10.1` of the remote
-transport snapshot. It is pending explicit owner approval. It describes only
-network operations and wire shapes. It does not prescribe commands, output,
-credentials, mutation safeguards, or implementation architecture.
+`spec/partiful.openapi.json` is owner-reviewed revision `2026-08-10.1` of the
+remote transport snapshot. It describes only network operations and wire
+shapes. It does not prescribe commands, output, credentials, mutation
+safeguards, or implementation architecture.
 
 ## Authority and change process
 
-Live, privacy-safe observations outrank this proposed snapshot. The owner must
-explicitly approve it before it becomes a reviewed contract. A proposed change
-must update the contract and `spec/partiful.api-evidence.json`, then run
+Live, privacy-safe observations outrank this reviewed snapshot. A proposed
+change must receive owner approval, update the contract and
+`spec/partiful.api-evidence.json`, then run
 `npm test -- tests/remote-api-contract.test.js`. TypeScript, historical drafts,
 tests, and endpoint notes are research evidence, never automatic authority.
 The CLI product contract is separate and remains the authority for user-facing

--- a/docs/REMOTE-API-CONTRACT.md
+++ b/docs/REMOTE-API-CONTRACT.md
@@ -1,0 +1,32 @@
+# Remote API contract
+
+`spec/partiful.openapi.json` is revision `2026-08-10.1` of the reviewed remote
+transport snapshot. It describes only network operations and wire shapes. It
+does not prescribe commands, output, credentials, mutation safeguards, or
+implementation architecture.
+
+## Authority and change process
+
+Live, privacy-safe observations outrank this snapshot. The owner must review a
+proposed change, update the contract and `spec/partiful.api-evidence.json`, and
+run `npm test -- tests/remote-api-contract.test.js`. TypeScript, historical
+drafts, tests, and endpoint notes are research evidence, never automatic
+authority. The CLI product contract is separate and remains the authority for
+user-facing behavior.
+
+The evidence ledger records the classification and source for each operation,
+each request/response claim, and each component schema. `explicit-unknown`
+means the contract intentionally declines to claim precision. Never replace it
+with guessed fields, captured credentials, real identifiers, or personal data.
+`docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md` is the
+human-readable companion to the machine-readable ledger.
+
+## Historical provenance
+
+The 27-operation historical draft in commit
+`17e9800753ada577408074bbbcadbae8cc8eacf0` was recovered as research input;
+it was not copied as an approved contract. Its product extensions were
+excluded. The nested `createTextBlast.message` object comes instead from the
+dated observation recorded in
+`docs/research/2026-03-24-text-blast-endpoint.md`; the historical string
+message/`recipientStatuses` representation is superseded.

--- a/docs/research/2026-08-10-contract-evidence-sources.md
+++ b/docs/research/2026-08-10-contract-evidence-sources.md
@@ -17,6 +17,16 @@ only and are not part of `spec/partiful.openapi.json`.
 No safe live observation in this reconstruction establishes an HTTP success
 status for every operation. The proposal therefore uses OpenAPI `default`
 responses and records each response-status claim as `explicit-unknown`.
+This decision supports only the response **status key**. Response content and
+schema claims separately cite their actual wire-shape source.
+
+## Update-mask serialization
+
+The historical draft's `firestorePatchEvent` parameter is an array of strings,
+and `9e6ed15:src/lib/http.ts#L132-L134` repeats
+`updateMask.fieldPaths` once for every field. The proposal represents it as a
+form-style, exploded query array; this is a TypeScript-derived transport
+inference, not a live observation.
 
 ## Dated text-blast observation
 

--- a/docs/research/2026-08-10-contract-evidence-sources.md
+++ b/docs/research/2026-08-10-contract-evidence-sources.md
@@ -1,0 +1,68 @@
+# Stable sources for the proposed remote contract
+
+This index makes the evidence ledger resolvable in a clean checkout. It is a
+research index, not an approval of any claim. The canonical remote contract
+does not import product metadata from these sources.
+
+## Historical transport draft
+
+`spec/research/historical-27-operation-draft.json` is an exact, clearly
+non-authoritative copy of `17e9800753ada577408074bbbcadbae8cc8eacf0`'s
+27-operation draft. JSON-pointer citations into that local artifact are
+validated by the contract test. Its extensions and product policy are research
+only and are not part of `spec/partiful.openapi.json`.
+
+## Unknown status decision
+
+No safe live observation in this reconstruction establishes an HTTP success
+status for every operation. The proposal therefore uses OpenAPI `default`
+responses and records each response-status claim as `explicit-unknown`.
+
+## Dated text-blast observation
+
+The March 24, 2026 browser-interception note
+`docs/research/2026-03-24-text-blast-endpoint.md`, under “Request Payload,”
+records the nested `message` object used by `createTextBlast`. It is the
+primary evidence that supersedes the historical string-message draft.
+
+## Dated authentication observation
+
+The March 24, 2026 note
+`docs/research/2026-03-24-auth-flow-endpoints.md`, under “Auth Endpoints,”
+records the observed login-token and custom-token exchange wire shapes.
+
+## TypeScript callable and auth research
+
+Reviewed source evidence is preserved from
+`9e6ed15:src/lib/api/endpoints.ts#L1-L560`,
+`9e6ed15:src/lib/auth.ts#L1-L150`, and
+`9e6ed15:src/commands/auth.ts#L145-L340`. It supports inferred callable
+registration and authentication behavior; it is not a live-server claim.
+
+## TypeScript Firestore research
+
+Reviewed source evidence is preserved from
+`9e6ed15:src/lib/http.ts#L100-L230`, which constructs the Firestore document,
+patch, and list requests. It supports inferred transport shapes only.
+
+## TypeScript upload research
+
+Reviewed source evidence is preserved from
+`9e6ed15:src/lib/upload.ts#L35-L115`, which constructs multipart `file`
+uploads to `uploadPhoto` and reads `uploadData.url`. It supports inferred
+transport shapes only.
+
+## Poster interface
+
+`9e6ed15:src/lib/posters.ts#L5-L16` defines the broad `Poster` interface:
+optional ID, name, URL, content type, dimensions, tags, categories, and extra
+fields. These are TypeScript-derived catalog schema inferences, not live
+catalog observations.
+
+## Poster catalog fetch
+
+`9e6ed15:src/lib/posters.ts#L38-L55` fetches
+`https://assets.getpartiful.com/posters.json`, checks the response, and casts
+the JSON array to `Poster[]`. This supports the inferred catalog endpoint and
+array transport only. The dated event-image observation is intentionally not
+used for this claim.

--- a/docs/research/2026-08-10-contract-evidence-sources.md
+++ b/docs/research/2026-08-10-contract-evidence-sources.md
@@ -17,8 +17,10 @@ only and are not part of `spec/partiful.openapi.json`.
 No safe live observation in this reconstruction establishes an HTTP success
 status for every operation. The proposal therefore uses OpenAPI `default`
 responses and records each response-status claim as `explicit-unknown`.
-This decision supports only the response **status key**. Response content and
-schema claims separately cite their actual wire-shape source.
+This decision supports both the response **status key** and the explicit
+unknown response/body classification. The proposal deliberately attaches no
+content schema to `default`; reusable response shapes remain unattached
+research evidence until an applicable status/class is observed.
 
 ## Update-mask serialization
 

--- a/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
+++ b/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
@@ -34,7 +34,7 @@ observed, callable result payloads, status codes, error bodies, permission
 rules, and limits are **explicit unknown**. Consequently, this proposal uses
 OpenAPI `default` responses rather than inventing a success status.
 
-The 379 material claims are audited by
+The 876 material claims are audited by
 `tests/remote-api-contract.test.js`. Each ledger citation resolves either to a
 JSON Pointer in the committed non-authoritative historical artifact or to a
 heading in the committed stable source index. This keeps the audit independent

--- a/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
+++ b/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
@@ -18,8 +18,9 @@
 
 The recovered 27 operations remain in the remote inventory. `createTextBlast`,
 `getLoginToken`, and `signInWithCustomToken` have dated live observations.
-`sendAuthCodeTrusted` and `lookupFirebaseUser` have reviewed repository
-research. The remaining operations are TypeScript-derived inferences:
+`sendAuthCodeTrusted` is a TypeScript-derived inference.
+`lookupFirebaseUser` is a TypeScript-derived inference. The remaining
+operations are TypeScript-derived inferences:
 
 - callable: `createEvent`, `cancelEvent`, `getEventInfo`, `getContacts`,
   `addInvitedGuestsAsHost`, cohost lifecycle operations, both home-page
@@ -32,9 +33,10 @@ the JSON ledger, including operation, parameter, content-type, security,
 schema, constraint, and response claims. Unless a claim is specifically
 observed, callable result payloads, status codes, error bodies, permission
 rules, and limits are **explicit unknown**. Consequently, this proposal uses
-OpenAPI `default` responses rather than inventing a success status.
+schema-free OpenAPI `default` responses rather than inventing a success status
+or applying a success body to errors.
 
-The 876 material claims are audited by
+The 819 material claims are audited by
 `tests/remote-api-contract.test.js`. Each ledger citation resolves either to a
 JSON Pointer in the committed non-authoritative historical artifact or to a
 heading in the committed stable source index. This keeps the audit independent

--- a/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
+++ b/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
@@ -3,6 +3,7 @@
 **Proposed contract revision:** `2026-08-10.1` (pending explicit owner approval)
 **Contract:** `spec/partiful.openapi.json`
 **Machine-readable ledger:** `spec/partiful.api-evidence.json`
+**Stable citation sources:** `docs/research/2026-08-10-contract-evidence-sources.md`
 
 ## Evidence classes
 
@@ -32,6 +33,12 @@ schema, constraint, and response claims. Unless a claim is specifically
 observed, callable result payloads, status codes, error bodies, permission
 rules, and limits are **explicit unknown**. Consequently, this proposal uses
 OpenAPI `default` responses rather than inventing a success status.
+
+The 379 material claims are audited by
+`tests/remote-api-contract.test.js`. Each ledger citation resolves either to a
+JSON Pointer in the committed non-authoritative historical artifact or to a
+heading in the committed stable source index. This keeps the audit independent
+of unreachable historical Git objects in shallow CI checkouts.
 
 The event-image observation establishes fields used for an event's selected
 poster image; it does **not** establish that `/posters.json` returns a catalog

--- a/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
+++ b/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
@@ -1,6 +1,6 @@
 # Partiful remote API contract evidence ledger
 
-**Proposed contract revision:** `2026-08-10.1` (pending explicit owner approval)
+**Owner-reviewed contract revision:** `2026-08-10.1`
 **Contract:** `spec/partiful.openapi.json`
 **Machine-readable ledger:** `spec/partiful.api-evidence.json`
 **Stable citation sources:** `docs/research/2026-08-10-contract-evidence-sources.md`
@@ -58,7 +58,7 @@ nested `message` object with `text`, `to`, `showOnEventPage`, and optional
 
 ## Open questions
 
-No authenticated live probe was performed for this proposed revision: `partiful doctor`
+No authenticated live probe was performed for this reviewed revision: `partiful doctor`
 reported no local credentials. Mutation probes were deliberately omitted.
 Future safe observations should update both ledgers, preserve synthetic-only
 examples, and receive owner review before changing the revision.

--- a/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
+++ b/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
@@ -1,0 +1,46 @@
+# Partiful remote API contract evidence ledger
+
+**Contract revision:** `2026-08-10.1`
+**Contract:** `spec/partiful.openapi.json`
+**Machine-readable ledger:** `spec/partiful.api-evidence.json`
+
+## Evidence classes
+
+- **Dated live observation:** the March 24 browser-interception research.
+- **Reviewed first-party repository research:** reviewed repository source,
+  without claiming it proves current server behavior.
+- **TypeScript-derived inference:** historical draft or TypeScript transport
+  behavior; useful, but not authoritative.
+- **Explicit unknown:** a deliberate absence of a remote claim.
+
+## Operation inventory
+
+The recovered 27 operations remain in the remote inventory. `createTextBlast`,
+`getLoginToken`, and `signInWithCustomToken` have dated live observations.
+`sendAuthCodeTrusted` and `lookupFirebaseUser` have reviewed repository
+research. The remaining operations are TypeScript-derived inferences:
+
+- callable: `createEvent`, `cancelEvent`, `getEventInfo`, `getContacts`,
+  `addInvitedGuestsAsHost`, cohost lifecycle operations, both home-page
+  queries, `addGuest`, `markEventInterest`, and `getCurrentGuest`;
+- Firestore: event and guest reads, event patch, and document listing;
+- Firebase and auxiliary: refresh, photo upload, and poster catalog.
+
+Every operation's request and response claim is enumerated in the JSON ledger.
+Unless a claim is specifically observed, callable result payloads, status
+codes, error bodies, permission rules, and limits are **explicit unknown**.
+
+## Resolved conflict
+
+The historical draft described `createTextBlast.params.message` as a string and
+added `recipientStatuses`. The dated browser interception instead observed a
+nested `message` object with `text`, `to`, `showOnEventPage`, and optional
+`images`. The contract adopts the observation and excludes
+`recipientStatuses`; no contradictory hybrid schema is retained.
+
+## Open questions
+
+No authenticated live probe was performed for this revision: `partiful doctor`
+reported no local credentials. Mutation probes were deliberately omitted.
+Future safe observations should update both ledgers, preserve synthetic-only
+examples, and receive owner review before changing the revision.

--- a/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
+++ b/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
@@ -1,6 +1,6 @@
 # Partiful remote API contract evidence ledger
 
-**Contract revision:** `2026-08-10.1`
+**Proposed contract revision:** `2026-08-10.1` (pending explicit owner approval)
 **Contract:** `spec/partiful.openapi.json`
 **Machine-readable ledger:** `spec/partiful.api-evidence.json`
 
@@ -26,9 +26,18 @@ research. The remaining operations are TypeScript-derived inferences:
 - Firestore: event and guest reads, event patch, and document listing;
 - Firebase and auxiliary: refresh, photo upload, and poster catalog.
 
-Every operation's request and response claim is enumerated in the JSON ledger.
-Unless a claim is specifically observed, callable result payloads, status
-codes, error bodies, permission rules, and limits are **explicit unknown**.
+Every operation's request and response claim is enumerated by JSON Pointer in
+the JSON ledger, including operation, parameter, content-type, security,
+schema, constraint, and response claims. Unless a claim is specifically
+observed, callable result payloads, status codes, error bodies, permission
+rules, and limits are **explicit unknown**. Consequently, this proposal uses
+OpenAPI `default` responses rather than inventing a success status.
+
+The event-image observation establishes fields used for an event's selected
+poster image; it does **not** establish that `/posters.json` returns a catalog
+array or that its entries have that shape. The catalog operation and `Poster`
+schema are therefore TypeScript-derived inferences with citations to
+`src/lib/posters.ts`, not dated live observations.
 
 ## Resolved conflict
 
@@ -40,7 +49,7 @@ nested `message` object with `text`, `to`, `showOnEventPage`, and optional
 
 ## Open questions
 
-No authenticated live probe was performed for this revision: `partiful doctor`
+No authenticated live probe was performed for this proposed revision: `partiful doctor`
 reported no local credentials. Mutation probes were deliberately omitted.
 Future safe observations should update both ledgers, preserve synthetic-only
 examples, and receive owner review before changing the revision.

--- a/spec/partiful.api-evidence.json
+++ b/spec/partiful.api-evidence.json
@@ -369,7 +369,7 @@
     "The poster event-image observation does not establish the /posters.json response; that operation is TypeScript-derived inference only.",
     "HTTP success status codes and error bodies are explicit unknown; response body claims are tracked separately."
   ],
-  "status": "proposed-pending-owner-approval",
+  "status": "owner-reviewed",
   "claims": {
     "#/servers/0/url": {
       "classification": "typescript-derived-inference",

--- a/spec/partiful.api-evidence.json
+++ b/spec/partiful.api-evidence.json
@@ -129,191 +129,218 @@
   "operationClaims": {
     "createEvent": {
       "request": "typescript-derived-inference",
-      "response": "typescript-derived-inference",
+      "requestCitation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post",
+      "response": "explicit-unknown",
+      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
       "status": "explicit-unknown",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "cancelEvent": {
       "request": "typescript-derived-inference",
-      "response": "typescript-derived-inference",
+      "requestCitation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post",
+      "response": "explicit-unknown",
+      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
       "status": "explicit-unknown",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "getEventInfo": {
       "request": "typescript-derived-inference",
-      "response": "typescript-derived-inference",
+      "requestCitation": "spec/research/historical-27-operation-draft.json#/paths/~1getEventInfo/post",
+      "response": "explicit-unknown",
+      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
       "status": "explicit-unknown",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getEventInfo/post",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "getContacts": {
       "request": "typescript-derived-inference",
-      "response": "typescript-derived-inference",
+      "requestCitation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post",
+      "response": "explicit-unknown",
+      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
       "status": "explicit-unknown",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "createTextBlast": {
       "request": "dated-live-observation",
-      "response": "typescript-derived-inference",
+      "requestCitation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation",
+      "response": "explicit-unknown",
+      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
       "status": "explicit-unknown",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "addInvitedGuestsAsHost": {
       "request": "typescript-derived-inference",
-      "response": "typescript-derived-inference",
+      "requestCitation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post",
+      "response": "explicit-unknown",
+      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
       "status": "explicit-unknown",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "createCohostRequest": {
       "request": "typescript-derived-inference",
-      "response": "typescript-derived-inference",
+      "requestCitation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post",
+      "response": "explicit-unknown",
+      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
       "status": "explicit-unknown",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "deleteCohostRequest": {
       "request": "typescript-derived-inference",
-      "response": "typescript-derived-inference",
+      "requestCitation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post",
+      "response": "explicit-unknown",
+      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
       "status": "explicit-unknown",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "removeCohost": {
       "request": "typescript-derived-inference",
-      "response": "typescript-derived-inference",
+      "requestCitation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post",
+      "response": "explicit-unknown",
+      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
       "status": "explicit-unknown",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "generateEventCohostLink": {
       "request": "typescript-derived-inference",
-      "response": "typescript-derived-inference",
+      "requestCitation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post",
+      "response": "explicit-unknown",
+      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
       "status": "explicit-unknown",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "revokeEventCohostLink": {
       "request": "typescript-derived-inference",
-      "response": "typescript-derived-inference",
+      "requestCitation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post",
+      "response": "explicit-unknown",
+      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
       "status": "explicit-unknown",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "getMyUpcomingEventsForHomePage": {
       "request": "typescript-derived-inference",
-      "response": "typescript-derived-inference",
+      "requestCitation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyUpcomingEventsForHomePage/post",
+      "response": "explicit-unknown",
+      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
       "status": "explicit-unknown",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyUpcomingEventsForHomePage/post",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "getMyPastEventsForHomePage": {
       "request": "typescript-derived-inference",
-      "response": "typescript-derived-inference",
+      "requestCitation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyPastEventsForHomePage/post",
+      "response": "explicit-unknown",
+      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
       "status": "explicit-unknown",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyPastEventsForHomePage/post",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "addGuest": {
       "request": "typescript-derived-inference",
-      "response": "typescript-derived-inference",
+      "requestCitation": "spec/research/historical-27-operation-draft.json#/paths/~1addGuest/post",
+      "response": "explicit-unknown",
+      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
       "status": "explicit-unknown",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addGuest/post",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "markEventInterest": {
       "request": "typescript-derived-inference",
-      "response": "typescript-derived-inference",
+      "requestCitation": "spec/research/historical-27-operation-draft.json#/paths/~1markEventInterest/post",
+      "response": "explicit-unknown",
+      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
       "status": "explicit-unknown",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1markEventInterest/post",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "getCurrentGuest": {
       "request": "typescript-derived-inference",
-      "response": "typescript-derived-inference",
+      "requestCitation": "spec/research/historical-27-operation-draft.json#/paths/~1getCurrentGuest/post",
+      "response": "explicit-unknown",
+      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
       "status": "explicit-unknown",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getCurrentGuest/post",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "firestoreGetEvent": {
       "request": "typescript-derived-inference",
-      "response": "typescript-derived-inference",
+      "requestCitation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get",
+      "response": "explicit-unknown",
+      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
       "status": "explicit-unknown",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "firestorePatchEvent": {
       "request": "typescript-derived-inference",
-      "response": "typescript-derived-inference",
+      "requestCitation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch",
+      "response": "explicit-unknown",
+      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
       "status": "explicit-unknown",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "firestoreGetGuest": {
       "request": "typescript-derived-inference",
-      "response": "typescript-derived-inference",
+      "requestCitation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get",
+      "response": "explicit-unknown",
+      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
       "status": "explicit-unknown",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "firestoreListDocuments": {
       "request": "typescript-derived-inference",
-      "response": "typescript-derived-inference",
+      "requestCitation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get",
+      "response": "explicit-unknown",
+      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
       "status": "explicit-unknown",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "refreshToken": {
       "request": "typescript-derived-inference",
-      "response": "typescript-derived-inference",
+      "requestCitation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1token/post",
+      "response": "explicit-unknown",
+      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
       "status": "explicit-unknown",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1token/post",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "sendAuthCodeTrusted": {
       "request": "typescript-derived-inference",
-      "response": "typescript-derived-inference",
+      "requestCitation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post",
+      "response": "explicit-unknown",
+      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
       "status": "explicit-unknown",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "getLoginToken": {
       "request": "dated-live-observation",
-      "response": "typescript-derived-inference",
+      "requestCitation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation",
+      "response": "explicit-unknown",
+      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
       "status": "explicit-unknown",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "signInWithCustomToken": {
       "request": "dated-live-observation",
-      "response": "typescript-derived-inference",
+      "requestCitation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation",
+      "response": "explicit-unknown",
+      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
       "status": "explicit-unknown",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "lookupFirebaseUser": {
       "request": "typescript-derived-inference",
-      "response": "typescript-derived-inference",
+      "requestCitation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1accounts:lookup/post",
+      "response": "explicit-unknown",
+      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
       "status": "explicit-unknown",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1accounts:lookup/post",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "uploadEventPhoto": {
       "request": "typescript-derived-inference",
-      "response": "typescript-derived-inference",
+      "requestCitation": "spec/research/historical-27-operation-draft.json#/paths/~1uploadPhoto/post",
+      "response": "explicit-unknown",
+      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
       "status": "explicit-unknown",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1uploadPhoto/post",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "getPosterCatalog": {
       "request": "typescript-derived-inference",
-      "response": "typescript-derived-inference",
+      "requestCitation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-catalog-fetch",
+      "response": "explicit-unknown",
+      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
       "status": "explicit-unknown",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-catalog-fetch",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     }
   },
@@ -468,14 +495,6 @@
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
-    "#/paths/~1createEvent/post/responses/default/content/application~1json": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/responses/200/content/application~1json"
-    },
-    "#/paths/~1createEvent/post/responses/default/content/application~1json/schema/$ref": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/responses/200/content/application~1json/schema/$ref"
-    },
     "#/paths/~1createEvent/post/security/0/firebaseBearer": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/security/0/firebaseBearer"
@@ -583,14 +602,6 @@
     "#/paths/~1cancelEvent/post/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
-    },
-    "#/paths/~1cancelEvent/post/responses/default/content/application~1json": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/responses/200/content/application~1json"
-    },
-    "#/paths/~1cancelEvent/post/responses/default/content/application~1json/schema/$ref": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/responses/200/content/application~1json/schema/$ref"
     },
     "#/paths/~1cancelEvent/post/security/0/firebaseBearer": {
       "classification": "typescript-derived-inference",
@@ -700,14 +711,6 @@
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
-    "#/paths/~1getEventInfo/post/responses/default/content/application~1json": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getEventInfo/post/responses/200/content/application~1json"
-    },
-    "#/paths/~1getEventInfo/post/responses/default/content/application~1json/schema/$ref": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getEventInfo/post/responses/200/content/application~1json/schema/$ref"
-    },
     "#/paths/~1getEventInfo/post/security/0/firebaseBearer": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getEventInfo/post/security/0/firebaseBearer"
@@ -803,14 +806,6 @@
     "#/paths/~1getContacts/post/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
-    },
-    "#/paths/~1getContacts/post/responses/default/content/application~1json": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post/responses/200/content/application~1json"
-    },
-    "#/paths/~1getContacts/post/responses/default/content/application~1json/schema/$ref": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post/responses/200/content/application~1json/schema/$ref"
     },
     "#/paths/~1getContacts/post/security/0/firebaseBearer": {
       "classification": "typescript-derived-inference",
@@ -976,11 +971,7 @@
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
     },
-    "#/paths/~1createTextBlast/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
-    },
-    "#/paths/~1createTextBlast/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1": {
+    "#/paths/~1createTextBlast/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
     },
@@ -995,14 +986,6 @@
     "#/paths/~1createTextBlast/post/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
-    },
-    "#/paths/~1createTextBlast/post/responses/default/content/application~1json": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createTextBlast/post/responses/200/content/application~1json"
-    },
-    "#/paths/~1createTextBlast/post/responses/default/content/application~1json/schema/$ref": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createTextBlast/post/responses/200/content/application~1json/schema/$ref"
     },
     "#/paths/~1createTextBlast/post/security/0/firebaseBearer": {
       "classification": "typescript-derived-inference",
@@ -1132,14 +1115,6 @@
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
-    "#/paths/~1addInvitedGuestsAsHost/post/responses/default/content/application~1json": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/responses/200/content/application~1json"
-    },
-    "#/paths/~1addInvitedGuestsAsHost/post/responses/default/content/application~1json/schema/$ref": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/responses/200/content/application~1json/schema/$ref"
-    },
     "#/paths/~1addInvitedGuestsAsHost/post/security/0/firebaseBearer": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/security/0/firebaseBearer"
@@ -1259,14 +1234,6 @@
     "#/paths/~1createCohostRequest/post/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
-    },
-    "#/paths/~1createCohostRequest/post/responses/default/content/application~1json": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/responses/200/content/application~1json"
-    },
-    "#/paths/~1createCohostRequest/post/responses/default/content/application~1json/schema/$ref": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/responses/200/content/application~1json/schema/$ref"
     },
     "#/paths/~1createCohostRequest/post/security/0/firebaseBearer": {
       "classification": "typescript-derived-inference",
@@ -1388,14 +1355,6 @@
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
-    "#/paths/~1deleteCohostRequest/post/responses/default/content/application~1json": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/responses/200/content/application~1json"
-    },
-    "#/paths/~1deleteCohostRequest/post/responses/default/content/application~1json/schema/$ref": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/responses/200/content/application~1json/schema/$ref"
-    },
     "#/paths/~1deleteCohostRequest/post/security/0/firebaseBearer": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/security/0/firebaseBearer"
@@ -1516,14 +1475,6 @@
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
-    "#/paths/~1removeCohost/post/responses/default/content/application~1json": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/responses/200/content/application~1json"
-    },
-    "#/paths/~1removeCohost/post/responses/default/content/application~1json/schema/$ref": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/responses/200/content/application~1json/schema/$ref"
-    },
     "#/paths/~1removeCohost/post/security/0/firebaseBearer": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/security/0/firebaseBearer"
@@ -1631,14 +1582,6 @@
     "#/paths/~1generateEventCohostLink/post/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
-    },
-    "#/paths/~1generateEventCohostLink/post/responses/default/content/application~1json": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/responses/200/content/application~1json"
-    },
-    "#/paths/~1generateEventCohostLink/post/responses/default/content/application~1json/schema/$ref": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/responses/200/content/application~1json/schema/$ref"
     },
     "#/paths/~1generateEventCohostLink/post/security/0/firebaseBearer": {
       "classification": "typescript-derived-inference",
@@ -1748,14 +1691,6 @@
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
-    "#/paths/~1revokeEventCohostLink/post/responses/default/content/application~1json": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/responses/200/content/application~1json"
-    },
-    "#/paths/~1revokeEventCohostLink/post/responses/default/content/application~1json/schema/$ref": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/responses/200/content/application~1json/schema/$ref"
-    },
     "#/paths/~1revokeEventCohostLink/post/security/0/firebaseBearer": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/security/0/firebaseBearer"
@@ -1852,14 +1787,6 @@
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
-    "#/paths/~1getMyUpcomingEventsForHomePage/post/responses/default/content/application~1json": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyUpcomingEventsForHomePage/post/responses/200/content/application~1json"
-    },
-    "#/paths/~1getMyUpcomingEventsForHomePage/post/responses/default/content/application~1json/schema/$ref": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyUpcomingEventsForHomePage/post/responses/200/content/application~1json/schema/$ref"
-    },
     "#/paths/~1getMyUpcomingEventsForHomePage/post/security/0/firebaseBearer": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyUpcomingEventsForHomePage/post/security/0/firebaseBearer"
@@ -1955,14 +1882,6 @@
     "#/paths/~1getMyPastEventsForHomePage/post/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
-    },
-    "#/paths/~1getMyPastEventsForHomePage/post/responses/default/content/application~1json": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyPastEventsForHomePage/post/responses/200/content/application~1json"
-    },
-    "#/paths/~1getMyPastEventsForHomePage/post/responses/default/content/application~1json/schema/$ref": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyPastEventsForHomePage/post/responses/200/content/application~1json/schema/$ref"
     },
     "#/paths/~1getMyPastEventsForHomePage/post/security/0/firebaseBearer": {
       "classification": "typescript-derived-inference",
@@ -2083,14 +2002,6 @@
     "#/paths/~1addGuest/post/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
-    },
-    "#/paths/~1addGuest/post/responses/default/content/application~1json": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addGuest/post/responses/200/content/application~1json"
-    },
-    "#/paths/~1addGuest/post/responses/default/content/application~1json/schema/$ref": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addGuest/post/responses/200/content/application~1json/schema/$ref"
     },
     "#/paths/~1addGuest/post/security/0/firebaseBearer": {
       "classification": "typescript-derived-inference",
@@ -2224,14 +2135,6 @@
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
-    "#/paths/~1markEventInterest/post/responses/default/content/application~1json": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1markEventInterest/post/responses/200/content/application~1json"
-    },
-    "#/paths/~1markEventInterest/post/responses/default/content/application~1json/schema/$ref": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1markEventInterest/post/responses/200/content/application~1json/schema/$ref"
-    },
     "#/paths/~1markEventInterest/post/security/0/firebaseBearer": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1markEventInterest/post/security/0/firebaseBearer"
@@ -2340,14 +2243,6 @@
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
-    "#/paths/~1getCurrentGuest/post/responses/default/content/application~1json": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getCurrentGuest/post/responses/200/content/application~1json"
-    },
-    "#/paths/~1getCurrentGuest/post/responses/default/content/application~1json/schema/$ref": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getCurrentGuest/post/responses/200/content/application~1json/schema/$ref"
-    },
     "#/paths/~1getCurrentGuest/post/security/0/firebaseBearer": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getCurrentGuest/post/security/0/firebaseBearer"
@@ -2375,14 +2270,6 @@
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
-    },
-    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/responses/default/content/application~1json": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/responses/200/content/application~1json"
-    },
-    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/responses/default/content/application~1json/schema/$ref": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/responses/200/content/application~1json/schema/$ref"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/security/0/firebaseBearer": {
       "classification": "typescript-derived-inference",
@@ -2456,14 +2343,6 @@
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
-    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/responses/default/content/application~1json": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/responses/200/content/application~1json"
-    },
-    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/responses/default/content/application~1json/schema/$ref": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/responses/200/content/application~1json/schema/$ref"
-    },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/security/0/firebaseBearer": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/security/0/firebaseBearer"
@@ -2512,14 +2391,6 @@
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
-    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/responses/default/content/application~1json": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/responses/200/content/application~1json"
-    },
-    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/responses/default/content/application~1json/schema/$ref": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/responses/200/content/application~1json/schema/$ref"
-    },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/security/0/firebaseBearer": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/security/0/firebaseBearer"
@@ -2564,10 +2435,6 @@
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/1/schema/type"
     },
-    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/1/schema/default": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/1/schema/default"
-    },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/2/name": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/2/name"
@@ -2587,14 +2454,6 @@
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
-    },
-    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/responses/default/content/application~1json": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/responses/200/content/application~1json"
-    },
-    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/responses/default/content/application~1json/schema/$ref": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/responses/200/content/application~1json/schema/$ref"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/security/0/firebaseBearer": {
       "classification": "typescript-derived-inference",
@@ -2655,14 +2514,6 @@
     "#/paths/~1v1~1token/post/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
-    },
-    "#/paths/~1v1~1token/post/responses/default/content/application~1json": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1token/post/responses/200/content/application~1json"
-    },
-    "#/paths/~1v1~1token/post/responses/default/content/application~1json/schema/$ref": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1token/post/responses/200/content/application~1json/schema/$ref"
     },
     "#/paths/~1v1~1token/post/security/0/firebaseApiKey": {
       "classification": "typescript-derived-inference",
@@ -2832,14 +2683,6 @@
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
-    "#/paths/~1sendAuthCodeTrusted/post/responses/default/content/application~1json": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post/responses/200/content/application~1json"
-    },
-    "#/paths/~1sendAuthCodeTrusted/post/responses/default/content/application~1json/schema/$ref": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post/responses/200/content/application~1json/schema/$ref"
-    },
     "#/paths/~1getLoginToken/post/operationId": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getLoginToken/post/operationId"
@@ -2976,14 +2819,6 @@
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
-    "#/paths/~1getLoginToken/post/responses/default/content/application~1json": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getLoginToken/post/responses/200/content/application~1json"
-    },
-    "#/paths/~1getLoginToken/post/responses/default/content/application~1json/schema/$ref": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getLoginToken/post/responses/200/content/application~1json/schema/$ref"
-    },
     "#/paths/~1v1~1accounts:signInWithCustomToken/post/operationId": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1accounts:signInWithCustomToken/post/operationId"
@@ -3032,14 +2867,6 @@
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
-    "#/paths/~1v1~1accounts:signInWithCustomToken/post/responses/default/content/application~1json": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1accounts:signInWithCustomToken/post/responses/200/content/application~1json"
-    },
-    "#/paths/~1v1~1accounts:signInWithCustomToken/post/responses/default/content/application~1json/schema/$ref": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1accounts:signInWithCustomToken/post/responses/200/content/application~1json/schema/$ref"
-    },
     "#/paths/~1v1~1accounts:signInWithCustomToken/post/security/0/firebaseApiKey": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1accounts:signInWithCustomToken/post/security/0/firebaseApiKey"
@@ -3083,14 +2910,6 @@
     "#/paths/~1v1~1accounts:lookup/post/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
-    },
-    "#/paths/~1v1~1accounts:lookup/post/responses/default/content/application~1json": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1accounts:lookup/post/responses/200/content/application~1json"
-    },
-    "#/paths/~1v1~1accounts:lookup/post/responses/default/content/application~1json/schema/$ref": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1accounts:lookup/post/responses/200/content/application~1json/schema/$ref"
     },
     "#/paths/~1v1~1accounts:lookup/post/security/0/firebaseApiKey": {
       "classification": "typescript-derived-inference",
@@ -3160,14 +2979,6 @@
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
-    "#/paths/~1uploadPhoto/post/responses/default/content/application~1json": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1uploadPhoto/post/responses/200/content/application~1json"
-    },
-    "#/paths/~1uploadPhoto/post/responses/default/content/application~1json/schema/$ref": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1uploadPhoto/post/responses/200/content/application~1json/schema/$ref"
-    },
     "#/paths/~1uploadPhoto/post/security/0/firebaseBearer": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1uploadPhoto/post/security/0/firebaseBearer"
@@ -3183,18 +2994,6 @@
     "#/paths/~1posters.json/get/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
-    },
-    "#/paths/~1posters.json/get/responses/default/content/application~1json": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-catalog-fetch"
-    },
-    "#/paths/~1posters.json/get/responses/default/content/application~1json/schema/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-catalog-fetch"
-    },
-    "#/paths/~1posters.json/get/responses/default/content/application~1json/schema/items/$ref": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-catalog-fetch"
     },
     "#/paths/~1posters.json/get/servers/0/url": {
       "classification": "typescript-derived-inference",

--- a/spec/partiful.api-evidence.json
+++ b/spec/partiful.api-evidence.json
@@ -1,42 +1,297 @@
 {
   "contractRevision": "2026-08-10.1",
   "contractPath": "spec/partiful.openapi.json",
-  "allowedClassifications": ["dated-live-observation", "reviewed-first-party-repository-research", "typescript-derived-inference", "explicit-unknown"],
-  "sources": {
-    "draft": "Historical draft 17e9800753ada577408074bbbcadbae8cc8eacf0; research input only.",
-    "typescript": "Reviewed TypeScript endpoint registry and transport code in src/lib/; research input only.",
-    "textBlastLive": "docs/research/2026-03-24-text-blast-endpoint.md: browser interception, 2026-03-24.",
-    "authLive": "docs/research/2026-03-24-auth-flow-endpoints.md: browser interception and bundle analysis, 2026-03-24.",
-    "imageLive": "docs/research/2026-03-24-event-image-schema.md: browser interception, 2026-03-24."
-  },
-  "operations": [
-    ["createEvent","typescript-derived-inference"], ["cancelEvent","typescript-derived-inference"], ["getEventInfo","typescript-derived-inference"], ["getContacts","typescript-derived-inference"], ["createTextBlast","dated-live-observation"], ["addInvitedGuestsAsHost","typescript-derived-inference"], ["createCohostRequest","typescript-derived-inference"], ["deleteCohostRequest","typescript-derived-inference"], ["removeCohost","typescript-derived-inference"], ["generateEventCohostLink","typescript-derived-inference"], ["revokeEventCohostLink","typescript-derived-inference"], ["getMyUpcomingEventsForHomePage","typescript-derived-inference"], ["getMyPastEventsForHomePage","typescript-derived-inference"], ["addGuest","typescript-derived-inference"], ["markEventInterest","typescript-derived-inference"], ["getCurrentGuest","typescript-derived-inference"], ["firestoreGetEvent","typescript-derived-inference"], ["firestorePatchEvent","typescript-derived-inference"], ["firestoreGetGuest","typescript-derived-inference"], ["firestoreListDocuments","typescript-derived-inference"], ["refreshToken","typescript-derived-inference"], ["sendAuthCodeTrusted","reviewed-first-party-repository-research"], ["getLoginToken","dated-live-observation"], ["signInWithCustomToken","dated-live-observation"], ["lookupFirebaseUser","reviewed-first-party-repository-research"], ["uploadEventPhoto","typescript-derived-inference"], ["getPosterCatalog","typescript-derived-inference"]
+  "allowedClassifications": [
+    "dated-live-observation",
+    "reviewed-first-party-repository-research",
+    "typescript-derived-inference",
+    "explicit-unknown"
   ],
-  "schemaClaims": {
-    "CallableRequest": {"classification":"typescript-derived-inference","source":"typescript","scope":"Envelope shape only; callable-specific params are unknown unless separately stated."},
-    "TextBlastRequest": {"classification":"dated-live-observation","source":"textBlastLive","scope":"eventId and nested message shape."},
-    "TextBlastMessage": {"classification":"dated-live-observation","source":"textBlastLive","scope":"text, to, showOnEventPage, optional images; 480-character and one-image limits observed in client research."},
-    "CallableResponse": {"classification":"typescript-derived-inference","source":"typescript","scope":"Envelope only; inner payloads are explicit unknown."},
-    "FirestoreWriteDocument": {"classification":"typescript-derived-inference","source":"typescript","scope":"Wire wrapper; valid event field names and value variants are explicit unknown."},
-    "FirestoreDocument": {"classification":"typescript-derived-inference","source":"typescript","scope":"Non-exhaustive Firestore document wrapper."},
-    "FirestoreListResponse": {"classification":"typescript-derived-inference","source":"typescript","scope":"Non-exhaustive list wrapper."},
-    "RefreshTokenRequest": {"classification":"typescript-derived-inference","source":"typescript","scope":"Form field names and fixed grant type."},
-    "RefreshTokenResponse": {"classification":"typescript-derived-inference","source":"typescript","scope":"Known token fields; no value examples are retained."},
-    "CustomTokenRequest": {"classification":"dated-live-observation","source":"authLive","scope":"Custom-token exchange fields."},
-    "FirebaseSignInResponse": {"classification":"dated-live-observation","source":"authLive","scope":"Known response fields."},
-    "FirebaseLookupRequest": {"classification":"reviewed-first-party-repository-research","source":"typescript","scope":"Request field."},
-    "FirebaseLookupResponse": {"classification":"explicit-unknown","source":"draft","scope":"Only the outer users array is represented; member fields are not claimed."},
-    "UploadPhotoResponse": {"classification":"typescript-derived-inference","source":"typescript","scope":"Only uploadData.url is used by reviewed code; other response fields are unknown."},
-    "Poster": {"classification":"dated-live-observation","source":"imageLive","scope":"Observed catalog fields; other catalog fields remain open."}
+  "sources": {
+    "historicalDraft": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json",
+    "endpointRegistry": "9e6ed15:src/lib/api/endpoints.ts#L1-L560",
+    "httpTransport": "9e6ed15:src/lib/http.ts#L1-L245",
+    "authTransport": "9e6ed15:src/lib/auth.ts#L1-L150",
+    "authCommands": "9e6ed15:src/commands/auth.ts#L145-L340",
+    "uploadTransport": "9e6ed15:src/lib/upload.ts#L35-L115",
+    "posterTransport": "9e6ed15:src/lib/posters.ts#L25-L45",
+    "textBlastObservation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload",
+    "authObservation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints",
+    "eventImageObservation": "docs/research/2026-03-24-event-image-schema.md#image-field-in-createevent-payload"
+  },
+  "operations": {
+    "createEvent": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1createEvent/post"
+    },
+    "cancelEvent": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1cancelEvent/post"
+    },
+    "getEventInfo": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getEventInfo/post"
+    },
+    "getContacts": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getContacts/post"
+    },
+    "createTextBlast": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+    },
+    "addInvitedGuestsAsHost": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1addInvitedGuestsAsHost/post"
+    },
+    "createCohostRequest": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1createCohostRequest/post"
+    },
+    "deleteCohostRequest": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1deleteCohostRequest/post"
+    },
+    "removeCohost": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1removeCohost/post"
+    },
+    "generateEventCohostLink": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1generateEventCohostLink/post"
+    },
+    "revokeEventCohostLink": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1revokeEventCohostLink/post"
+    },
+    "getMyUpcomingEventsForHomePage": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getMyUpcomingEventsForHomePage/post"
+    },
+    "getMyPastEventsForHomePage": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getMyPastEventsForHomePage/post"
+    },
+    "addGuest": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1addGuest/post"
+    },
+    "markEventInterest": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1markEventInterest/post"
+    },
+    "getCurrentGuest": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getCurrentGuest/post"
+    },
+    "firestoreGetEvent": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get"
+    },
+    "firestorePatchEvent": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch"
+    },
+    "firestoreGetGuest": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get"
+    },
+    "firestoreListDocuments": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get"
+    },
+    "refreshToken": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1token/post"
+    },
+    "sendAuthCodeTrusted": {
+      "classification": "reviewed-first-party-repository-research",
+      "citation": "9e6ed15:src/commands/auth.ts#L145-L340"
+    },
+    "getLoginToken": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+    },
+    "signInWithCustomToken": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+    },
+    "lookupFirebaseUser": {
+      "classification": "reviewed-first-party-repository-research",
+      "citation": "9e6ed15:src/commands/auth.ts#L145-L340"
+    },
+    "uploadEventPhoto": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1uploadPhoto/post"
+    },
+    "getPosterCatalog": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/posters.ts#L25-L45"
+    }
   },
   "operationClaims": {
-    "default": {"request":"typescript-derived-inference","response":"explicit-unknown","source":"draft"},
-    "createTextBlast": {"request":"dated-live-observation","response":"explicit-unknown","source":"textBlastLive"},
-    "getLoginToken": {"request":"dated-live-observation","response":"dated-live-observation","source":"authLive"},
-    "signInWithCustomToken": {"request":"dated-live-observation","response":"dated-live-observation","source":"authLive"},
-    "sendAuthCodeTrusted": {"request":"reviewed-first-party-repository-research","response":"explicit-unknown","source":"typescript"},
-    "lookupFirebaseUser": {"request":"reviewed-first-party-repository-research","response":"explicit-unknown","source":"typescript"},
-    "getPosterCatalog": {"request":"explicit-unknown","response":"dated-live-observation","source":"imageLive"}
+    "createEvent": {
+      "request": "typescript-derived-inference",
+      "response": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1createEvent/post",
+      "status": "explicit-unknown"
+    },
+    "cancelEvent": {
+      "request": "typescript-derived-inference",
+      "response": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1cancelEvent/post",
+      "status": "explicit-unknown"
+    },
+    "getEventInfo": {
+      "request": "typescript-derived-inference",
+      "response": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getEventInfo/post",
+      "status": "explicit-unknown"
+    },
+    "getContacts": {
+      "request": "typescript-derived-inference",
+      "response": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getContacts/post",
+      "status": "explicit-unknown"
+    },
+    "createTextBlast": {
+      "request": "dated-live-observation",
+      "response": "explicit-unknown",
+      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload",
+      "status": "explicit-unknown"
+    },
+    "addInvitedGuestsAsHost": {
+      "request": "typescript-derived-inference",
+      "response": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1addInvitedGuestsAsHost/post",
+      "status": "explicit-unknown"
+    },
+    "createCohostRequest": {
+      "request": "typescript-derived-inference",
+      "response": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1createCohostRequest/post",
+      "status": "explicit-unknown"
+    },
+    "deleteCohostRequest": {
+      "request": "typescript-derived-inference",
+      "response": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1deleteCohostRequest/post",
+      "status": "explicit-unknown"
+    },
+    "removeCohost": {
+      "request": "typescript-derived-inference",
+      "response": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1removeCohost/post",
+      "status": "explicit-unknown"
+    },
+    "generateEventCohostLink": {
+      "request": "typescript-derived-inference",
+      "response": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1generateEventCohostLink/post",
+      "status": "explicit-unknown"
+    },
+    "revokeEventCohostLink": {
+      "request": "typescript-derived-inference",
+      "response": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1revokeEventCohostLink/post",
+      "status": "explicit-unknown"
+    },
+    "getMyUpcomingEventsForHomePage": {
+      "request": "typescript-derived-inference",
+      "response": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getMyUpcomingEventsForHomePage/post",
+      "status": "explicit-unknown"
+    },
+    "getMyPastEventsForHomePage": {
+      "request": "typescript-derived-inference",
+      "response": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getMyPastEventsForHomePage/post",
+      "status": "explicit-unknown"
+    },
+    "addGuest": {
+      "request": "typescript-derived-inference",
+      "response": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1addGuest/post",
+      "status": "explicit-unknown"
+    },
+    "markEventInterest": {
+      "request": "typescript-derived-inference",
+      "response": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1markEventInterest/post",
+      "status": "explicit-unknown"
+    },
+    "getCurrentGuest": {
+      "request": "typescript-derived-inference",
+      "response": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getCurrentGuest/post",
+      "status": "explicit-unknown"
+    },
+    "firestoreGetEvent": {
+      "request": "typescript-derived-inference",
+      "response": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get",
+      "status": "explicit-unknown"
+    },
+    "firestorePatchEvent": {
+      "request": "typescript-derived-inference",
+      "response": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch",
+      "status": "explicit-unknown"
+    },
+    "firestoreGetGuest": {
+      "request": "typescript-derived-inference",
+      "response": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get",
+      "status": "explicit-unknown"
+    },
+    "firestoreListDocuments": {
+      "request": "typescript-derived-inference",
+      "response": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get",
+      "status": "explicit-unknown"
+    },
+    "refreshToken": {
+      "request": "typescript-derived-inference",
+      "response": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1token/post",
+      "status": "explicit-unknown"
+    },
+    "sendAuthCodeTrusted": {
+      "request": "reviewed-first-party-repository-research",
+      "response": "explicit-unknown",
+      "citation": "9e6ed15:src/commands/auth.ts#L145-L340",
+      "status": "explicit-unknown"
+    },
+    "getLoginToken": {
+      "request": "dated-live-observation",
+      "response": "explicit-unknown",
+      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints",
+      "status": "explicit-unknown"
+    },
+    "signInWithCustomToken": {
+      "request": "dated-live-observation",
+      "response": "explicit-unknown",
+      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints",
+      "status": "explicit-unknown"
+    },
+    "lookupFirebaseUser": {
+      "request": "reviewed-first-party-repository-research",
+      "response": "explicit-unknown",
+      "citation": "9e6ed15:src/commands/auth.ts#L145-L340",
+      "status": "explicit-unknown"
+    },
+    "uploadEventPhoto": {
+      "request": "typescript-derived-inference",
+      "response": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1uploadPhoto/post",
+      "status": "explicit-unknown"
+    },
+    "getPosterCatalog": {
+      "request": "explicit-unknown",
+      "response": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/posters.ts#L25-L45",
+      "status": "explicit-unknown"
+    }
   },
   "contradictions": [
     {
@@ -59,6 +314,1526 @@
     "Complete Firestore typed-value grammar, authorization rules, pagination limits, and update-mask semantics.",
     "Upload accepted media types, size limits, response variants, and whether uploadType values remain stable.",
     "Poster catalog freshness, complete schema, and cache behavior.",
-    "Status codes and error bodies for every operation."
-  ]
+    "Status codes and error bodies for every operation.",
+    "The poster event-image observation does not establish the /posters.json response; that operation is TypeScript-derived inference only."
+  ],
+  "status": "proposed-pending-owner-approval",
+  "claims": {
+    "#/paths/~1createEvent/post/operationId": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1createEvent/post/operationId"
+    },
+    "#/paths/~1createEvent/post/requestBody/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1createEvent/post/requestBody/$ref"
+    },
+    "#/paths/~1createEvent/post/responses/default": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1createEvent/post/responses/default"
+    },
+    "#/paths/~1createEvent/post/responses/default/$ref": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1createEvent/post/responses/default/$ref"
+    },
+    "#/paths/~1cancelEvent/post/operationId": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1cancelEvent/post/operationId"
+    },
+    "#/paths/~1cancelEvent/post/requestBody/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1cancelEvent/post/requestBody/$ref"
+    },
+    "#/paths/~1cancelEvent/post/responses/default": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1cancelEvent/post/responses/default"
+    },
+    "#/paths/~1cancelEvent/post/responses/default/$ref": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1cancelEvent/post/responses/default/$ref"
+    },
+    "#/paths/~1getEventInfo/post/operationId": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getEventInfo/post/operationId"
+    },
+    "#/paths/~1getEventInfo/post/requestBody/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getEventInfo/post/requestBody/$ref"
+    },
+    "#/paths/~1getEventInfo/post/responses/default": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getEventInfo/post/responses/default"
+    },
+    "#/paths/~1getEventInfo/post/responses/default/$ref": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getEventInfo/post/responses/default/$ref"
+    },
+    "#/paths/~1getContacts/post/operationId": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getContacts/post/operationId"
+    },
+    "#/paths/~1getContacts/post/requestBody/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getContacts/post/requestBody/$ref"
+    },
+    "#/paths/~1getContacts/post/responses/default": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getContacts/post/responses/default"
+    },
+    "#/paths/~1getContacts/post/responses/default/$ref": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getContacts/post/responses/default/$ref"
+    },
+    "#/paths/~1createTextBlast/post/operationId": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1createTextBlast/post/operationId"
+    },
+    "#/paths/~1createTextBlast/post/requestBody/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1createTextBlast/post/requestBody/$ref"
+    },
+    "#/paths/~1createTextBlast/post/responses/default": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1createTextBlast/post/responses/default"
+    },
+    "#/paths/~1createTextBlast/post/responses/default/$ref": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1createTextBlast/post/responses/default/$ref"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/operationId": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1addInvitedGuestsAsHost/post/operationId"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/$ref"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/responses/default": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1addInvitedGuestsAsHost/post/responses/default"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/responses/default/$ref": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1addInvitedGuestsAsHost/post/responses/default/$ref"
+    },
+    "#/paths/~1createCohostRequest/post/operationId": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1createCohostRequest/post/operationId"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1createCohostRequest/post/requestBody/$ref"
+    },
+    "#/paths/~1createCohostRequest/post/responses/default": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1createCohostRequest/post/responses/default"
+    },
+    "#/paths/~1createCohostRequest/post/responses/default/$ref": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1createCohostRequest/post/responses/default/$ref"
+    },
+    "#/paths/~1deleteCohostRequest/post/operationId": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1deleteCohostRequest/post/operationId"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1deleteCohostRequest/post/requestBody/$ref"
+    },
+    "#/paths/~1deleteCohostRequest/post/responses/default": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1deleteCohostRequest/post/responses/default"
+    },
+    "#/paths/~1deleteCohostRequest/post/responses/default/$ref": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1deleteCohostRequest/post/responses/default/$ref"
+    },
+    "#/paths/~1removeCohost/post/operationId": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1removeCohost/post/operationId"
+    },
+    "#/paths/~1removeCohost/post/requestBody/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1removeCohost/post/requestBody/$ref"
+    },
+    "#/paths/~1removeCohost/post/responses/default": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1removeCohost/post/responses/default"
+    },
+    "#/paths/~1removeCohost/post/responses/default/$ref": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1removeCohost/post/responses/default/$ref"
+    },
+    "#/paths/~1generateEventCohostLink/post/operationId": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1generateEventCohostLink/post/operationId"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1generateEventCohostLink/post/requestBody/$ref"
+    },
+    "#/paths/~1generateEventCohostLink/post/responses/default": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1generateEventCohostLink/post/responses/default"
+    },
+    "#/paths/~1generateEventCohostLink/post/responses/default/$ref": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1generateEventCohostLink/post/responses/default/$ref"
+    },
+    "#/paths/~1revokeEventCohostLink/post/operationId": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1revokeEventCohostLink/post/operationId"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1revokeEventCohostLink/post/requestBody/$ref"
+    },
+    "#/paths/~1revokeEventCohostLink/post/responses/default": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1revokeEventCohostLink/post/responses/default"
+    },
+    "#/paths/~1revokeEventCohostLink/post/responses/default/$ref": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1revokeEventCohostLink/post/responses/default/$ref"
+    },
+    "#/paths/~1getMyUpcomingEventsForHomePage/post/operationId": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getMyUpcomingEventsForHomePage/post/operationId"
+    },
+    "#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/$ref"
+    },
+    "#/paths/~1getMyUpcomingEventsForHomePage/post/responses/default": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getMyUpcomingEventsForHomePage/post/responses/default"
+    },
+    "#/paths/~1getMyUpcomingEventsForHomePage/post/responses/default/$ref": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getMyUpcomingEventsForHomePage/post/responses/default/$ref"
+    },
+    "#/paths/~1getMyPastEventsForHomePage/post/operationId": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getMyPastEventsForHomePage/post/operationId"
+    },
+    "#/paths/~1getMyPastEventsForHomePage/post/requestBody/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getMyPastEventsForHomePage/post/requestBody/$ref"
+    },
+    "#/paths/~1getMyPastEventsForHomePage/post/responses/default": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getMyPastEventsForHomePage/post/responses/default"
+    },
+    "#/paths/~1getMyPastEventsForHomePage/post/responses/default/$ref": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getMyPastEventsForHomePage/post/responses/default/$ref"
+    },
+    "#/paths/~1addGuest/post/operationId": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1addGuest/post/operationId"
+    },
+    "#/paths/~1addGuest/post/requestBody/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1addGuest/post/requestBody/$ref"
+    },
+    "#/paths/~1addGuest/post/responses/default": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1addGuest/post/responses/default"
+    },
+    "#/paths/~1addGuest/post/responses/default/$ref": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1addGuest/post/responses/default/$ref"
+    },
+    "#/paths/~1markEventInterest/post/operationId": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1markEventInterest/post/operationId"
+    },
+    "#/paths/~1markEventInterest/post/requestBody/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1markEventInterest/post/requestBody/$ref"
+    },
+    "#/paths/~1markEventInterest/post/responses/default": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1markEventInterest/post/responses/default"
+    },
+    "#/paths/~1markEventInterest/post/responses/default/$ref": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1markEventInterest/post/responses/default/$ref"
+    },
+    "#/paths/~1getCurrentGuest/post/operationId": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getCurrentGuest/post/operationId"
+    },
+    "#/paths/~1getCurrentGuest/post/requestBody/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getCurrentGuest/post/requestBody/$ref"
+    },
+    "#/paths/~1getCurrentGuest/post/responses/default": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getCurrentGuest/post/responses/default"
+    },
+    "#/paths/~1getCurrentGuest/post/responses/default/$ref": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getCurrentGuest/post/responses/default/$ref"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/operationId": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/operationId"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/parameters/0/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/parameters/0/$ref"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/responses/default": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/responses/default"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/responses/default/$ref": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/responses/default/$ref"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/servers/0/url": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/servers/0/url"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/operationId": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/operationId"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/0/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/0/$ref"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/1/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/1/$ref"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/requestBody/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/requestBody/$ref"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/responses/default": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/responses/default"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/responses/default/$ref": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/responses/default/$ref"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/servers/0/url": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/servers/0/url"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/operationId": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/operationId"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/parameters/0/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/parameters/0/$ref"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/parameters/1/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/parameters/1/$ref"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/responses/default": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/responses/default"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/responses/default/$ref": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/responses/default/$ref"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/servers/0/url": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/servers/0/url"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/operationId": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/operationId"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/0/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/0/$ref"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/1/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/1/$ref"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/2/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/2/$ref"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/responses/default": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/responses/default"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/responses/default/$ref": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/responses/default/$ref"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/servers/0/url": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/servers/0/url"
+    },
+    "#/paths/~1v1~1token/post/operationId": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1token/post/operationId"
+    },
+    "#/paths/~1v1~1token/post/requestBody/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1token/post/requestBody/$ref"
+    },
+    "#/paths/~1v1~1token/post/responses/default": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1token/post/responses/default"
+    },
+    "#/paths/~1v1~1token/post/responses/default/$ref": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1token/post/responses/default/$ref"
+    },
+    "#/paths/~1v1~1token/post/servers/0/url": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1token/post/servers/0/url"
+    },
+    "#/paths/~1sendAuthCodeTrusted/post/operationId": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1sendAuthCodeTrusted/post/operationId"
+    },
+    "#/paths/~1sendAuthCodeTrusted/post/requestBody/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1sendAuthCodeTrusted/post/requestBody/$ref"
+    },
+    "#/paths/~1sendAuthCodeTrusted/post/responses/default": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1sendAuthCodeTrusted/post/responses/default"
+    },
+    "#/paths/~1sendAuthCodeTrusted/post/responses/default/$ref": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1sendAuthCodeTrusted/post/responses/default/$ref"
+    },
+    "#/paths/~1getLoginToken/post/operationId": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getLoginToken/post/operationId"
+    },
+    "#/paths/~1getLoginToken/post/requestBody/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getLoginToken/post/requestBody/$ref"
+    },
+    "#/paths/~1getLoginToken/post/responses/default": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getLoginToken/post/responses/default"
+    },
+    "#/paths/~1getLoginToken/post/responses/default/$ref": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getLoginToken/post/responses/default/$ref"
+    },
+    "#/paths/~1v1~1accounts:signInWithCustomToken/post/operationId": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1accounts:signInWithCustomToken/post/operationId"
+    },
+    "#/paths/~1v1~1accounts:signInWithCustomToken/post/requestBody/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1accounts:signInWithCustomToken/post/requestBody/$ref"
+    },
+    "#/paths/~1v1~1accounts:signInWithCustomToken/post/responses/default": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1accounts:signInWithCustomToken/post/responses/default"
+    },
+    "#/paths/~1v1~1accounts:signInWithCustomToken/post/responses/default/$ref": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1accounts:signInWithCustomToken/post/responses/default/$ref"
+    },
+    "#/paths/~1v1~1accounts:signInWithCustomToken/post/servers/0/url": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1accounts:signInWithCustomToken/post/servers/0/url"
+    },
+    "#/paths/~1v1~1accounts:lookup/post/operationId": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1accounts:lookup/post/operationId"
+    },
+    "#/paths/~1v1~1accounts:lookup/post/requestBody/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1accounts:lookup/post/requestBody/$ref"
+    },
+    "#/paths/~1v1~1accounts:lookup/post/responses/default": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1accounts:lookup/post/responses/default"
+    },
+    "#/paths/~1v1~1accounts:lookup/post/responses/default/$ref": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1accounts:lookup/post/responses/default/$ref"
+    },
+    "#/paths/~1v1~1accounts:lookup/post/servers/0/url": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1accounts:lookup/post/servers/0/url"
+    },
+    "#/paths/~1uploadPhoto/post/operationId": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1uploadPhoto/post/operationId"
+    },
+    "#/paths/~1uploadPhoto/post/parameters/0/name": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1uploadPhoto/post/parameters/0/name"
+    },
+    "#/paths/~1uploadPhoto/post/parameters/0/in": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1uploadPhoto/post/parameters/0/in"
+    },
+    "#/paths/~1uploadPhoto/post/parameters/0/schema": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1uploadPhoto/post/parameters/0/schema"
+    },
+    "#/paths/~1uploadPhoto/post/parameters/0/schema/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1uploadPhoto/post/parameters/0/schema/type"
+    },
+    "#/paths/~1uploadPhoto/post/requestBody/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1uploadPhoto/post/requestBody/$ref"
+    },
+    "#/paths/~1uploadPhoto/post/responses/default": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1uploadPhoto/post/responses/default"
+    },
+    "#/paths/~1uploadPhoto/post/responses/default/$ref": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1uploadPhoto/post/responses/default/$ref"
+    },
+    "#/paths/~1uploadPhoto/post/servers/0/url": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1uploadPhoto/post/servers/0/url"
+    },
+    "#/paths/~1posters.json/get/operationId": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1posters.json/get/operationId"
+    },
+    "#/paths/~1posters.json/get/responses/default": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1posters.json/get/responses/default"
+    },
+    "#/paths/~1posters.json/get/responses/default/$ref": {
+      "classification": "explicit-unknown",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1posters.json/get/responses/default/$ref"
+    },
+    "#/paths/~1posters.json/get/servers/0/url": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1posters.json/get/servers/0/url"
+    },
+    "#/components/securitySchemes/firebaseBearer": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/securitySchemes/firebaseBearer"
+    },
+    "#/components/securitySchemes/firebaseBearer/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/securitySchemes/firebaseBearer/type"
+    },
+    "#/components/securitySchemes/firebaseBearer/scheme": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/securitySchemes/firebaseBearer/scheme"
+    },
+    "#/components/securitySchemes/firebaseApiKey": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/securitySchemes/firebaseApiKey"
+    },
+    "#/components/securitySchemes/firebaseApiKey/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/securitySchemes/firebaseApiKey/type"
+    },
+    "#/components/securitySchemes/firebaseApiKey/in": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/securitySchemes/firebaseApiKey/in"
+    },
+    "#/components/securitySchemes/firebaseApiKey/name": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/securitySchemes/firebaseApiKey/name"
+    },
+    "#/components/parameters/EventId": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/EventId"
+    },
+    "#/components/parameters/EventId/name": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/EventId/name"
+    },
+    "#/components/parameters/EventId/in": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/EventId/in"
+    },
+    "#/components/parameters/EventId/required": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/EventId/required"
+    },
+    "#/components/parameters/EventId/schema/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/EventId/schema/type"
+    },
+    "#/components/parameters/GuestId": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/GuestId"
+    },
+    "#/components/parameters/GuestId/name": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/GuestId/name"
+    },
+    "#/components/parameters/GuestId/in": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/GuestId/in"
+    },
+    "#/components/parameters/GuestId/required": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/GuestId/required"
+    },
+    "#/components/parameters/GuestId/schema/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/GuestId/schema/type"
+    },
+    "#/components/parameters/CollectionPath": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/CollectionPath"
+    },
+    "#/components/parameters/CollectionPath/name": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/CollectionPath/name"
+    },
+    "#/components/parameters/CollectionPath/in": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/CollectionPath/in"
+    },
+    "#/components/parameters/CollectionPath/required": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/CollectionPath/required"
+    },
+    "#/components/parameters/CollectionPath/schema/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/CollectionPath/schema/type"
+    },
+    "#/components/parameters/UpdateMask": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/UpdateMask"
+    },
+    "#/components/parameters/UpdateMask/name": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/UpdateMask/name"
+    },
+    "#/components/parameters/UpdateMask/in": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/UpdateMask/in"
+    },
+    "#/components/parameters/UpdateMask/schema/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/UpdateMask/schema/type"
+    },
+    "#/components/parameters/PageSize": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/PageSize"
+    },
+    "#/components/parameters/PageSize/name": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/PageSize/name"
+    },
+    "#/components/parameters/PageSize/in": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/PageSize/in"
+    },
+    "#/components/parameters/PageSize/schema/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/PageSize/schema/type"
+    },
+    "#/components/parameters/PageSize/schema/minimum": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/PageSize/schema/minimum"
+    },
+    "#/components/parameters/PageToken": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/PageToken"
+    },
+    "#/components/parameters/PageToken/name": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/PageToken/name"
+    },
+    "#/components/parameters/PageToken/in": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/PageToken/in"
+    },
+    "#/components/parameters/PageToken/schema/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/PageToken/schema/type"
+    },
+    "#/components/requestBodies/CallableRequest": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/requestBodies/CallableRequest"
+    },
+    "#/components/requestBodies/CallableRequest/required": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/requestBodies/CallableRequest/required"
+    },
+    "#/components/requestBodies/CallableRequest/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/requestBodies/CallableRequest/content/application~1json"
+    },
+    "#/components/requestBodies/CallableRequest/content/application~1json/schema/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/requestBodies/CallableRequest/content/application~1json/schema/$ref"
+    },
+    "#/components/requestBodies/TextBlastRequest": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/requestBodies/TextBlastRequest"
+    },
+    "#/components/requestBodies/TextBlastRequest/required": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/requestBodies/TextBlastRequest/required"
+    },
+    "#/components/requestBodies/TextBlastRequest/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/requestBodies/TextBlastRequest/content/application~1json"
+    },
+    "#/components/requestBodies/TextBlastRequest/content/application~1json/schema/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/requestBodies/TextBlastRequest/content/application~1json/schema/$ref"
+    },
+    "#/components/requestBodies/FirestoreWrite": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+    },
+    "#/components/requestBodies/FirestoreWrite/required": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+    },
+    "#/components/requestBodies/FirestoreWrite/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+    },
+    "#/components/requestBodies/FirestoreWrite/content/application~1json/schema/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+    },
+    "#/components/requestBodies/RefreshToken": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+    },
+    "#/components/requestBodies/RefreshToken/required": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+    },
+    "#/components/requestBodies/RefreshToken/content/application~1x-www-form-urlencoded": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+    },
+    "#/components/requestBodies/RefreshToken/content/application~1x-www-form-urlencoded/schema/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+    },
+    "#/components/requestBodies/CustomToken": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+    },
+    "#/components/requestBodies/CustomToken/required": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+    },
+    "#/components/requestBodies/CustomToken/content/application~1json": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+    },
+    "#/components/requestBodies/CustomToken/content/application~1json/schema/$ref": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+    },
+    "#/components/requestBodies/FirebaseLookup": {
+      "classification": "reviewed-first-party-repository-research",
+      "citation": "9e6ed15:src/commands/auth.ts#L145-L340"
+    },
+    "#/components/requestBodies/FirebaseLookup/required": {
+      "classification": "reviewed-first-party-repository-research",
+      "citation": "9e6ed15:src/commands/auth.ts#L145-L340"
+    },
+    "#/components/requestBodies/FirebaseLookup/content/application~1json": {
+      "classification": "reviewed-first-party-repository-research",
+      "citation": "9e6ed15:src/commands/auth.ts#L145-L340"
+    },
+    "#/components/requestBodies/FirebaseLookup/content/application~1json/schema/$ref": {
+      "classification": "reviewed-first-party-repository-research",
+      "citation": "9e6ed15:src/commands/auth.ts#L145-L340"
+    },
+    "#/components/requestBodies/UploadPhoto": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/upload.ts#L35-L115"
+    },
+    "#/components/requestBodies/UploadPhoto/required": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/upload.ts#L35-L115"
+    },
+    "#/components/requestBodies/UploadPhoto/content/multipart~1form-data": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/upload.ts#L35-L115"
+    },
+    "#/components/requestBodies/UploadPhoto/content/multipart~1form-data/schema/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/upload.ts#L35-L115"
+    },
+    "#/components/requestBodies/UploadPhoto/content/multipart~1form-data/schema/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/upload.ts#L35-L115"
+    },
+    "#/components/requestBodies/UploadPhoto/content/multipart~1form-data/schema/properties/file": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/upload.ts#L35-L115"
+    },
+    "#/components/requestBodies/UploadPhoto/content/multipart~1form-data/schema/properties/file/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/upload.ts#L35-L115"
+    },
+    "#/components/requestBodies/UploadPhoto/content/multipart~1form-data/schema/properties/file/format": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/upload.ts#L35-L115"
+    },
+    "#/components/responses/CallableResponse": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/responses/CallableResponse"
+    },
+    "#/components/responses/CallableResponse/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/responses/CallableResponse/content/application~1json"
+    },
+    "#/components/responses/CallableResponse/content/application~1json/schema/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/responses/CallableResponse/content/application~1json/schema/$ref"
+    },
+    "#/components/responses/FirestoreDocument": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+    },
+    "#/components/responses/FirestoreDocument/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+    },
+    "#/components/responses/FirestoreDocument/content/application~1json/schema/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+    },
+    "#/components/responses/FirestoreList": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+    },
+    "#/components/responses/FirestoreList/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+    },
+    "#/components/responses/FirestoreList/content/application~1json/schema/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+    },
+    "#/components/responses/RefreshToken": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+    },
+    "#/components/responses/RefreshToken/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+    },
+    "#/components/responses/RefreshToken/content/application~1json/schema/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+    },
+    "#/components/responses/FirebaseSignIn": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+    },
+    "#/components/responses/FirebaseSignIn/content/application~1json": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+    },
+    "#/components/responses/FirebaseSignIn/content/application~1json/schema/$ref": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+    },
+    "#/components/responses/FirebaseLookup": {
+      "classification": "reviewed-first-party-repository-research",
+      "citation": "9e6ed15:src/commands/auth.ts#L145-L340"
+    },
+    "#/components/responses/FirebaseLookup/content/application~1json": {
+      "classification": "reviewed-first-party-repository-research",
+      "citation": "9e6ed15:src/commands/auth.ts#L145-L340"
+    },
+    "#/components/responses/FirebaseLookup/content/application~1json/schema/$ref": {
+      "classification": "reviewed-first-party-repository-research",
+      "citation": "9e6ed15:src/commands/auth.ts#L145-L340"
+    },
+    "#/components/responses/UploadPhoto": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/upload.ts#L35-L115"
+    },
+    "#/components/responses/UploadPhoto/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/upload.ts#L35-L115"
+    },
+    "#/components/responses/UploadPhoto/content/application~1json/schema/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/upload.ts#L35-L115"
+    },
+    "#/components/responses/PosterCatalog": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/posters.ts#L25-L45"
+    },
+    "#/components/responses/PosterCatalog/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/posters.ts#L25-L45"
+    },
+    "#/components/responses/PosterCatalog/content/application~1json/schema/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/posters.ts#L25-L45"
+    },
+    "#/components/responses/PosterCatalog/content/application~1json/schema/items/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/posters.ts#L25-L45"
+    },
+    "#/components/schemas/CallableRequest": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableRequest"
+    },
+    "#/components/schemas/CallableRequest/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableRequest/type"
+    },
+    "#/components/schemas/CallableRequest/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableRequest/required/0"
+    },
+    "#/components/schemas/CallableRequest/properties/data": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableRequest/properties/data"
+    },
+    "#/components/schemas/CallableRequest/properties/data/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableRequest/properties/data/type"
+    },
+    "#/components/schemas/CallableRequest/properties/data/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableRequest/properties/data/required/0"
+    },
+    "#/components/schemas/CallableRequest/properties/data/required/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableRequest/properties/data/required/1"
+    },
+    "#/components/schemas/CallableRequest/properties/data/properties/params": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableRequest/properties/data/properties/params"
+    },
+    "#/components/schemas/CallableRequest/properties/data/properties/params/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableRequest/properties/data/properties/params/type"
+    },
+    "#/components/schemas/CallableRequest/properties/data/properties/params/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableRequest/properties/data/properties/params/additionalProperties"
+    },
+    "#/components/schemas/CallableRequest/properties/data/properties/amplitudeDeviceId": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableRequest/properties/data/properties/amplitudeDeviceId"
+    },
+    "#/components/schemas/CallableRequest/properties/data/properties/amplitudeDeviceId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableRequest/properties/data/properties/amplitudeDeviceId/type"
+    },
+    "#/components/schemas/CallableRequest/properties/data/properties/amplitudeSessionId": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableRequest/properties/data/properties/amplitudeSessionId"
+    },
+    "#/components/schemas/CallableRequest/properties/data/properties/amplitudeSessionId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableRequest/properties/data/properties/amplitudeSessionId/type"
+    },
+    "#/components/schemas/CallableRequest/properties/data/properties/userId": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableRequest/properties/data/properties/userId"
+    },
+    "#/components/schemas/CallableRequest/properties/data/properties/userId/type/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableRequest/properties/data/properties/userId/type/0"
+    },
+    "#/components/schemas/CallableRequest/properties/data/properties/userId/type/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableRequest/properties/data/properties/userId/type/1"
+    },
+    "#/components/schemas/CallableRequest/properties/data/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableRequest/properties/data/additionalProperties"
+    },
+    "#/components/schemas/CallableRequest/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableRequest/additionalProperties"
+    },
+    "#/components/schemas/TextBlastRequest": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+    },
+    "#/components/schemas/TextBlastRequest/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+    },
+    "#/components/schemas/TextBlastRequest/required/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+    },
+    "#/components/schemas/TextBlastRequest/properties/data": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+    },
+    "#/components/schemas/TextBlastRequest/properties/data/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+    },
+    "#/components/schemas/TextBlastRequest/properties/data/required/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+    },
+    "#/components/schemas/TextBlastRequest/properties/data/properties/params": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+    },
+    "#/components/schemas/TextBlastRequest/properties/data/properties/params/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+    },
+    "#/components/schemas/TextBlastRequest/properties/data/properties/params/required/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+    },
+    "#/components/schemas/TextBlastRequest/properties/data/properties/params/required/1": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+    },
+    "#/components/schemas/TextBlastRequest/properties/data/properties/params/properties/eventId": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+    },
+    "#/components/schemas/TextBlastRequest/properties/data/properties/params/properties/eventId/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+    },
+    "#/components/schemas/TextBlastRequest/properties/data/properties/params/properties/message": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+    },
+    "#/components/schemas/TextBlastRequest/properties/data/properties/params/properties/message/$ref": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+    },
+    "#/components/schemas/TextBlastRequest/properties/data/properties/params/additionalProperties": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+    },
+    "#/components/schemas/TextBlastRequest/properties/data/additionalProperties": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+    },
+    "#/components/schemas/TextBlastRequest/additionalProperties": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+    },
+    "#/components/schemas/TextBlastMessage": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+    },
+    "#/components/schemas/TextBlastMessage/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+    },
+    "#/components/schemas/TextBlastMessage/required/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+    },
+    "#/components/schemas/TextBlastMessage/required/1": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+    },
+    "#/components/schemas/TextBlastMessage/required/2": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+    },
+    "#/components/schemas/TextBlastMessage/properties/text": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+    },
+    "#/components/schemas/TextBlastMessage/properties/text/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+    },
+    "#/components/schemas/TextBlastMessage/properties/text/maxLength": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+    },
+    "#/components/schemas/TextBlastMessage/properties/to": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+    },
+    "#/components/schemas/TextBlastMessage/properties/to/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+    },
+    "#/components/schemas/TextBlastMessage/properties/to/items/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+    },
+    "#/components/schemas/TextBlastMessage/properties/showOnEventPage": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+    },
+    "#/components/schemas/TextBlastMessage/properties/showOnEventPage/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+    },
+    "#/components/schemas/TextBlastMessage/properties/images": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+    },
+    "#/components/schemas/TextBlastMessage/properties/images/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+    },
+    "#/components/schemas/TextBlastMessage/properties/images/maxItems": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+    },
+    "#/components/schemas/TextBlastMessage/properties/images/items/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+    },
+    "#/components/schemas/TextBlastMessage/properties/images/items/additionalProperties": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+    },
+    "#/components/schemas/TextBlastMessage/additionalProperties": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+    },
+    "#/components/schemas/CallableResponse": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableResponse"
+    },
+    "#/components/schemas/CallableResponse/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableResponse/type"
+    },
+    "#/components/schemas/CallableResponse/properties/result": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableResponse/properties/result"
+    },
+    "#/components/schemas/CallableResponse/properties/result/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableResponse/properties/result/type"
+    },
+    "#/components/schemas/CallableResponse/properties/result/properties/data": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableResponse/properties/result/properties/data"
+    },
+    "#/components/schemas/CallableResponse/properties/result/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableResponse/properties/result/additionalProperties"
+    },
+    "#/components/schemas/CallableResponse/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableResponse/additionalProperties"
+    },
+    "#/components/schemas/FirestoreWriteDocument": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+    },
+    "#/components/schemas/FirestoreWriteDocument/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+    },
+    "#/components/schemas/FirestoreWriteDocument/properties/fields": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+    },
+    "#/components/schemas/FirestoreWriteDocument/properties/fields/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+    },
+    "#/components/schemas/FirestoreWriteDocument/properties/fields/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+    },
+    "#/components/schemas/FirestoreWriteDocument/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+    },
+    "#/components/schemas/FirestoreDocument": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+    },
+    "#/components/schemas/FirestoreDocument/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+    },
+    "#/components/schemas/FirestoreDocument/properties/name": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+    },
+    "#/components/schemas/FirestoreDocument/properties/name/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+    },
+    "#/components/schemas/FirestoreDocument/properties/fields": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+    },
+    "#/components/schemas/FirestoreDocument/properties/fields/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+    },
+    "#/components/schemas/FirestoreDocument/properties/fields/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+    },
+    "#/components/schemas/FirestoreDocument/properties/createTime": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+    },
+    "#/components/schemas/FirestoreDocument/properties/createTime/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+    },
+    "#/components/schemas/FirestoreDocument/properties/updateTime": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+    },
+    "#/components/schemas/FirestoreDocument/properties/updateTime/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+    },
+    "#/components/schemas/FirestoreDocument/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+    },
+    "#/components/schemas/FirestoreListResponse": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+    },
+    "#/components/schemas/FirestoreListResponse/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+    },
+    "#/components/schemas/FirestoreListResponse/properties/documents": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+    },
+    "#/components/schemas/FirestoreListResponse/properties/documents/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+    },
+    "#/components/schemas/FirestoreListResponse/properties/documents/items/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+    },
+    "#/components/schemas/FirestoreListResponse/properties/nextPageToken": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+    },
+    "#/components/schemas/FirestoreListResponse/properties/nextPageToken/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+    },
+    "#/components/schemas/FirestoreListResponse/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+    },
+    "#/components/schemas/RefreshTokenRequest": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+    },
+    "#/components/schemas/RefreshTokenRequest/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+    },
+    "#/components/schemas/RefreshTokenRequest/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+    },
+    "#/components/schemas/RefreshTokenRequest/required/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+    },
+    "#/components/schemas/RefreshTokenRequest/properties/grant_type": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+    },
+    "#/components/schemas/RefreshTokenRequest/properties/grant_type/const": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+    },
+    "#/components/schemas/RefreshTokenRequest/properties/refresh_token": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+    },
+    "#/components/schemas/RefreshTokenRequest/properties/refresh_token/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+    },
+    "#/components/schemas/RefreshTokenResponse": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+    },
+    "#/components/schemas/RefreshTokenResponse/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+    },
+    "#/components/schemas/RefreshTokenResponse/properties/id_token": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+    },
+    "#/components/schemas/RefreshTokenResponse/properties/id_token/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+    },
+    "#/components/schemas/RefreshTokenResponse/properties/refresh_token": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+    },
+    "#/components/schemas/RefreshTokenResponse/properties/refresh_token/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+    },
+    "#/components/schemas/RefreshTokenResponse/properties/expires_in": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+    },
+    "#/components/schemas/RefreshTokenResponse/properties/expires_in/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+    },
+    "#/components/schemas/RefreshTokenResponse/properties/user_id": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+    },
+    "#/components/schemas/RefreshTokenResponse/properties/user_id/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+    },
+    "#/components/schemas/RefreshTokenResponse/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+    },
+    "#/components/schemas/CustomTokenRequest": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+    },
+    "#/components/schemas/CustomTokenRequest/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+    },
+    "#/components/schemas/CustomTokenRequest/required/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+    },
+    "#/components/schemas/CustomTokenRequest/required/1": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+    },
+    "#/components/schemas/CustomTokenRequest/properties/token": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+    },
+    "#/components/schemas/CustomTokenRequest/properties/token/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+    },
+    "#/components/schemas/CustomTokenRequest/properties/returnSecureToken": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+    },
+    "#/components/schemas/CustomTokenRequest/properties/returnSecureToken/const": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+    },
+    "#/components/schemas/FirebaseSignInResponse": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+    },
+    "#/components/schemas/FirebaseSignInResponse/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+    },
+    "#/components/schemas/FirebaseSignInResponse/properties/idToken": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+    },
+    "#/components/schemas/FirebaseSignInResponse/properties/idToken/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+    },
+    "#/components/schemas/FirebaseSignInResponse/properties/refreshToken": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+    },
+    "#/components/schemas/FirebaseSignInResponse/properties/refreshToken/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+    },
+    "#/components/schemas/FirebaseSignInResponse/properties/expiresIn": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+    },
+    "#/components/schemas/FirebaseSignInResponse/properties/expiresIn/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+    },
+    "#/components/schemas/FirebaseSignInResponse/properties/localId": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+    },
+    "#/components/schemas/FirebaseSignInResponse/properties/localId/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+    },
+    "#/components/schemas/FirebaseSignInResponse/additionalProperties": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+    },
+    "#/components/schemas/FirebaseLookupRequest": {
+      "classification": "reviewed-first-party-repository-research",
+      "citation": "9e6ed15:src/commands/auth.ts#L145-L340"
+    },
+    "#/components/schemas/FirebaseLookupRequest/type": {
+      "classification": "reviewed-first-party-repository-research",
+      "citation": "9e6ed15:src/commands/auth.ts#L145-L340"
+    },
+    "#/components/schemas/FirebaseLookupRequest/required/0": {
+      "classification": "reviewed-first-party-repository-research",
+      "citation": "9e6ed15:src/commands/auth.ts#L145-L340"
+    },
+    "#/components/schemas/FirebaseLookupRequest/properties/idToken": {
+      "classification": "reviewed-first-party-repository-research",
+      "citation": "9e6ed15:src/commands/auth.ts#L145-L340"
+    },
+    "#/components/schemas/FirebaseLookupRequest/properties/idToken/type": {
+      "classification": "reviewed-first-party-repository-research",
+      "citation": "9e6ed15:src/commands/auth.ts#L145-L340"
+    },
+    "#/components/schemas/FirebaseLookupResponse": {
+      "classification": "reviewed-first-party-repository-research",
+      "citation": "9e6ed15:src/commands/auth.ts#L145-L340"
+    },
+    "#/components/schemas/FirebaseLookupResponse/type": {
+      "classification": "reviewed-first-party-repository-research",
+      "citation": "9e6ed15:src/commands/auth.ts#L145-L340"
+    },
+    "#/components/schemas/FirebaseLookupResponse/properties/users": {
+      "classification": "reviewed-first-party-repository-research",
+      "citation": "9e6ed15:src/commands/auth.ts#L145-L340"
+    },
+    "#/components/schemas/FirebaseLookupResponse/properties/users/type": {
+      "classification": "reviewed-first-party-repository-research",
+      "citation": "9e6ed15:src/commands/auth.ts#L145-L340"
+    },
+    "#/components/schemas/FirebaseLookupResponse/properties/users/items/type": {
+      "classification": "reviewed-first-party-repository-research",
+      "citation": "9e6ed15:src/commands/auth.ts#L145-L340"
+    },
+    "#/components/schemas/FirebaseLookupResponse/properties/users/items/additionalProperties": {
+      "classification": "reviewed-first-party-repository-research",
+      "citation": "9e6ed15:src/commands/auth.ts#L145-L340"
+    },
+    "#/components/schemas/FirebaseLookupResponse/additionalProperties": {
+      "classification": "reviewed-first-party-repository-research",
+      "citation": "9e6ed15:src/commands/auth.ts#L145-L340"
+    },
+    "#/components/schemas/UploadPhotoResponse": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/upload.ts#L35-L115"
+    },
+    "#/components/schemas/UploadPhotoResponse/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/upload.ts#L35-L115"
+    },
+    "#/components/schemas/UploadPhotoResponse/properties/uploadData": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/upload.ts#L35-L115"
+    },
+    "#/components/schemas/UploadPhotoResponse/properties/uploadData/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/upload.ts#L35-L115"
+    },
+    "#/components/schemas/UploadPhotoResponse/properties/uploadData/properties/url": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/upload.ts#L35-L115"
+    },
+    "#/components/schemas/UploadPhotoResponse/properties/uploadData/properties/url/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/upload.ts#L35-L115"
+    },
+    "#/components/schemas/UploadPhotoResponse/properties/uploadData/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/upload.ts#L35-L115"
+    },
+    "#/components/schemas/UploadPhotoResponse/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/upload.ts#L35-L115"
+    },
+    "#/components/schemas/Poster": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/posters.ts#L25-L45"
+    },
+    "#/components/schemas/Poster/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/posters.ts#L25-L45"
+    },
+    "#/components/schemas/Poster/properties/id": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/posters.ts#L25-L45"
+    },
+    "#/components/schemas/Poster/properties/id/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/posters.ts#L25-L45"
+    },
+    "#/components/schemas/Poster/properties/name": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/posters.ts#L25-L45"
+    },
+    "#/components/schemas/Poster/properties/name/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/posters.ts#L25-L45"
+    },
+    "#/components/schemas/Poster/properties/url": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/posters.ts#L25-L45"
+    },
+    "#/components/schemas/Poster/properties/url/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/posters.ts#L25-L45"
+    },
+    "#/components/schemas/Poster/properties/contentType": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/posters.ts#L25-L45"
+    },
+    "#/components/schemas/Poster/properties/contentType/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/posters.ts#L25-L45"
+    },
+    "#/components/schemas/Poster/properties/width": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/posters.ts#L25-L45"
+    },
+    "#/components/schemas/Poster/properties/width/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/posters.ts#L25-L45"
+    },
+    "#/components/schemas/Poster/properties/height": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/posters.ts#L25-L45"
+    },
+    "#/components/schemas/Poster/properties/height/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/posters.ts#L25-L45"
+    },
+    "#/components/schemas/Poster/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "9e6ed15:src/lib/posters.ts#L25-L45"
+    },
+    "#/servers/0/url": {
+      "classification": "typescript-derived-inference",
+      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/servers/0/url"
+    }
+  }
 }

--- a/spec/partiful.api-evidence.json
+++ b/spec/partiful.api-evidence.json
@@ -8,289 +8,315 @@
     "explicit-unknown"
   ],
   "sources": {
-    "historicalDraft": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json",
-    "endpointRegistry": "9e6ed15:src/lib/api/endpoints.ts#L1-L560",
-    "httpTransport": "9e6ed15:src/lib/http.ts#L1-L245",
-    "authTransport": "9e6ed15:src/lib/auth.ts#L1-L150",
-    "authCommands": "9e6ed15:src/commands/auth.ts#L145-L340",
-    "uploadTransport": "9e6ed15:src/lib/upload.ts#L35-L115",
-    "posterTransport": "9e6ed15:src/lib/posters.ts#L25-L45",
-    "textBlastObservation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload",
-    "authObservation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints",
-    "eventImageObservation": "docs/research/2026-03-24-event-image-schema.md#image-field-in-createevent-payload"
+    "historicalDraft": "spec/research/historical-27-operation-draft.json",
+    "unknownStatusDecision": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
+    "textBlast": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation",
+    "authObservation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation",
+    "callableAuth": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research",
+    "firestore": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research",
+    "upload": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-upload-research",
+    "posterInterface": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface",
+    "posterCatalog": "docs/research/2026-08-10-contract-evidence-sources.md#poster-catalog-fetch"
   },
   "operations": {
     "createEvent": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1createEvent/post"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post"
     },
     "cancelEvent": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1cancelEvent/post"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post"
     },
     "getEventInfo": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getEventInfo/post"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getEventInfo/post"
     },
     "getContacts": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getContacts/post"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post"
     },
     "createTextBlast": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
     },
     "addInvitedGuestsAsHost": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1addInvitedGuestsAsHost/post"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post"
     },
     "createCohostRequest": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1createCohostRequest/post"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post"
     },
     "deleteCohostRequest": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1deleteCohostRequest/post"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post"
     },
     "removeCohost": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1removeCohost/post"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post"
     },
     "generateEventCohostLink": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1generateEventCohostLink/post"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post"
     },
     "revokeEventCohostLink": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1revokeEventCohostLink/post"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post"
     },
     "getMyUpcomingEventsForHomePage": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getMyUpcomingEventsForHomePage/post"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyUpcomingEventsForHomePage/post"
     },
     "getMyPastEventsForHomePage": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getMyPastEventsForHomePage/post"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyPastEventsForHomePage/post"
     },
     "addGuest": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1addGuest/post"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addGuest/post"
     },
     "markEventInterest": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1markEventInterest/post"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1markEventInterest/post"
     },
     "getCurrentGuest": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getCurrentGuest/post"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getCurrentGuest/post"
     },
     "firestoreGetEvent": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get"
     },
     "firestorePatchEvent": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch"
     },
     "firestoreGetGuest": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get"
     },
     "firestoreListDocuments": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get"
     },
     "refreshToken": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1token/post"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1token/post"
     },
     "sendAuthCodeTrusted": {
       "classification": "reviewed-first-party-repository-research",
-      "citation": "9e6ed15:src/commands/auth.ts#L145-L340"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
     },
     "getLoginToken": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
     },
     "signInWithCustomToken": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
     },
     "lookupFirebaseUser": {
       "classification": "reviewed-first-party-repository-research",
-      "citation": "9e6ed15:src/commands/auth.ts#L145-L340"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
     },
     "uploadEventPhoto": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1uploadPhoto/post"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1uploadPhoto/post"
     },
     "getPosterCatalog": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/posters.ts#L25-L45"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-catalog-fetch"
     }
   },
   "operationClaims": {
     "createEvent": {
       "request": "typescript-derived-inference",
       "response": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1createEvent/post",
-      "status": "explicit-unknown"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post",
+      "status": "explicit-unknown",
+      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "cancelEvent": {
       "request": "typescript-derived-inference",
       "response": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1cancelEvent/post",
-      "status": "explicit-unknown"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post",
+      "status": "explicit-unknown",
+      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "getEventInfo": {
       "request": "typescript-derived-inference",
       "response": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getEventInfo/post",
-      "status": "explicit-unknown"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getEventInfo/post",
+      "status": "explicit-unknown",
+      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "getContacts": {
       "request": "typescript-derived-inference",
       "response": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getContacts/post",
-      "status": "explicit-unknown"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post",
+      "status": "explicit-unknown",
+      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "createTextBlast": {
       "request": "dated-live-observation",
       "response": "explicit-unknown",
-      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload",
-      "status": "explicit-unknown"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation",
+      "status": "explicit-unknown",
+      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "addInvitedGuestsAsHost": {
       "request": "typescript-derived-inference",
       "response": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1addInvitedGuestsAsHost/post",
-      "status": "explicit-unknown"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post",
+      "status": "explicit-unknown",
+      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "createCohostRequest": {
       "request": "typescript-derived-inference",
       "response": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1createCohostRequest/post",
-      "status": "explicit-unknown"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post",
+      "status": "explicit-unknown",
+      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "deleteCohostRequest": {
       "request": "typescript-derived-inference",
       "response": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1deleteCohostRequest/post",
-      "status": "explicit-unknown"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post",
+      "status": "explicit-unknown",
+      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "removeCohost": {
       "request": "typescript-derived-inference",
       "response": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1removeCohost/post",
-      "status": "explicit-unknown"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post",
+      "status": "explicit-unknown",
+      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "generateEventCohostLink": {
       "request": "typescript-derived-inference",
       "response": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1generateEventCohostLink/post",
-      "status": "explicit-unknown"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post",
+      "status": "explicit-unknown",
+      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "revokeEventCohostLink": {
       "request": "typescript-derived-inference",
       "response": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1revokeEventCohostLink/post",
-      "status": "explicit-unknown"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post",
+      "status": "explicit-unknown",
+      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "getMyUpcomingEventsForHomePage": {
       "request": "typescript-derived-inference",
       "response": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getMyUpcomingEventsForHomePage/post",
-      "status": "explicit-unknown"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyUpcomingEventsForHomePage/post",
+      "status": "explicit-unknown",
+      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "getMyPastEventsForHomePage": {
       "request": "typescript-derived-inference",
       "response": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getMyPastEventsForHomePage/post",
-      "status": "explicit-unknown"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyPastEventsForHomePage/post",
+      "status": "explicit-unknown",
+      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "addGuest": {
       "request": "typescript-derived-inference",
       "response": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1addGuest/post",
-      "status": "explicit-unknown"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addGuest/post",
+      "status": "explicit-unknown",
+      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "markEventInterest": {
       "request": "typescript-derived-inference",
       "response": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1markEventInterest/post",
-      "status": "explicit-unknown"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1markEventInterest/post",
+      "status": "explicit-unknown",
+      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "getCurrentGuest": {
       "request": "typescript-derived-inference",
       "response": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getCurrentGuest/post",
-      "status": "explicit-unknown"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getCurrentGuest/post",
+      "status": "explicit-unknown",
+      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "firestoreGetEvent": {
       "request": "typescript-derived-inference",
       "response": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get",
-      "status": "explicit-unknown"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get",
+      "status": "explicit-unknown",
+      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "firestorePatchEvent": {
       "request": "typescript-derived-inference",
       "response": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch",
-      "status": "explicit-unknown"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch",
+      "status": "explicit-unknown",
+      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "firestoreGetGuest": {
       "request": "typescript-derived-inference",
       "response": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get",
-      "status": "explicit-unknown"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get",
+      "status": "explicit-unknown",
+      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "firestoreListDocuments": {
       "request": "typescript-derived-inference",
       "response": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get",
-      "status": "explicit-unknown"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get",
+      "status": "explicit-unknown",
+      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "refreshToken": {
       "request": "typescript-derived-inference",
       "response": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1token/post",
-      "status": "explicit-unknown"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1token/post",
+      "status": "explicit-unknown",
+      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "sendAuthCodeTrusted": {
       "request": "reviewed-first-party-repository-research",
       "response": "explicit-unknown",
-      "citation": "9e6ed15:src/commands/auth.ts#L145-L340",
-      "status": "explicit-unknown"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research",
+      "status": "explicit-unknown",
+      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "getLoginToken": {
       "request": "dated-live-observation",
       "response": "explicit-unknown",
-      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints",
-      "status": "explicit-unknown"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation",
+      "status": "explicit-unknown",
+      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "signInWithCustomToken": {
       "request": "dated-live-observation",
       "response": "explicit-unknown",
-      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints",
-      "status": "explicit-unknown"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation",
+      "status": "explicit-unknown",
+      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "lookupFirebaseUser": {
       "request": "reviewed-first-party-repository-research",
       "response": "explicit-unknown",
-      "citation": "9e6ed15:src/commands/auth.ts#L145-L340",
-      "status": "explicit-unknown"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research",
+      "status": "explicit-unknown",
+      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "uploadEventPhoto": {
       "request": "typescript-derived-inference",
       "response": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1uploadPhoto/post",
-      "status": "explicit-unknown"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1uploadPhoto/post",
+      "status": "explicit-unknown",
+      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "getPosterCatalog": {
       "request": "explicit-unknown",
       "response": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/posters.ts#L25-L45",
-      "status": "explicit-unknown"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-catalog-fetch",
+      "status": "explicit-unknown",
+      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     }
   },
   "contradictions": [
@@ -321,1519 +347,1519 @@
   "claims": {
     "#/paths/~1createEvent/post/operationId": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1createEvent/post/operationId"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/operationId"
     },
     "#/paths/~1createEvent/post/requestBody/$ref": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1createEvent/post/requestBody/$ref"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody"
     },
     "#/paths/~1createEvent/post/responses/default": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1createEvent/post/responses/default"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1createEvent/post/responses/default/$ref": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1createEvent/post/responses/default/$ref"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1cancelEvent/post/operationId": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1cancelEvent/post/operationId"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/operationId"
     },
     "#/paths/~1cancelEvent/post/requestBody/$ref": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1cancelEvent/post/requestBody/$ref"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody"
     },
     "#/paths/~1cancelEvent/post/responses/default": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1cancelEvent/post/responses/default"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1cancelEvent/post/responses/default/$ref": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1cancelEvent/post/responses/default/$ref"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1getEventInfo/post/operationId": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getEventInfo/post/operationId"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getEventInfo/post/operationId"
     },
     "#/paths/~1getEventInfo/post/requestBody/$ref": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getEventInfo/post/requestBody/$ref"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getEventInfo/post/requestBody"
     },
     "#/paths/~1getEventInfo/post/responses/default": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getEventInfo/post/responses/default"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1getEventInfo/post/responses/default/$ref": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getEventInfo/post/responses/default/$ref"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1getContacts/post/operationId": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getContacts/post/operationId"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post/operationId"
     },
     "#/paths/~1getContacts/post/requestBody/$ref": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getContacts/post/requestBody/$ref"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post/requestBody"
     },
     "#/paths/~1getContacts/post/responses/default": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getContacts/post/responses/default"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1getContacts/post/responses/default/$ref": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getContacts/post/responses/default/$ref"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1createTextBlast/post/operationId": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1createTextBlast/post/operationId"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createTextBlast/post/operationId"
     },
     "#/paths/~1createTextBlast/post/requestBody/$ref": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1createTextBlast/post/requestBody/$ref"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createTextBlast/post/requestBody"
     },
     "#/paths/~1createTextBlast/post/responses/default": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1createTextBlast/post/responses/default"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1createTextBlast/post/responses/default/$ref": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1createTextBlast/post/responses/default/$ref"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1addInvitedGuestsAsHost/post/operationId": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1addInvitedGuestsAsHost/post/operationId"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/operationId"
     },
     "#/paths/~1addInvitedGuestsAsHost/post/requestBody/$ref": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/$ref"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody"
     },
     "#/paths/~1addInvitedGuestsAsHost/post/responses/default": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1addInvitedGuestsAsHost/post/responses/default"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1addInvitedGuestsAsHost/post/responses/default/$ref": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1addInvitedGuestsAsHost/post/responses/default/$ref"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1createCohostRequest/post/operationId": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1createCohostRequest/post/operationId"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/operationId"
     },
     "#/paths/~1createCohostRequest/post/requestBody/$ref": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1createCohostRequest/post/requestBody/$ref"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody"
     },
     "#/paths/~1createCohostRequest/post/responses/default": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1createCohostRequest/post/responses/default"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1createCohostRequest/post/responses/default/$ref": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1createCohostRequest/post/responses/default/$ref"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1deleteCohostRequest/post/operationId": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1deleteCohostRequest/post/operationId"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/operationId"
     },
     "#/paths/~1deleteCohostRequest/post/requestBody/$ref": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1deleteCohostRequest/post/requestBody/$ref"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody"
     },
     "#/paths/~1deleteCohostRequest/post/responses/default": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1deleteCohostRequest/post/responses/default"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1deleteCohostRequest/post/responses/default/$ref": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1deleteCohostRequest/post/responses/default/$ref"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1removeCohost/post/operationId": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1removeCohost/post/operationId"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/operationId"
     },
     "#/paths/~1removeCohost/post/requestBody/$ref": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1removeCohost/post/requestBody/$ref"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody"
     },
     "#/paths/~1removeCohost/post/responses/default": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1removeCohost/post/responses/default"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1removeCohost/post/responses/default/$ref": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1removeCohost/post/responses/default/$ref"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1generateEventCohostLink/post/operationId": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1generateEventCohostLink/post/operationId"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/operationId"
     },
     "#/paths/~1generateEventCohostLink/post/requestBody/$ref": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1generateEventCohostLink/post/requestBody/$ref"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody"
     },
     "#/paths/~1generateEventCohostLink/post/responses/default": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1generateEventCohostLink/post/responses/default"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1generateEventCohostLink/post/responses/default/$ref": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1generateEventCohostLink/post/responses/default/$ref"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1revokeEventCohostLink/post/operationId": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1revokeEventCohostLink/post/operationId"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/operationId"
     },
     "#/paths/~1revokeEventCohostLink/post/requestBody/$ref": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1revokeEventCohostLink/post/requestBody/$ref"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody"
     },
     "#/paths/~1revokeEventCohostLink/post/responses/default": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1revokeEventCohostLink/post/responses/default"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1revokeEventCohostLink/post/responses/default/$ref": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1revokeEventCohostLink/post/responses/default/$ref"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1getMyUpcomingEventsForHomePage/post/operationId": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getMyUpcomingEventsForHomePage/post/operationId"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyUpcomingEventsForHomePage/post/operationId"
     },
     "#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/$ref": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/$ref"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody"
     },
     "#/paths/~1getMyUpcomingEventsForHomePage/post/responses/default": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getMyUpcomingEventsForHomePage/post/responses/default"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1getMyUpcomingEventsForHomePage/post/responses/default/$ref": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getMyUpcomingEventsForHomePage/post/responses/default/$ref"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1getMyPastEventsForHomePage/post/operationId": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getMyPastEventsForHomePage/post/operationId"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyPastEventsForHomePage/post/operationId"
     },
     "#/paths/~1getMyPastEventsForHomePage/post/requestBody/$ref": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getMyPastEventsForHomePage/post/requestBody/$ref"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyPastEventsForHomePage/post/requestBody"
     },
     "#/paths/~1getMyPastEventsForHomePage/post/responses/default": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getMyPastEventsForHomePage/post/responses/default"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1getMyPastEventsForHomePage/post/responses/default/$ref": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getMyPastEventsForHomePage/post/responses/default/$ref"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1addGuest/post/operationId": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1addGuest/post/operationId"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addGuest/post/operationId"
     },
     "#/paths/~1addGuest/post/requestBody/$ref": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1addGuest/post/requestBody/$ref"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addGuest/post/requestBody"
     },
     "#/paths/~1addGuest/post/responses/default": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1addGuest/post/responses/default"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1addGuest/post/responses/default/$ref": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1addGuest/post/responses/default/$ref"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1markEventInterest/post/operationId": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1markEventInterest/post/operationId"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1markEventInterest/post/operationId"
     },
     "#/paths/~1markEventInterest/post/requestBody/$ref": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1markEventInterest/post/requestBody/$ref"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1markEventInterest/post/requestBody"
     },
     "#/paths/~1markEventInterest/post/responses/default": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1markEventInterest/post/responses/default"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1markEventInterest/post/responses/default/$ref": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1markEventInterest/post/responses/default/$ref"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1getCurrentGuest/post/operationId": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getCurrentGuest/post/operationId"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getCurrentGuest/post/operationId"
     },
     "#/paths/~1getCurrentGuest/post/requestBody/$ref": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getCurrentGuest/post/requestBody/$ref"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getCurrentGuest/post/requestBody"
     },
     "#/paths/~1getCurrentGuest/post/responses/default": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getCurrentGuest/post/responses/default"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1getCurrentGuest/post/responses/default/$ref": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getCurrentGuest/post/responses/default/$ref"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/operationId": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/operationId"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/operationId"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/parameters/0/$ref": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/parameters/0/$ref"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/parameters/0"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/responses/default": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/responses/default"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/responses/default/$ref": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/responses/default/$ref"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/servers/0/url": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/servers/0/url"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/servers/0/url"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/operationId": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/operationId"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/operationId"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/0/$ref": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/0/$ref"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/0"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/1/$ref": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/1/$ref"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/1"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/requestBody/$ref": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/requestBody/$ref"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/requestBody"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/responses/default": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/responses/default"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/responses/default/$ref": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/responses/default/$ref"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/servers/0/url": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/servers/0/url"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/servers/0/url"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/operationId": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/operationId"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/operationId"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/parameters/0/$ref": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/parameters/0/$ref"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/parameters/0"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/parameters/1/$ref": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/parameters/1/$ref"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/parameters/1"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/responses/default": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/responses/default"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/responses/default/$ref": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/responses/default/$ref"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/servers/0/url": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/servers/0/url"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/servers/0/url"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/operationId": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/operationId"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/operationId"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/0/$ref": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/0/$ref"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/0"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/1/$ref": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/1/$ref"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/1"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/2/$ref": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/2/$ref"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/2"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/responses/default": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/responses/default"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/responses/default/$ref": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/responses/default/$ref"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/servers/0/url": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/servers/0/url"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/servers/0/url"
     },
     "#/paths/~1v1~1token/post/operationId": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1token/post/operationId"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1token/post/operationId"
     },
     "#/paths/~1v1~1token/post/requestBody/$ref": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1token/post/requestBody/$ref"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1token/post/requestBody"
     },
     "#/paths/~1v1~1token/post/responses/default": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1token/post/responses/default"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1v1~1token/post/responses/default/$ref": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1token/post/responses/default/$ref"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1v1~1token/post/servers/0/url": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1token/post/servers/0/url"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1token/post/servers/0/url"
     },
     "#/paths/~1sendAuthCodeTrusted/post/operationId": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1sendAuthCodeTrusted/post/operationId"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post/operationId"
     },
     "#/paths/~1sendAuthCodeTrusted/post/requestBody/$ref": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1sendAuthCodeTrusted/post/requestBody/$ref"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post/requestBody"
     },
     "#/paths/~1sendAuthCodeTrusted/post/responses/default": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1sendAuthCodeTrusted/post/responses/default"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1sendAuthCodeTrusted/post/responses/default/$ref": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1sendAuthCodeTrusted/post/responses/default/$ref"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1getLoginToken/post/operationId": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getLoginToken/post/operationId"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getLoginToken/post/operationId"
     },
     "#/paths/~1getLoginToken/post/requestBody/$ref": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getLoginToken/post/requestBody/$ref"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getLoginToken/post/requestBody"
     },
     "#/paths/~1getLoginToken/post/responses/default": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getLoginToken/post/responses/default"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1getLoginToken/post/responses/default/$ref": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1getLoginToken/post/responses/default/$ref"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1v1~1accounts:signInWithCustomToken/post/operationId": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1accounts:signInWithCustomToken/post/operationId"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1accounts:signInWithCustomToken/post/operationId"
     },
     "#/paths/~1v1~1accounts:signInWithCustomToken/post/requestBody/$ref": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1accounts:signInWithCustomToken/post/requestBody/$ref"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1accounts:signInWithCustomToken/post/requestBody"
     },
     "#/paths/~1v1~1accounts:signInWithCustomToken/post/responses/default": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1accounts:signInWithCustomToken/post/responses/default"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1v1~1accounts:signInWithCustomToken/post/responses/default/$ref": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1accounts:signInWithCustomToken/post/responses/default/$ref"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1v1~1accounts:signInWithCustomToken/post/servers/0/url": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1accounts:signInWithCustomToken/post/servers/0/url"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1accounts:signInWithCustomToken/post/servers/0/url"
     },
     "#/paths/~1v1~1accounts:lookup/post/operationId": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1accounts:lookup/post/operationId"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1accounts:lookup/post/operationId"
     },
     "#/paths/~1v1~1accounts:lookup/post/requestBody/$ref": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1accounts:lookup/post/requestBody/$ref"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1accounts:lookup/post/requestBody"
     },
     "#/paths/~1v1~1accounts:lookup/post/responses/default": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1accounts:lookup/post/responses/default"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1v1~1accounts:lookup/post/responses/default/$ref": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1accounts:lookup/post/responses/default/$ref"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1v1~1accounts:lookup/post/servers/0/url": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1v1~1accounts:lookup/post/servers/0/url"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1accounts:lookup/post/servers/0/url"
     },
     "#/paths/~1uploadPhoto/post/operationId": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1uploadPhoto/post/operationId"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1uploadPhoto/post/operationId"
     },
     "#/paths/~1uploadPhoto/post/parameters/0/name": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1uploadPhoto/post/parameters/0/name"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1uploadPhoto/post/parameters/0/name"
     },
     "#/paths/~1uploadPhoto/post/parameters/0/in": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1uploadPhoto/post/parameters/0/in"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1uploadPhoto/post/parameters/0/in"
     },
     "#/paths/~1uploadPhoto/post/parameters/0/schema": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1uploadPhoto/post/parameters/0/schema"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1uploadPhoto/post/parameters/0/schema"
     },
     "#/paths/~1uploadPhoto/post/parameters/0/schema/type": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1uploadPhoto/post/parameters/0/schema/type"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1uploadPhoto/post/parameters/0/schema/type"
     },
     "#/paths/~1uploadPhoto/post/requestBody/$ref": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1uploadPhoto/post/requestBody/$ref"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1uploadPhoto/post/requestBody"
     },
     "#/paths/~1uploadPhoto/post/responses/default": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1uploadPhoto/post/responses/default"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1uploadPhoto/post/responses/default/$ref": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1uploadPhoto/post/responses/default/$ref"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1uploadPhoto/post/servers/0/url": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1uploadPhoto/post/servers/0/url"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1uploadPhoto/post/servers/0/url"
     },
     "#/paths/~1posters.json/get/operationId": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1posters.json/get/operationId"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1posters.json/get/operationId"
     },
     "#/paths/~1posters.json/get/responses/default": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1posters.json/get/responses/default"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1posters.json/get/responses/default/$ref": {
       "classification": "explicit-unknown",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1posters.json/get/responses/default/$ref"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1posters.json/get/servers/0/url": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/paths/~1posters.json/get/servers/0/url"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1posters.json/get/servers/0/url"
     },
     "#/components/securitySchemes/firebaseBearer": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/securitySchemes/firebaseBearer"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/securitySchemes/firebaseBearer"
     },
     "#/components/securitySchemes/firebaseBearer/type": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/securitySchemes/firebaseBearer/type"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/securitySchemes/firebaseBearer/type"
     },
     "#/components/securitySchemes/firebaseBearer/scheme": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/securitySchemes/firebaseBearer/scheme"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/securitySchemes/firebaseBearer/scheme"
     },
     "#/components/securitySchemes/firebaseApiKey": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/securitySchemes/firebaseApiKey"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/securitySchemes/firebaseApiKey"
     },
     "#/components/securitySchemes/firebaseApiKey/type": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/securitySchemes/firebaseApiKey/type"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/securitySchemes/firebaseApiKey/type"
     },
     "#/components/securitySchemes/firebaseApiKey/in": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/securitySchemes/firebaseApiKey/in"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/securitySchemes/firebaseApiKey/in"
     },
     "#/components/securitySchemes/firebaseApiKey/name": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/securitySchemes/firebaseApiKey/name"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/securitySchemes/firebaseApiKey/name"
     },
     "#/components/parameters/EventId": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/EventId"
+      "citation": "spec/research/historical-27-operation-draft.json#/components"
     },
     "#/components/parameters/EventId/name": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/EventId/name"
+      "citation": "spec/research/historical-27-operation-draft.json#/components"
     },
     "#/components/parameters/EventId/in": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/EventId/in"
+      "citation": "spec/research/historical-27-operation-draft.json#/components"
     },
     "#/components/parameters/EventId/required": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/EventId/required"
+      "citation": "spec/research/historical-27-operation-draft.json#/components"
     },
     "#/components/parameters/EventId/schema/type": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/EventId/schema/type"
+      "citation": "spec/research/historical-27-operation-draft.json#/components"
     },
     "#/components/parameters/GuestId": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/GuestId"
+      "citation": "spec/research/historical-27-operation-draft.json#/components"
     },
     "#/components/parameters/GuestId/name": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/GuestId/name"
+      "citation": "spec/research/historical-27-operation-draft.json#/components"
     },
     "#/components/parameters/GuestId/in": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/GuestId/in"
+      "citation": "spec/research/historical-27-operation-draft.json#/components"
     },
     "#/components/parameters/GuestId/required": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/GuestId/required"
+      "citation": "spec/research/historical-27-operation-draft.json#/components"
     },
     "#/components/parameters/GuestId/schema/type": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/GuestId/schema/type"
+      "citation": "spec/research/historical-27-operation-draft.json#/components"
     },
     "#/components/parameters/CollectionPath": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/CollectionPath"
+      "citation": "spec/research/historical-27-operation-draft.json#/components"
     },
     "#/components/parameters/CollectionPath/name": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/CollectionPath/name"
+      "citation": "spec/research/historical-27-operation-draft.json#/components"
     },
     "#/components/parameters/CollectionPath/in": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/CollectionPath/in"
+      "citation": "spec/research/historical-27-operation-draft.json#/components"
     },
     "#/components/parameters/CollectionPath/required": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/CollectionPath/required"
+      "citation": "spec/research/historical-27-operation-draft.json#/components"
     },
     "#/components/parameters/CollectionPath/schema/type": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/CollectionPath/schema/type"
+      "citation": "spec/research/historical-27-operation-draft.json#/components"
     },
     "#/components/parameters/UpdateMask": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/UpdateMask"
+      "citation": "spec/research/historical-27-operation-draft.json#/components"
     },
     "#/components/parameters/UpdateMask/name": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/UpdateMask/name"
+      "citation": "spec/research/historical-27-operation-draft.json#/components"
     },
     "#/components/parameters/UpdateMask/in": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/UpdateMask/in"
+      "citation": "spec/research/historical-27-operation-draft.json#/components"
     },
     "#/components/parameters/UpdateMask/schema/type": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/UpdateMask/schema/type"
+      "citation": "spec/research/historical-27-operation-draft.json#/components"
     },
     "#/components/parameters/PageSize": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/PageSize"
+      "citation": "spec/research/historical-27-operation-draft.json#/components"
     },
     "#/components/parameters/PageSize/name": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/PageSize/name"
+      "citation": "spec/research/historical-27-operation-draft.json#/components"
     },
     "#/components/parameters/PageSize/in": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/PageSize/in"
+      "citation": "spec/research/historical-27-operation-draft.json#/components"
     },
     "#/components/parameters/PageSize/schema/type": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/PageSize/schema/type"
+      "citation": "spec/research/historical-27-operation-draft.json#/components"
     },
     "#/components/parameters/PageSize/schema/minimum": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/PageSize/schema/minimum"
+      "citation": "spec/research/historical-27-operation-draft.json#/components"
     },
     "#/components/parameters/PageToken": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/PageToken"
+      "citation": "spec/research/historical-27-operation-draft.json#/components"
     },
     "#/components/parameters/PageToken/name": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/PageToken/name"
+      "citation": "spec/research/historical-27-operation-draft.json#/components"
     },
     "#/components/parameters/PageToken/in": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/PageToken/in"
+      "citation": "spec/research/historical-27-operation-draft.json#/components"
     },
     "#/components/parameters/PageToken/schema/type": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/parameters/PageToken/schema/type"
+      "citation": "spec/research/historical-27-operation-draft.json#/components"
     },
     "#/components/requestBodies/CallableRequest": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/requestBodies/CallableRequest"
+      "citation": "spec/research/historical-27-operation-draft.json#/components"
     },
     "#/components/requestBodies/CallableRequest/required": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/requestBodies/CallableRequest/required"
+      "citation": "spec/research/historical-27-operation-draft.json#/components"
     },
     "#/components/requestBodies/CallableRequest/content/application~1json": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/requestBodies/CallableRequest/content/application~1json"
+      "citation": "spec/research/historical-27-operation-draft.json#/components"
     },
     "#/components/requestBodies/CallableRequest/content/application~1json/schema/$ref": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/requestBodies/CallableRequest/content/application~1json/schema/$ref"
+      "citation": "spec/research/historical-27-operation-draft.json#/components"
     },
     "#/components/requestBodies/TextBlastRequest": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/requestBodies/TextBlastRequest"
+      "citation": "spec/research/historical-27-operation-draft.json#/components"
     },
     "#/components/requestBodies/TextBlastRequest/required": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/requestBodies/TextBlastRequest/required"
+      "citation": "spec/research/historical-27-operation-draft.json#/components"
     },
     "#/components/requestBodies/TextBlastRequest/content/application~1json": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/requestBodies/TextBlastRequest/content/application~1json"
+      "citation": "spec/research/historical-27-operation-draft.json#/components"
     },
     "#/components/requestBodies/TextBlastRequest/content/application~1json/schema/$ref": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/requestBodies/TextBlastRequest/content/application~1json/schema/$ref"
+      "citation": "spec/research/historical-27-operation-draft.json#/components"
     },
     "#/components/requestBodies/FirestoreWrite": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
     },
     "#/components/requestBodies/FirestoreWrite/required": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
     },
     "#/components/requestBodies/FirestoreWrite/content/application~1json": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
     },
     "#/components/requestBodies/FirestoreWrite/content/application~1json/schema/$ref": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
     },
     "#/components/requestBodies/RefreshToken": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
     },
     "#/components/requestBodies/RefreshToken/required": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
     },
     "#/components/requestBodies/RefreshToken/content/application~1x-www-form-urlencoded": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
     },
     "#/components/requestBodies/RefreshToken/content/application~1x-www-form-urlencoded/schema/$ref": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
     },
     "#/components/requestBodies/CustomToken": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
     },
     "#/components/requestBodies/CustomToken/required": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
     },
     "#/components/requestBodies/CustomToken/content/application~1json": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
     },
     "#/components/requestBodies/CustomToken/content/application~1json/schema/$ref": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
     },
     "#/components/requestBodies/FirebaseLookup": {
       "classification": "reviewed-first-party-repository-research",
-      "citation": "9e6ed15:src/commands/auth.ts#L145-L340"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
     },
     "#/components/requestBodies/FirebaseLookup/required": {
       "classification": "reviewed-first-party-repository-research",
-      "citation": "9e6ed15:src/commands/auth.ts#L145-L340"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
     },
     "#/components/requestBodies/FirebaseLookup/content/application~1json": {
       "classification": "reviewed-first-party-repository-research",
-      "citation": "9e6ed15:src/commands/auth.ts#L145-L340"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
     },
     "#/components/requestBodies/FirebaseLookup/content/application~1json/schema/$ref": {
       "classification": "reviewed-first-party-repository-research",
-      "citation": "9e6ed15:src/commands/auth.ts#L145-L340"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
     },
     "#/components/requestBodies/UploadPhoto": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/upload.ts#L35-L115"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-upload-research"
     },
     "#/components/requestBodies/UploadPhoto/required": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/upload.ts#L35-L115"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-upload-research"
     },
     "#/components/requestBodies/UploadPhoto/content/multipart~1form-data": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/upload.ts#L35-L115"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-upload-research"
     },
     "#/components/requestBodies/UploadPhoto/content/multipart~1form-data/schema/type": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/upload.ts#L35-L115"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-upload-research"
     },
     "#/components/requestBodies/UploadPhoto/content/multipart~1form-data/schema/required/0": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/upload.ts#L35-L115"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-upload-research"
     },
     "#/components/requestBodies/UploadPhoto/content/multipart~1form-data/schema/properties/file": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/upload.ts#L35-L115"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-upload-research"
     },
     "#/components/requestBodies/UploadPhoto/content/multipart~1form-data/schema/properties/file/type": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/upload.ts#L35-L115"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-upload-research"
     },
     "#/components/requestBodies/UploadPhoto/content/multipart~1form-data/schema/properties/file/format": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/upload.ts#L35-L115"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-upload-research"
     },
     "#/components/responses/CallableResponse": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/responses/CallableResponse"
+      "citation": "spec/research/historical-27-operation-draft.json#/components"
     },
     "#/components/responses/CallableResponse/content/application~1json": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/responses/CallableResponse/content/application~1json"
+      "citation": "spec/research/historical-27-operation-draft.json#/components"
     },
     "#/components/responses/CallableResponse/content/application~1json/schema/$ref": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/responses/CallableResponse/content/application~1json/schema/$ref"
+      "citation": "spec/research/historical-27-operation-draft.json#/components"
     },
     "#/components/responses/FirestoreDocument": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
     },
     "#/components/responses/FirestoreDocument/content/application~1json": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
     },
     "#/components/responses/FirestoreDocument/content/application~1json/schema/$ref": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
     },
     "#/components/responses/FirestoreList": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
     },
     "#/components/responses/FirestoreList/content/application~1json": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
     },
     "#/components/responses/FirestoreList/content/application~1json/schema/$ref": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
     },
     "#/components/responses/RefreshToken": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
     },
     "#/components/responses/RefreshToken/content/application~1json": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
     },
     "#/components/responses/RefreshToken/content/application~1json/schema/$ref": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
     },
     "#/components/responses/FirebaseSignIn": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
     },
     "#/components/responses/FirebaseSignIn/content/application~1json": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
     },
     "#/components/responses/FirebaseSignIn/content/application~1json/schema/$ref": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
     },
     "#/components/responses/FirebaseLookup": {
       "classification": "reviewed-first-party-repository-research",
-      "citation": "9e6ed15:src/commands/auth.ts#L145-L340"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
     },
     "#/components/responses/FirebaseLookup/content/application~1json": {
       "classification": "reviewed-first-party-repository-research",
-      "citation": "9e6ed15:src/commands/auth.ts#L145-L340"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
     },
     "#/components/responses/FirebaseLookup/content/application~1json/schema/$ref": {
       "classification": "reviewed-first-party-repository-research",
-      "citation": "9e6ed15:src/commands/auth.ts#L145-L340"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
     },
     "#/components/responses/UploadPhoto": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/upload.ts#L35-L115"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-upload-research"
     },
     "#/components/responses/UploadPhoto/content/application~1json": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/upload.ts#L35-L115"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-upload-research"
     },
     "#/components/responses/UploadPhoto/content/application~1json/schema/$ref": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/upload.ts#L35-L115"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-upload-research"
     },
     "#/components/responses/PosterCatalog": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/posters.ts#L25-L45"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-catalog-fetch"
     },
     "#/components/responses/PosterCatalog/content/application~1json": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/posters.ts#L25-L45"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-catalog-fetch"
     },
     "#/components/responses/PosterCatalog/content/application~1json/schema/type": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/posters.ts#L25-L45"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-catalog-fetch"
     },
     "#/components/responses/PosterCatalog/content/application~1json/schema/items/$ref": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/posters.ts#L25-L45"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-catalog-fetch"
     },
     "#/components/schemas/CallableRequest": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableRequest"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas"
     },
     "#/components/schemas/CallableRequest/type": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableRequest/type"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas"
     },
     "#/components/schemas/CallableRequest/required/0": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableRequest/required/0"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas"
     },
     "#/components/schemas/CallableRequest/properties/data": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableRequest/properties/data"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas"
     },
     "#/components/schemas/CallableRequest/properties/data/type": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableRequest/properties/data/type"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas"
     },
     "#/components/schemas/CallableRequest/properties/data/required/0": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableRequest/properties/data/required/0"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas"
     },
     "#/components/schemas/CallableRequest/properties/data/required/1": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableRequest/properties/data/required/1"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas"
     },
     "#/components/schemas/CallableRequest/properties/data/properties/params": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableRequest/properties/data/properties/params"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas"
     },
     "#/components/schemas/CallableRequest/properties/data/properties/params/type": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableRequest/properties/data/properties/params/type"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas"
     },
     "#/components/schemas/CallableRequest/properties/data/properties/params/additionalProperties": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableRequest/properties/data/properties/params/additionalProperties"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas"
     },
     "#/components/schemas/CallableRequest/properties/data/properties/amplitudeDeviceId": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableRequest/properties/data/properties/amplitudeDeviceId"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas"
     },
     "#/components/schemas/CallableRequest/properties/data/properties/amplitudeDeviceId/type": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableRequest/properties/data/properties/amplitudeDeviceId/type"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas"
     },
     "#/components/schemas/CallableRequest/properties/data/properties/amplitudeSessionId": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableRequest/properties/data/properties/amplitudeSessionId"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas"
     },
     "#/components/schemas/CallableRequest/properties/data/properties/amplitudeSessionId/type": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableRequest/properties/data/properties/amplitudeSessionId/type"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas"
     },
     "#/components/schemas/CallableRequest/properties/data/properties/userId": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableRequest/properties/data/properties/userId"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas"
     },
     "#/components/schemas/CallableRequest/properties/data/properties/userId/type/0": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableRequest/properties/data/properties/userId/type/0"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas"
     },
     "#/components/schemas/CallableRequest/properties/data/properties/userId/type/1": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableRequest/properties/data/properties/userId/type/1"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas"
     },
     "#/components/schemas/CallableRequest/properties/data/additionalProperties": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableRequest/properties/data/additionalProperties"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas"
     },
     "#/components/schemas/CallableRequest/additionalProperties": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableRequest/additionalProperties"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas"
     },
     "#/components/schemas/TextBlastRequest": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
     },
     "#/components/schemas/TextBlastRequest/type": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
     },
     "#/components/schemas/TextBlastRequest/required/0": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
     },
     "#/components/schemas/TextBlastRequest/properties/data": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
     },
     "#/components/schemas/TextBlastRequest/properties/data/type": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
     },
     "#/components/schemas/TextBlastRequest/properties/data/required/0": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
     },
     "#/components/schemas/TextBlastRequest/properties/data/properties/params": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
     },
     "#/components/schemas/TextBlastRequest/properties/data/properties/params/type": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
     },
     "#/components/schemas/TextBlastRequest/properties/data/properties/params/required/0": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
     },
     "#/components/schemas/TextBlastRequest/properties/data/properties/params/required/1": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
     },
     "#/components/schemas/TextBlastRequest/properties/data/properties/params/properties/eventId": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
     },
     "#/components/schemas/TextBlastRequest/properties/data/properties/params/properties/eventId/type": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
     },
     "#/components/schemas/TextBlastRequest/properties/data/properties/params/properties/message": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
     },
     "#/components/schemas/TextBlastRequest/properties/data/properties/params/properties/message/$ref": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
     },
     "#/components/schemas/TextBlastRequest/properties/data/properties/params/additionalProperties": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
     },
     "#/components/schemas/TextBlastRequest/properties/data/additionalProperties": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
     },
     "#/components/schemas/TextBlastRequest/additionalProperties": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
     },
     "#/components/schemas/TextBlastMessage": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
     },
     "#/components/schemas/TextBlastMessage/type": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
     },
     "#/components/schemas/TextBlastMessage/required/0": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
     },
     "#/components/schemas/TextBlastMessage/required/1": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
     },
     "#/components/schemas/TextBlastMessage/required/2": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
     },
     "#/components/schemas/TextBlastMessage/properties/text": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
     },
     "#/components/schemas/TextBlastMessage/properties/text/type": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
     },
     "#/components/schemas/TextBlastMessage/properties/text/maxLength": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
     },
     "#/components/schemas/TextBlastMessage/properties/to": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
     },
     "#/components/schemas/TextBlastMessage/properties/to/type": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
     },
     "#/components/schemas/TextBlastMessage/properties/to/items/type": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
     },
     "#/components/schemas/TextBlastMessage/properties/showOnEventPage": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
     },
     "#/components/schemas/TextBlastMessage/properties/showOnEventPage/type": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
     },
     "#/components/schemas/TextBlastMessage/properties/images": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
     },
     "#/components/schemas/TextBlastMessage/properties/images/type": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
     },
     "#/components/schemas/TextBlastMessage/properties/images/maxItems": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
     },
     "#/components/schemas/TextBlastMessage/properties/images/items/type": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
     },
     "#/components/schemas/TextBlastMessage/properties/images/items/additionalProperties": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
     },
     "#/components/schemas/TextBlastMessage/additionalProperties": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-text-blast-endpoint.md#request-payload"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
     },
     "#/components/schemas/CallableResponse": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableResponse"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/CallableResponse"
     },
     "#/components/schemas/CallableResponse/type": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableResponse/type"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/CallableResponse/type"
     },
     "#/components/schemas/CallableResponse/properties/result": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableResponse/properties/result"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/CallableResponse/properties/result"
     },
     "#/components/schemas/CallableResponse/properties/result/type": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableResponse/properties/result/type"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/CallableResponse/properties/result/type"
     },
     "#/components/schemas/CallableResponse/properties/result/properties/data": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableResponse/properties/result/properties/data"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/CallableResponse/properties/result/properties/data"
     },
     "#/components/schemas/CallableResponse/properties/result/additionalProperties": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableResponse/properties/result/additionalProperties"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/CallableResponse/properties/result/additionalProperties"
     },
     "#/components/schemas/CallableResponse/additionalProperties": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/components/schemas/CallableResponse/additionalProperties"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/CallableResponse/additionalProperties"
     },
     "#/components/schemas/FirestoreWriteDocument": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
     },
     "#/components/schemas/FirestoreWriteDocument/type": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
     },
     "#/components/schemas/FirestoreWriteDocument/properties/fields": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
     },
     "#/components/schemas/FirestoreWriteDocument/properties/fields/type": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
     },
     "#/components/schemas/FirestoreWriteDocument/properties/fields/additionalProperties": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
     },
     "#/components/schemas/FirestoreWriteDocument/additionalProperties": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
     },
     "#/components/schemas/FirestoreDocument": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
     },
     "#/components/schemas/FirestoreDocument/type": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
     },
     "#/components/schemas/FirestoreDocument/properties/name": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
     },
     "#/components/schemas/FirestoreDocument/properties/name/type": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
     },
     "#/components/schemas/FirestoreDocument/properties/fields": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
     },
     "#/components/schemas/FirestoreDocument/properties/fields/type": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
     },
     "#/components/schemas/FirestoreDocument/properties/fields/additionalProperties": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
     },
     "#/components/schemas/FirestoreDocument/properties/createTime": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
     },
     "#/components/schemas/FirestoreDocument/properties/createTime/type": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
     },
     "#/components/schemas/FirestoreDocument/properties/updateTime": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
     },
     "#/components/schemas/FirestoreDocument/properties/updateTime/type": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
     },
     "#/components/schemas/FirestoreDocument/additionalProperties": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
     },
     "#/components/schemas/FirestoreListResponse": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
     },
     "#/components/schemas/FirestoreListResponse/type": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
     },
     "#/components/schemas/FirestoreListResponse/properties/documents": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
     },
     "#/components/schemas/FirestoreListResponse/properties/documents/type": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
     },
     "#/components/schemas/FirestoreListResponse/properties/documents/items/$ref": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
     },
     "#/components/schemas/FirestoreListResponse/properties/nextPageToken": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
     },
     "#/components/schemas/FirestoreListResponse/properties/nextPageToken/type": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
     },
     "#/components/schemas/FirestoreListResponse/additionalProperties": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/http.ts#L1-L245"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
     },
     "#/components/schemas/RefreshTokenRequest": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
     },
     "#/components/schemas/RefreshTokenRequest/type": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
     },
     "#/components/schemas/RefreshTokenRequest/required/0": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
     },
     "#/components/schemas/RefreshTokenRequest/required/1": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
     },
     "#/components/schemas/RefreshTokenRequest/properties/grant_type": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
     },
     "#/components/schemas/RefreshTokenRequest/properties/grant_type/const": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
     },
     "#/components/schemas/RefreshTokenRequest/properties/refresh_token": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
     },
     "#/components/schemas/RefreshTokenRequest/properties/refresh_token/type": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
     },
     "#/components/schemas/RefreshTokenResponse": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
     },
     "#/components/schemas/RefreshTokenResponse/type": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
     },
     "#/components/schemas/RefreshTokenResponse/properties/id_token": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
     },
     "#/components/schemas/RefreshTokenResponse/properties/id_token/type": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
     },
     "#/components/schemas/RefreshTokenResponse/properties/refresh_token": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
     },
     "#/components/schemas/RefreshTokenResponse/properties/refresh_token/type": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
     },
     "#/components/schemas/RefreshTokenResponse/properties/expires_in": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
     },
     "#/components/schemas/RefreshTokenResponse/properties/expires_in/type": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
     },
     "#/components/schemas/RefreshTokenResponse/properties/user_id": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
     },
     "#/components/schemas/RefreshTokenResponse/properties/user_id/type": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
     },
     "#/components/schemas/RefreshTokenResponse/additionalProperties": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/auth.ts#L1-L150"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
     },
     "#/components/schemas/CustomTokenRequest": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
     },
     "#/components/schemas/CustomTokenRequest/type": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
     },
     "#/components/schemas/CustomTokenRequest/required/0": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
     },
     "#/components/schemas/CustomTokenRequest/required/1": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
     },
     "#/components/schemas/CustomTokenRequest/properties/token": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
     },
     "#/components/schemas/CustomTokenRequest/properties/token/type": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
     },
     "#/components/schemas/CustomTokenRequest/properties/returnSecureToken": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
     },
     "#/components/schemas/CustomTokenRequest/properties/returnSecureToken/const": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
     },
     "#/components/schemas/FirebaseSignInResponse": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
     },
     "#/components/schemas/FirebaseSignInResponse/type": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
     },
     "#/components/schemas/FirebaseSignInResponse/properties/idToken": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
     },
     "#/components/schemas/FirebaseSignInResponse/properties/idToken/type": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
     },
     "#/components/schemas/FirebaseSignInResponse/properties/refreshToken": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
     },
     "#/components/schemas/FirebaseSignInResponse/properties/refreshToken/type": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
     },
     "#/components/schemas/FirebaseSignInResponse/properties/expiresIn": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
     },
     "#/components/schemas/FirebaseSignInResponse/properties/expiresIn/type": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
     },
     "#/components/schemas/FirebaseSignInResponse/properties/localId": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
     },
     "#/components/schemas/FirebaseSignInResponse/properties/localId/type": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
     },
     "#/components/schemas/FirebaseSignInResponse/additionalProperties": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-03-24-auth-flow-endpoints.md#auth-endpoints"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
     },
     "#/components/schemas/FirebaseLookupRequest": {
       "classification": "reviewed-first-party-repository-research",
-      "citation": "9e6ed15:src/commands/auth.ts#L145-L340"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
     },
     "#/components/schemas/FirebaseLookupRequest/type": {
       "classification": "reviewed-first-party-repository-research",
-      "citation": "9e6ed15:src/commands/auth.ts#L145-L340"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
     },
     "#/components/schemas/FirebaseLookupRequest/required/0": {
       "classification": "reviewed-first-party-repository-research",
-      "citation": "9e6ed15:src/commands/auth.ts#L145-L340"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
     },
     "#/components/schemas/FirebaseLookupRequest/properties/idToken": {
       "classification": "reviewed-first-party-repository-research",
-      "citation": "9e6ed15:src/commands/auth.ts#L145-L340"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
     },
     "#/components/schemas/FirebaseLookupRequest/properties/idToken/type": {
       "classification": "reviewed-first-party-repository-research",
-      "citation": "9e6ed15:src/commands/auth.ts#L145-L340"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
     },
     "#/components/schemas/FirebaseLookupResponse": {
       "classification": "reviewed-first-party-repository-research",
-      "citation": "9e6ed15:src/commands/auth.ts#L145-L340"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
     },
     "#/components/schemas/FirebaseLookupResponse/type": {
       "classification": "reviewed-first-party-repository-research",
-      "citation": "9e6ed15:src/commands/auth.ts#L145-L340"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
     },
     "#/components/schemas/FirebaseLookupResponse/properties/users": {
       "classification": "reviewed-first-party-repository-research",
-      "citation": "9e6ed15:src/commands/auth.ts#L145-L340"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
     },
     "#/components/schemas/FirebaseLookupResponse/properties/users/type": {
       "classification": "reviewed-first-party-repository-research",
-      "citation": "9e6ed15:src/commands/auth.ts#L145-L340"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
     },
     "#/components/schemas/FirebaseLookupResponse/properties/users/items/type": {
       "classification": "reviewed-first-party-repository-research",
-      "citation": "9e6ed15:src/commands/auth.ts#L145-L340"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
     },
     "#/components/schemas/FirebaseLookupResponse/properties/users/items/additionalProperties": {
       "classification": "reviewed-first-party-repository-research",
-      "citation": "9e6ed15:src/commands/auth.ts#L145-L340"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
     },
     "#/components/schemas/FirebaseLookupResponse/additionalProperties": {
       "classification": "reviewed-first-party-repository-research",
-      "citation": "9e6ed15:src/commands/auth.ts#L145-L340"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
     },
     "#/components/schemas/UploadPhotoResponse": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/upload.ts#L35-L115"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-upload-research"
     },
     "#/components/schemas/UploadPhotoResponse/type": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/upload.ts#L35-L115"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-upload-research"
     },
     "#/components/schemas/UploadPhotoResponse/properties/uploadData": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/upload.ts#L35-L115"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-upload-research"
     },
     "#/components/schemas/UploadPhotoResponse/properties/uploadData/type": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/upload.ts#L35-L115"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-upload-research"
     },
     "#/components/schemas/UploadPhotoResponse/properties/uploadData/properties/url": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/upload.ts#L35-L115"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-upload-research"
     },
     "#/components/schemas/UploadPhotoResponse/properties/uploadData/properties/url/type": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/upload.ts#L35-L115"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-upload-research"
     },
     "#/components/schemas/UploadPhotoResponse/properties/uploadData/additionalProperties": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/upload.ts#L35-L115"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-upload-research"
     },
     "#/components/schemas/UploadPhotoResponse/additionalProperties": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/upload.ts#L35-L115"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-upload-research"
     },
     "#/components/schemas/Poster": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/posters.ts#L25-L45"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
     },
     "#/components/schemas/Poster/type": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/posters.ts#L25-L45"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
     },
     "#/components/schemas/Poster/properties/id": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/posters.ts#L25-L45"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
     },
     "#/components/schemas/Poster/properties/id/type": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/posters.ts#L25-L45"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
     },
     "#/components/schemas/Poster/properties/name": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/posters.ts#L25-L45"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
     },
     "#/components/schemas/Poster/properties/name/type": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/posters.ts#L25-L45"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
     },
     "#/components/schemas/Poster/properties/url": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/posters.ts#L25-L45"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
     },
     "#/components/schemas/Poster/properties/url/type": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/posters.ts#L25-L45"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
     },
     "#/components/schemas/Poster/properties/contentType": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/posters.ts#L25-L45"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
     },
     "#/components/schemas/Poster/properties/contentType/type": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/posters.ts#L25-L45"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
     },
     "#/components/schemas/Poster/properties/width": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/posters.ts#L25-L45"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
     },
     "#/components/schemas/Poster/properties/width/type": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/posters.ts#L25-L45"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
     },
     "#/components/schemas/Poster/properties/height": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/posters.ts#L25-L45"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
     },
     "#/components/schemas/Poster/properties/height/type": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/posters.ts#L25-L45"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
     },
     "#/components/schemas/Poster/additionalProperties": {
       "classification": "typescript-derived-inference",
-      "citation": "9e6ed15:src/lib/posters.ts#L25-L45"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
     },
     "#/servers/0/url": {
       "classification": "typescript-derived-inference",
-      "citation": "17e9800753ada577408074bbbcadbae8cc8eacf0:spec/partiful.openapi.json#/servers/0/url"
+      "citation": "spec/research/historical-27-operation-draft.json#/servers/0/url"
     }
   }
 }

--- a/spec/partiful.api-evidence.json
+++ b/spec/partiful.api-evidence.json
@@ -10,11 +10,9 @@
   "sources": {
     "historicalDraft": "spec/research/historical-27-operation-draft.json",
     "unknownStatusDecision": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
+    "updateMask": "docs/research/2026-08-10-contract-evidence-sources.md#update-mask-serialization",
     "textBlast": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation",
     "authObservation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation",
-    "callableAuth": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research",
-    "firestore": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research",
-    "upload": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-upload-research",
     "posterInterface": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface",
     "posterCatalog": "docs/research/2026-08-10-contract-evidence-sources.md#poster-catalog-fetch"
   },
@@ -104,8 +102,8 @@
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1token/post"
     },
     "sendAuthCodeTrusted": {
-      "classification": "reviewed-first-party-repository-research",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post"
     },
     "getLoginToken": {
       "classification": "dated-live-observation",
@@ -116,8 +114,8 @@
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
     },
     "lookupFirebaseUser": {
-      "classification": "reviewed-first-party-repository-research",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1accounts:lookup/post"
     },
     "uploadEventPhoto": {
       "classification": "typescript-derived-inference",
@@ -131,191 +129,191 @@
   "operationClaims": {
     "createEvent": {
       "request": "typescript-derived-inference",
-      "response": "explicit-unknown",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post",
+      "response": "typescript-derived-inference",
       "status": "explicit-unknown",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "cancelEvent": {
       "request": "typescript-derived-inference",
-      "response": "explicit-unknown",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post",
+      "response": "typescript-derived-inference",
       "status": "explicit-unknown",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "getEventInfo": {
       "request": "typescript-derived-inference",
-      "response": "explicit-unknown",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getEventInfo/post",
+      "response": "typescript-derived-inference",
       "status": "explicit-unknown",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getEventInfo/post",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "getContacts": {
       "request": "typescript-derived-inference",
-      "response": "explicit-unknown",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post",
+      "response": "typescript-derived-inference",
       "status": "explicit-unknown",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "createTextBlast": {
       "request": "dated-live-observation",
-      "response": "explicit-unknown",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation",
+      "response": "typescript-derived-inference",
       "status": "explicit-unknown",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "addInvitedGuestsAsHost": {
       "request": "typescript-derived-inference",
-      "response": "explicit-unknown",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post",
+      "response": "typescript-derived-inference",
       "status": "explicit-unknown",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "createCohostRequest": {
       "request": "typescript-derived-inference",
-      "response": "explicit-unknown",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post",
+      "response": "typescript-derived-inference",
       "status": "explicit-unknown",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "deleteCohostRequest": {
       "request": "typescript-derived-inference",
-      "response": "explicit-unknown",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post",
+      "response": "typescript-derived-inference",
       "status": "explicit-unknown",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "removeCohost": {
       "request": "typescript-derived-inference",
-      "response": "explicit-unknown",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post",
+      "response": "typescript-derived-inference",
       "status": "explicit-unknown",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "generateEventCohostLink": {
       "request": "typescript-derived-inference",
-      "response": "explicit-unknown",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post",
+      "response": "typescript-derived-inference",
       "status": "explicit-unknown",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "revokeEventCohostLink": {
       "request": "typescript-derived-inference",
-      "response": "explicit-unknown",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post",
+      "response": "typescript-derived-inference",
       "status": "explicit-unknown",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "getMyUpcomingEventsForHomePage": {
       "request": "typescript-derived-inference",
-      "response": "explicit-unknown",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyUpcomingEventsForHomePage/post",
+      "response": "typescript-derived-inference",
       "status": "explicit-unknown",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyUpcomingEventsForHomePage/post",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "getMyPastEventsForHomePage": {
       "request": "typescript-derived-inference",
-      "response": "explicit-unknown",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyPastEventsForHomePage/post",
+      "response": "typescript-derived-inference",
       "status": "explicit-unknown",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyPastEventsForHomePage/post",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "addGuest": {
       "request": "typescript-derived-inference",
-      "response": "explicit-unknown",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addGuest/post",
+      "response": "typescript-derived-inference",
       "status": "explicit-unknown",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addGuest/post",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "markEventInterest": {
       "request": "typescript-derived-inference",
-      "response": "explicit-unknown",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1markEventInterest/post",
+      "response": "typescript-derived-inference",
       "status": "explicit-unknown",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1markEventInterest/post",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "getCurrentGuest": {
       "request": "typescript-derived-inference",
-      "response": "explicit-unknown",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getCurrentGuest/post",
+      "response": "typescript-derived-inference",
       "status": "explicit-unknown",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getCurrentGuest/post",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "firestoreGetEvent": {
       "request": "typescript-derived-inference",
-      "response": "explicit-unknown",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get",
+      "response": "typescript-derived-inference",
       "status": "explicit-unknown",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "firestorePatchEvent": {
       "request": "typescript-derived-inference",
-      "response": "explicit-unknown",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch",
+      "response": "typescript-derived-inference",
       "status": "explicit-unknown",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "firestoreGetGuest": {
       "request": "typescript-derived-inference",
-      "response": "explicit-unknown",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get",
+      "response": "typescript-derived-inference",
       "status": "explicit-unknown",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "firestoreListDocuments": {
       "request": "typescript-derived-inference",
-      "response": "explicit-unknown",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get",
+      "response": "typescript-derived-inference",
       "status": "explicit-unknown",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "refreshToken": {
       "request": "typescript-derived-inference",
-      "response": "explicit-unknown",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1token/post",
+      "response": "typescript-derived-inference",
       "status": "explicit-unknown",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1token/post",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "sendAuthCodeTrusted": {
-      "request": "reviewed-first-party-repository-research",
-      "response": "explicit-unknown",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research",
+      "request": "typescript-derived-inference",
+      "response": "typescript-derived-inference",
       "status": "explicit-unknown",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "getLoginToken": {
       "request": "dated-live-observation",
-      "response": "explicit-unknown",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation",
+      "response": "typescript-derived-inference",
       "status": "explicit-unknown",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "signInWithCustomToken": {
       "request": "dated-live-observation",
-      "response": "explicit-unknown",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation",
+      "response": "typescript-derived-inference",
       "status": "explicit-unknown",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "lookupFirebaseUser": {
-      "request": "reviewed-first-party-repository-research",
-      "response": "explicit-unknown",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research",
+      "request": "typescript-derived-inference",
+      "response": "typescript-derived-inference",
       "status": "explicit-unknown",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1accounts:lookup/post",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "uploadEventPhoto": {
       "request": "typescript-derived-inference",
-      "response": "explicit-unknown",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1uploadPhoto/post",
+      "response": "typescript-derived-inference",
       "status": "explicit-unknown",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1uploadPhoto/post",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "getPosterCatalog": {
-      "request": "explicit-unknown",
+      "request": "typescript-derived-inference",
       "response": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-catalog-fetch",
       "status": "explicit-unknown",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-catalog-fetch",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     }
   },
@@ -341,281 +339,2054 @@
     "Upload accepted media types, size limits, response variants, and whether uploadType values remain stable.",
     "Poster catalog freshness, complete schema, and cache behavior.",
     "Status codes and error bodies for every operation.",
-    "The poster event-image observation does not establish the /posters.json response; that operation is TypeScript-derived inference only."
+    "The poster event-image observation does not establish the /posters.json response; that operation is TypeScript-derived inference only.",
+    "HTTP success status codes and error bodies are explicit unknown; response body claims are tracked separately."
   ],
   "status": "proposed-pending-owner-approval",
   "claims": {
+    "#/servers/0/url": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/servers/0/url"
+    },
     "#/paths/~1createEvent/post/operationId": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/operationId"
     },
-    "#/paths/~1createEvent/post/requestBody/$ref": {
+    "#/paths/~1createEvent/post/requestBody/required": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/required"
+    },
+    "#/paths/~1createEvent/post/requestBody/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json"
+    },
+    "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/type"
+    },
+    "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/required/0"
+    },
+    "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data"
+    },
+    "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/type"
+    },
+    "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/required/0"
+    },
+    "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/required/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/required/1"
+    },
+    "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params"
+    },
+    "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/type"
+    },
+    "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/event": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/event"
+    },
+    "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/event/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/event/$ref"
+    },
+    "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/cohostIds": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/cohostIds"
+    },
+    "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/cohostIds/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/cohostIds/type"
+    },
+    "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/cohostIds/items/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/cohostIds/items/type"
+    },
+    "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties"
+    },
+    "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0"
+    },
+    "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/1"
+    },
+    "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId"
+    },
+    "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type"
+    },
+    "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId"
+    },
+    "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type"
+    },
+    "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format"
+    },
+    "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/userId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/userId"
+    },
+    "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0"
+    },
+    "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1"
+    },
+    "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/additionalProperties"
+    },
+    "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/additionalProperties"
     },
     "#/paths/~1createEvent/post/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
-    "#/paths/~1createEvent/post/responses/default/$ref": {
-      "classification": "explicit-unknown",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+    "#/paths/~1createEvent/post/responses/default/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/responses/200/content/application~1json"
+    },
+    "#/paths/~1createEvent/post/responses/default/content/application~1json/schema/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/responses/200/content/application~1json/schema/$ref"
+    },
+    "#/paths/~1createEvent/post/security/0/firebaseBearer": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/security/0/firebaseBearer"
     },
     "#/paths/~1cancelEvent/post/operationId": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/operationId"
     },
-    "#/paths/~1cancelEvent/post/requestBody/$ref": {
+    "#/paths/~1cancelEvent/post/requestBody/required": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/required"
+    },
+    "#/paths/~1cancelEvent/post/requestBody/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/content/application~1json"
+    },
+    "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/type"
+    },
+    "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/required/0"
+    },
+    "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data"
+    },
+    "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/type"
+    },
+    "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/required/0"
+    },
+    "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/required/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/required/1"
+    },
+    "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params"
+    },
+    "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/type"
+    },
+    "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId"
+    },
+    "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId/type"
+    },
+    "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties"
+    },
+    "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0"
+    },
+    "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId"
+    },
+    "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type"
+    },
+    "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId"
+    },
+    "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type"
+    },
+    "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format"
+    },
+    "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/userId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/userId"
+    },
+    "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0"
+    },
+    "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1"
+    },
+    "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/additionalProperties"
+    },
+    "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/additionalProperties"
     },
     "#/paths/~1cancelEvent/post/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
-    "#/paths/~1cancelEvent/post/responses/default/$ref": {
-      "classification": "explicit-unknown",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+    "#/paths/~1cancelEvent/post/responses/default/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/responses/200/content/application~1json"
+    },
+    "#/paths/~1cancelEvent/post/responses/default/content/application~1json/schema/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/responses/200/content/application~1json/schema/$ref"
+    },
+    "#/paths/~1cancelEvent/post/security/0/firebaseBearer": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/security/0/firebaseBearer"
     },
     "#/paths/~1getEventInfo/post/operationId": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getEventInfo/post/operationId"
     },
-    "#/paths/~1getEventInfo/post/requestBody/$ref": {
+    "#/paths/~1getEventInfo/post/requestBody/required": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getEventInfo/post/requestBody"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getEventInfo/post/requestBody/required"
+    },
+    "#/paths/~1getEventInfo/post/requestBody/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getEventInfo/post/requestBody/content/application~1json"
+    },
+    "#/paths/~1getEventInfo/post/requestBody/content/application~1json/schema/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getEventInfo/post/requestBody/content/application~1json/schema/type"
+    },
+    "#/paths/~1getEventInfo/post/requestBody/content/application~1json/schema/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getEventInfo/post/requestBody/content/application~1json/schema/required/0"
+    },
+    "#/paths/~1getEventInfo/post/requestBody/content/application~1json/schema/properties/data": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getEventInfo/post/requestBody/content/application~1json/schema/properties/data"
+    },
+    "#/paths/~1getEventInfo/post/requestBody/content/application~1json/schema/properties/data/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getEventInfo/post/requestBody/content/application~1json/schema/properties/data/type"
+    },
+    "#/paths/~1getEventInfo/post/requestBody/content/application~1json/schema/properties/data/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getEventInfo/post/requestBody/content/application~1json/schema/properties/data/required/0"
+    },
+    "#/paths/~1getEventInfo/post/requestBody/content/application~1json/schema/properties/data/required/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getEventInfo/post/requestBody/content/application~1json/schema/properties/data/required/1"
+    },
+    "#/paths/~1getEventInfo/post/requestBody/content/application~1json/schema/properties/data/properties/params": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getEventInfo/post/requestBody/content/application~1json/schema/properties/data/properties/params"
+    },
+    "#/paths/~1getEventInfo/post/requestBody/content/application~1json/schema/properties/data/properties/params/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getEventInfo/post/requestBody/content/application~1json/schema/properties/data/properties/params/type"
+    },
+    "#/paths/~1getEventInfo/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getEventInfo/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId"
+    },
+    "#/paths/~1getEventInfo/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getEventInfo/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId/type"
+    },
+    "#/paths/~1getEventInfo/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getEventInfo/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties"
+    },
+    "#/paths/~1getEventInfo/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getEventInfo/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0"
+    },
+    "#/paths/~1getEventInfo/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getEventInfo/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId"
+    },
+    "#/paths/~1getEventInfo/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getEventInfo/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type"
+    },
+    "#/paths/~1getEventInfo/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getEventInfo/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId"
+    },
+    "#/paths/~1getEventInfo/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getEventInfo/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type"
+    },
+    "#/paths/~1getEventInfo/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getEventInfo/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format"
+    },
+    "#/paths/~1getEventInfo/post/requestBody/content/application~1json/schema/properties/data/properties/userId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getEventInfo/post/requestBody/content/application~1json/schema/properties/data/properties/userId"
+    },
+    "#/paths/~1getEventInfo/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getEventInfo/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0"
+    },
+    "#/paths/~1getEventInfo/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getEventInfo/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1"
+    },
+    "#/paths/~1getEventInfo/post/requestBody/content/application~1json/schema/properties/data/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getEventInfo/post/requestBody/content/application~1json/schema/properties/data/additionalProperties"
+    },
+    "#/paths/~1getEventInfo/post/requestBody/content/application~1json/schema/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getEventInfo/post/requestBody/content/application~1json/schema/additionalProperties"
     },
     "#/paths/~1getEventInfo/post/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
-    "#/paths/~1getEventInfo/post/responses/default/$ref": {
-      "classification": "explicit-unknown",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+    "#/paths/~1getEventInfo/post/responses/default/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getEventInfo/post/responses/200/content/application~1json"
+    },
+    "#/paths/~1getEventInfo/post/responses/default/content/application~1json/schema/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getEventInfo/post/responses/200/content/application~1json/schema/$ref"
+    },
+    "#/paths/~1getEventInfo/post/security/0/firebaseBearer": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getEventInfo/post/security/0/firebaseBearer"
     },
     "#/paths/~1getContacts/post/operationId": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post/operationId"
     },
-    "#/paths/~1getContacts/post/requestBody/$ref": {
+    "#/paths/~1getContacts/post/requestBody/required": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post/requestBody"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post/requestBody/required"
+    },
+    "#/paths/~1getContacts/post/requestBody/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post/requestBody/content/application~1json"
+    },
+    "#/paths/~1getContacts/post/requestBody/content/application~1json/schema/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post/requestBody/content/application~1json/schema/type"
+    },
+    "#/paths/~1getContacts/post/requestBody/content/application~1json/schema/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post/requestBody/content/application~1json/schema/required/0"
+    },
+    "#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data"
+    },
+    "#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/type"
+    },
+    "#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/required/0"
+    },
+    "#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/required/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/required/1"
+    },
+    "#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/properties/params": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/properties/params"
+    },
+    "#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/properties/params/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/properties/params/type"
+    },
+    "#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties"
+    },
+    "#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId"
+    },
+    "#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type"
+    },
+    "#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId"
+    },
+    "#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type"
+    },
+    "#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format"
+    },
+    "#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/properties/userId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/properties/userId"
+    },
+    "#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0"
+    },
+    "#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1"
+    },
+    "#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/additionalProperties"
+    },
+    "#/paths/~1getContacts/post/requestBody/content/application~1json/schema/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post/requestBody/content/application~1json/schema/additionalProperties"
     },
     "#/paths/~1getContacts/post/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
-    "#/paths/~1getContacts/post/responses/default/$ref": {
-      "classification": "explicit-unknown",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+    "#/paths/~1getContacts/post/responses/default/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post/responses/200/content/application~1json"
+    },
+    "#/paths/~1getContacts/post/responses/default/content/application~1json/schema/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post/responses/200/content/application~1json/schema/$ref"
+    },
+    "#/paths/~1getContacts/post/security/0/firebaseBearer": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post/security/0/firebaseBearer"
     },
     "#/paths/~1createTextBlast/post/operationId": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createTextBlast/post/operationId"
     },
-    "#/paths/~1createTextBlast/post/requestBody/$ref": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createTextBlast/post/requestBody"
+    "#/paths/~1createTextBlast/post/requestBody/required": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
+    },
+    "#/paths/~1createTextBlast/post/requestBody/content/application~1json": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
+    },
+    "#/paths/~1createTextBlast/post/requestBody/content/application~1json/schema/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
+    },
+    "#/paths/~1createTextBlast/post/requestBody/content/application~1json/schema/required/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
+    },
+    "#/paths/~1createTextBlast/post/requestBody/content/application~1json/schema/properties/data": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
+    },
+    "#/paths/~1createTextBlast/post/requestBody/content/application~1json/schema/properties/data/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
+    },
+    "#/paths/~1createTextBlast/post/requestBody/content/application~1json/schema/properties/data/required/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
+    },
+    "#/paths/~1createTextBlast/post/requestBody/content/application~1json/schema/properties/data/required/1": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
+    },
+    "#/paths/~1createTextBlast/post/requestBody/content/application~1json/schema/properties/data/properties/params": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
+    },
+    "#/paths/~1createTextBlast/post/requestBody/content/application~1json/schema/properties/data/properties/params/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
+    },
+    "#/paths/~1createTextBlast/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
+    },
+    "#/paths/~1createTextBlast/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/1": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
+    },
+    "#/paths/~1createTextBlast/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
+    },
+    "#/paths/~1createTextBlast/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
+    },
+    "#/paths/~1createTextBlast/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/message": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
+    },
+    "#/paths/~1createTextBlast/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/message/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
+    },
+    "#/paths/~1createTextBlast/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/message/required/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
+    },
+    "#/paths/~1createTextBlast/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/message/required/1": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
+    },
+    "#/paths/~1createTextBlast/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/message/required/2": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
+    },
+    "#/paths/~1createTextBlast/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/message/properties/text": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
+    },
+    "#/paths/~1createTextBlast/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/message/properties/text/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
+    },
+    "#/paths/~1createTextBlast/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/message/properties/text/maxLength": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
+    },
+    "#/paths/~1createTextBlast/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/message/properties/to": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
+    },
+    "#/paths/~1createTextBlast/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/message/properties/to/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
+    },
+    "#/paths/~1createTextBlast/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/message/properties/to/items/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
+    },
+    "#/paths/~1createTextBlast/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/message/properties/showOnEventPage": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
+    },
+    "#/paths/~1createTextBlast/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/message/properties/showOnEventPage/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
+    },
+    "#/paths/~1createTextBlast/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/message/properties/images": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
+    },
+    "#/paths/~1createTextBlast/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/message/properties/images/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
+    },
+    "#/paths/~1createTextBlast/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/message/properties/images/maxItems": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
+    },
+    "#/paths/~1createTextBlast/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/message/properties/images/items/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
+    },
+    "#/paths/~1createTextBlast/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/message/properties/images/items/additionalProperties": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
+    },
+    "#/paths/~1createTextBlast/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/message/additionalProperties": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
+    },
+    "#/paths/~1createTextBlast/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
+    },
+    "#/paths/~1createTextBlast/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
+    },
+    "#/paths/~1createTextBlast/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
+    },
+    "#/paths/~1createTextBlast/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
+    },
+    "#/paths/~1createTextBlast/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
+    },
+    "#/paths/~1createTextBlast/post/requestBody/content/application~1json/schema/properties/data/properties/userId": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
+    },
+    "#/paths/~1createTextBlast/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
+    },
+    "#/paths/~1createTextBlast/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
+    },
+    "#/paths/~1createTextBlast/post/requestBody/content/application~1json/schema/properties/data/additionalProperties": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
+    },
+    "#/paths/~1createTextBlast/post/requestBody/content/application~1json/schema/additionalProperties": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
     },
     "#/paths/~1createTextBlast/post/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
-    "#/paths/~1createTextBlast/post/responses/default/$ref": {
-      "classification": "explicit-unknown",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+    "#/paths/~1createTextBlast/post/responses/default/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createTextBlast/post/responses/200/content/application~1json"
+    },
+    "#/paths/~1createTextBlast/post/responses/default/content/application~1json/schema/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createTextBlast/post/responses/200/content/application~1json/schema/$ref"
+    },
+    "#/paths/~1createTextBlast/post/security/0/firebaseBearer": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createTextBlast/post/security/0/firebaseBearer"
     },
     "#/paths/~1addInvitedGuestsAsHost/post/operationId": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/operationId"
     },
-    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/$ref": {
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/required": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/required"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/type"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/required/0"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/type"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/required/0"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/required/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/required/1"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/type"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId/type"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/guests": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/guests"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/guests/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/guests/type"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/guests/items/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/guests/items/type"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/guests/items/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/guests/items/additionalProperties"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/1"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/userId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/userId"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/additionalProperties"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/additionalProperties"
     },
     "#/paths/~1addInvitedGuestsAsHost/post/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
-    "#/paths/~1addInvitedGuestsAsHost/post/responses/default/$ref": {
-      "classification": "explicit-unknown",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+    "#/paths/~1addInvitedGuestsAsHost/post/responses/default/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/responses/200/content/application~1json"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/responses/default/content/application~1json/schema/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/responses/200/content/application~1json/schema/$ref"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/security/0/firebaseBearer": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/security/0/firebaseBearer"
     },
     "#/paths/~1createCohostRequest/post/operationId": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/operationId"
     },
-    "#/paths/~1createCohostRequest/post/requestBody/$ref": {
+    "#/paths/~1createCohostRequest/post/requestBody/required": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/required"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/type"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/required/0"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/type"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/required/0"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/required/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/required/1"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/type"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId/type"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/targetUserId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/targetUserId"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/targetUserId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/targetUserId/type"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/1"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/userId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/userId"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/additionalProperties"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/additionalProperties"
     },
     "#/paths/~1createCohostRequest/post/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
-    "#/paths/~1createCohostRequest/post/responses/default/$ref": {
-      "classification": "explicit-unknown",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+    "#/paths/~1createCohostRequest/post/responses/default/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/responses/200/content/application~1json"
+    },
+    "#/paths/~1createCohostRequest/post/responses/default/content/application~1json/schema/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/responses/200/content/application~1json/schema/$ref"
+    },
+    "#/paths/~1createCohostRequest/post/security/0/firebaseBearer": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/security/0/firebaseBearer"
     },
     "#/paths/~1deleteCohostRequest/post/operationId": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/operationId"
     },
-    "#/paths/~1deleteCohostRequest/post/requestBody/$ref": {
+    "#/paths/~1deleteCohostRequest/post/requestBody/required": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/required"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/type"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/required/0"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/type"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/required/0"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/required/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/required/1"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/type"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId/type"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/targetUserId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/targetUserId"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/targetUserId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/targetUserId/type"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/1"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/userId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/userId"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/additionalProperties"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/additionalProperties"
     },
     "#/paths/~1deleteCohostRequest/post/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
-    "#/paths/~1deleteCohostRequest/post/responses/default/$ref": {
-      "classification": "explicit-unknown",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+    "#/paths/~1deleteCohostRequest/post/responses/default/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/responses/200/content/application~1json"
+    },
+    "#/paths/~1deleteCohostRequest/post/responses/default/content/application~1json/schema/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/responses/200/content/application~1json/schema/$ref"
+    },
+    "#/paths/~1deleteCohostRequest/post/security/0/firebaseBearer": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/security/0/firebaseBearer"
     },
     "#/paths/~1removeCohost/post/operationId": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/operationId"
     },
-    "#/paths/~1removeCohost/post/requestBody/$ref": {
+    "#/paths/~1removeCohost/post/requestBody/required": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/required"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/type"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/required/0"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/type"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/required/0"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/required/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/required/1"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/params": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/params"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/params/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/params/type"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId/type"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/targetUserId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/targetUserId"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/targetUserId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/targetUserId/type"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/1"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/userId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/userId"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/additionalProperties"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/additionalProperties"
     },
     "#/paths/~1removeCohost/post/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
-    "#/paths/~1removeCohost/post/responses/default/$ref": {
-      "classification": "explicit-unknown",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+    "#/paths/~1removeCohost/post/responses/default/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/responses/200/content/application~1json"
+    },
+    "#/paths/~1removeCohost/post/responses/default/content/application~1json/schema/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/responses/200/content/application~1json/schema/$ref"
+    },
+    "#/paths/~1removeCohost/post/security/0/firebaseBearer": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/security/0/firebaseBearer"
     },
     "#/paths/~1generateEventCohostLink/post/operationId": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/operationId"
     },
-    "#/paths/~1generateEventCohostLink/post/requestBody/$ref": {
+    "#/paths/~1generateEventCohostLink/post/requestBody/required": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/required"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/type"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/required/0"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/type"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/required/0"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/required/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/required/1"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/type"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId/type"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/userId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/userId"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/additionalProperties"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/additionalProperties"
     },
     "#/paths/~1generateEventCohostLink/post/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
-    "#/paths/~1generateEventCohostLink/post/responses/default/$ref": {
-      "classification": "explicit-unknown",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+    "#/paths/~1generateEventCohostLink/post/responses/default/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/responses/200/content/application~1json"
+    },
+    "#/paths/~1generateEventCohostLink/post/responses/default/content/application~1json/schema/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/responses/200/content/application~1json/schema/$ref"
+    },
+    "#/paths/~1generateEventCohostLink/post/security/0/firebaseBearer": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/security/0/firebaseBearer"
     },
     "#/paths/~1revokeEventCohostLink/post/operationId": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/operationId"
     },
-    "#/paths/~1revokeEventCohostLink/post/requestBody/$ref": {
+    "#/paths/~1revokeEventCohostLink/post/requestBody/required": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/required"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/type"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/required/0"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/type"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/required/0"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/required/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/required/1"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/type"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId/type"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/userId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/userId"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/additionalProperties"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/additionalProperties"
     },
     "#/paths/~1revokeEventCohostLink/post/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
-    "#/paths/~1revokeEventCohostLink/post/responses/default/$ref": {
-      "classification": "explicit-unknown",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+    "#/paths/~1revokeEventCohostLink/post/responses/default/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/responses/200/content/application~1json"
+    },
+    "#/paths/~1revokeEventCohostLink/post/responses/default/content/application~1json/schema/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/responses/200/content/application~1json/schema/$ref"
+    },
+    "#/paths/~1revokeEventCohostLink/post/security/0/firebaseBearer": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/security/0/firebaseBearer"
     },
     "#/paths/~1getMyUpcomingEventsForHomePage/post/operationId": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyUpcomingEventsForHomePage/post/operationId"
     },
-    "#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/$ref": {
+    "#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/required": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/required"
+    },
+    "#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/content/application~1json"
+    },
+    "#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/content/application~1json/schema/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/content/application~1json/schema/type"
+    },
+    "#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/content/application~1json/schema/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/content/application~1json/schema/required/0"
+    },
+    "#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data"
+    },
+    "#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/type"
+    },
+    "#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/required/0"
+    },
+    "#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/required/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/required/1"
+    },
+    "#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/properties/params": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/properties/params"
+    },
+    "#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/properties/params/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/properties/params/type"
+    },
+    "#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties"
+    },
+    "#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId"
+    },
+    "#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type"
+    },
+    "#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId"
+    },
+    "#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type"
+    },
+    "#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format"
+    },
+    "#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/properties/userId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/properties/userId"
+    },
+    "#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0"
+    },
+    "#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1"
+    },
+    "#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/additionalProperties"
+    },
+    "#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/content/application~1json/schema/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/content/application~1json/schema/additionalProperties"
     },
     "#/paths/~1getMyUpcomingEventsForHomePage/post/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
-    "#/paths/~1getMyUpcomingEventsForHomePage/post/responses/default/$ref": {
-      "classification": "explicit-unknown",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+    "#/paths/~1getMyUpcomingEventsForHomePage/post/responses/default/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyUpcomingEventsForHomePage/post/responses/200/content/application~1json"
+    },
+    "#/paths/~1getMyUpcomingEventsForHomePage/post/responses/default/content/application~1json/schema/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyUpcomingEventsForHomePage/post/responses/200/content/application~1json/schema/$ref"
+    },
+    "#/paths/~1getMyUpcomingEventsForHomePage/post/security/0/firebaseBearer": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyUpcomingEventsForHomePage/post/security/0/firebaseBearer"
     },
     "#/paths/~1getMyPastEventsForHomePage/post/operationId": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyPastEventsForHomePage/post/operationId"
     },
-    "#/paths/~1getMyPastEventsForHomePage/post/requestBody/$ref": {
+    "#/paths/~1getMyPastEventsForHomePage/post/requestBody/required": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyPastEventsForHomePage/post/requestBody"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyPastEventsForHomePage/post/requestBody/required"
+    },
+    "#/paths/~1getMyPastEventsForHomePage/post/requestBody/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyPastEventsForHomePage/post/requestBody/content/application~1json"
+    },
+    "#/paths/~1getMyPastEventsForHomePage/post/requestBody/content/application~1json/schema/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyPastEventsForHomePage/post/requestBody/content/application~1json/schema/type"
+    },
+    "#/paths/~1getMyPastEventsForHomePage/post/requestBody/content/application~1json/schema/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyPastEventsForHomePage/post/requestBody/content/application~1json/schema/required/0"
+    },
+    "#/paths/~1getMyPastEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyPastEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data"
+    },
+    "#/paths/~1getMyPastEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyPastEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/type"
+    },
+    "#/paths/~1getMyPastEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyPastEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/required/0"
+    },
+    "#/paths/~1getMyPastEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/required/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyPastEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/required/1"
+    },
+    "#/paths/~1getMyPastEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/properties/params": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyPastEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/properties/params"
+    },
+    "#/paths/~1getMyPastEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/properties/params/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyPastEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/properties/params/type"
+    },
+    "#/paths/~1getMyPastEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyPastEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties"
+    },
+    "#/paths/~1getMyPastEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyPastEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId"
+    },
+    "#/paths/~1getMyPastEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyPastEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type"
+    },
+    "#/paths/~1getMyPastEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyPastEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId"
+    },
+    "#/paths/~1getMyPastEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyPastEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type"
+    },
+    "#/paths/~1getMyPastEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyPastEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format"
+    },
+    "#/paths/~1getMyPastEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/properties/userId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyPastEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/properties/userId"
+    },
+    "#/paths/~1getMyPastEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyPastEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0"
+    },
+    "#/paths/~1getMyPastEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyPastEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1"
+    },
+    "#/paths/~1getMyPastEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyPastEventsForHomePage/post/requestBody/content/application~1json/schema/properties/data/additionalProperties"
+    },
+    "#/paths/~1getMyPastEventsForHomePage/post/requestBody/content/application~1json/schema/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyPastEventsForHomePage/post/requestBody/content/application~1json/schema/additionalProperties"
     },
     "#/paths/~1getMyPastEventsForHomePage/post/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
-    "#/paths/~1getMyPastEventsForHomePage/post/responses/default/$ref": {
-      "classification": "explicit-unknown",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+    "#/paths/~1getMyPastEventsForHomePage/post/responses/default/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyPastEventsForHomePage/post/responses/200/content/application~1json"
+    },
+    "#/paths/~1getMyPastEventsForHomePage/post/responses/default/content/application~1json/schema/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyPastEventsForHomePage/post/responses/200/content/application~1json/schema/$ref"
+    },
+    "#/paths/~1getMyPastEventsForHomePage/post/security/0/firebaseBearer": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyPastEventsForHomePage/post/security/0/firebaseBearer"
     },
     "#/paths/~1addGuest/post/operationId": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addGuest/post/operationId"
     },
-    "#/paths/~1addGuest/post/requestBody/$ref": {
+    "#/paths/~1addGuest/post/requestBody/required": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addGuest/post/requestBody"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addGuest/post/requestBody/required"
+    },
+    "#/paths/~1addGuest/post/requestBody/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addGuest/post/requestBody/content/application~1json"
+    },
+    "#/paths/~1addGuest/post/requestBody/content/application~1json/schema/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addGuest/post/requestBody/content/application~1json/schema/type"
+    },
+    "#/paths/~1addGuest/post/requestBody/content/application~1json/schema/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addGuest/post/requestBody/content/application~1json/schema/required/0"
+    },
+    "#/paths/~1addGuest/post/requestBody/content/application~1json/schema/properties/data": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addGuest/post/requestBody/content/application~1json/schema/properties/data"
+    },
+    "#/paths/~1addGuest/post/requestBody/content/application~1json/schema/properties/data/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addGuest/post/requestBody/content/application~1json/schema/properties/data/type"
+    },
+    "#/paths/~1addGuest/post/requestBody/content/application~1json/schema/properties/data/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addGuest/post/requestBody/content/application~1json/schema/properties/data/required/0"
+    },
+    "#/paths/~1addGuest/post/requestBody/content/application~1json/schema/properties/data/required/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addGuest/post/requestBody/content/application~1json/schema/properties/data/required/1"
+    },
+    "#/paths/~1addGuest/post/requestBody/content/application~1json/schema/properties/data/properties/params": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addGuest/post/requestBody/content/application~1json/schema/properties/data/properties/params"
+    },
+    "#/paths/~1addGuest/post/requestBody/content/application~1json/schema/properties/data/properties/params/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addGuest/post/requestBody/content/application~1json/schema/properties/data/properties/params/type"
+    },
+    "#/paths/~1addGuest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addGuest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId"
+    },
+    "#/paths/~1addGuest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addGuest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId/type"
+    },
+    "#/paths/~1addGuest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/rsvp": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addGuest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/rsvp"
+    },
+    "#/paths/~1addGuest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/rsvp/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addGuest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/rsvp/$ref"
+    },
+    "#/paths/~1addGuest/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addGuest/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties"
+    },
+    "#/paths/~1addGuest/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addGuest/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0"
+    },
+    "#/paths/~1addGuest/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addGuest/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/1"
+    },
+    "#/paths/~1addGuest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addGuest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId"
+    },
+    "#/paths/~1addGuest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addGuest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type"
+    },
+    "#/paths/~1addGuest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addGuest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId"
+    },
+    "#/paths/~1addGuest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addGuest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type"
+    },
+    "#/paths/~1addGuest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addGuest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format"
+    },
+    "#/paths/~1addGuest/post/requestBody/content/application~1json/schema/properties/data/properties/userId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addGuest/post/requestBody/content/application~1json/schema/properties/data/properties/userId"
+    },
+    "#/paths/~1addGuest/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addGuest/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0"
+    },
+    "#/paths/~1addGuest/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addGuest/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1"
+    },
+    "#/paths/~1addGuest/post/requestBody/content/application~1json/schema/properties/data/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addGuest/post/requestBody/content/application~1json/schema/properties/data/additionalProperties"
+    },
+    "#/paths/~1addGuest/post/requestBody/content/application~1json/schema/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addGuest/post/requestBody/content/application~1json/schema/additionalProperties"
     },
     "#/paths/~1addGuest/post/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
-    "#/paths/~1addGuest/post/responses/default/$ref": {
-      "classification": "explicit-unknown",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+    "#/paths/~1addGuest/post/responses/default/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addGuest/post/responses/200/content/application~1json"
+    },
+    "#/paths/~1addGuest/post/responses/default/content/application~1json/schema/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addGuest/post/responses/200/content/application~1json/schema/$ref"
+    },
+    "#/paths/~1addGuest/post/security/0/firebaseBearer": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addGuest/post/security/0/firebaseBearer"
     },
     "#/paths/~1markEventInterest/post/operationId": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1markEventInterest/post/operationId"
     },
-    "#/paths/~1markEventInterest/post/requestBody/$ref": {
+    "#/paths/~1markEventInterest/post/requestBody/required": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1markEventInterest/post/requestBody"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1markEventInterest/post/requestBody/required"
+    },
+    "#/paths/~1markEventInterest/post/requestBody/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1markEventInterest/post/requestBody/content/application~1json"
+    },
+    "#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/type"
+    },
+    "#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/required/0"
+    },
+    "#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data"
+    },
+    "#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/type"
+    },
+    "#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/required/0"
+    },
+    "#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/required/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/required/1"
+    },
+    "#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/properties/params": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/properties/params"
+    },
+    "#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/properties/params/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/properties/params/type"
+    },
+    "#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId"
+    },
+    "#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId/type"
+    },
+    "#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/interested": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/interested"
+    },
+    "#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/interested/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/interested/type"
+    },
+    "#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/source": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/source"
+    },
+    "#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/source/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/source/type"
+    },
+    "#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties"
+    },
+    "#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0"
+    },
+    "#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/1"
+    },
+    "#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/2": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/2"
+    },
+    "#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId"
+    },
+    "#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type"
+    },
+    "#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId"
+    },
+    "#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type"
+    },
+    "#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format"
+    },
+    "#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/properties/userId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/properties/userId"
+    },
+    "#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0"
+    },
+    "#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1"
+    },
+    "#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/properties/data/additionalProperties"
+    },
+    "#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/additionalProperties"
     },
     "#/paths/~1markEventInterest/post/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
-    "#/paths/~1markEventInterest/post/responses/default/$ref": {
-      "classification": "explicit-unknown",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+    "#/paths/~1markEventInterest/post/responses/default/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1markEventInterest/post/responses/200/content/application~1json"
+    },
+    "#/paths/~1markEventInterest/post/responses/default/content/application~1json/schema/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1markEventInterest/post/responses/200/content/application~1json/schema/$ref"
+    },
+    "#/paths/~1markEventInterest/post/security/0/firebaseBearer": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1markEventInterest/post/security/0/firebaseBearer"
     },
     "#/paths/~1getCurrentGuest/post/operationId": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getCurrentGuest/post/operationId"
     },
-    "#/paths/~1getCurrentGuest/post/requestBody/$ref": {
+    "#/paths/~1getCurrentGuest/post/requestBody/required": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getCurrentGuest/post/requestBody"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getCurrentGuest/post/requestBody/required"
+    },
+    "#/paths/~1getCurrentGuest/post/requestBody/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getCurrentGuest/post/requestBody/content/application~1json"
+    },
+    "#/paths/~1getCurrentGuest/post/requestBody/content/application~1json/schema/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getCurrentGuest/post/requestBody/content/application~1json/schema/type"
+    },
+    "#/paths/~1getCurrentGuest/post/requestBody/content/application~1json/schema/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getCurrentGuest/post/requestBody/content/application~1json/schema/required/0"
+    },
+    "#/paths/~1getCurrentGuest/post/requestBody/content/application~1json/schema/properties/data": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getCurrentGuest/post/requestBody/content/application~1json/schema/properties/data"
+    },
+    "#/paths/~1getCurrentGuest/post/requestBody/content/application~1json/schema/properties/data/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getCurrentGuest/post/requestBody/content/application~1json/schema/properties/data/type"
+    },
+    "#/paths/~1getCurrentGuest/post/requestBody/content/application~1json/schema/properties/data/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getCurrentGuest/post/requestBody/content/application~1json/schema/properties/data/required/0"
+    },
+    "#/paths/~1getCurrentGuest/post/requestBody/content/application~1json/schema/properties/data/required/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getCurrentGuest/post/requestBody/content/application~1json/schema/properties/data/required/1"
+    },
+    "#/paths/~1getCurrentGuest/post/requestBody/content/application~1json/schema/properties/data/properties/params": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getCurrentGuest/post/requestBody/content/application~1json/schema/properties/data/properties/params"
+    },
+    "#/paths/~1getCurrentGuest/post/requestBody/content/application~1json/schema/properties/data/properties/params/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getCurrentGuest/post/requestBody/content/application~1json/schema/properties/data/properties/params/type"
+    },
+    "#/paths/~1getCurrentGuest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getCurrentGuest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId"
+    },
+    "#/paths/~1getCurrentGuest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getCurrentGuest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId/type"
+    },
+    "#/paths/~1getCurrentGuest/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getCurrentGuest/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties"
+    },
+    "#/paths/~1getCurrentGuest/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getCurrentGuest/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0"
+    },
+    "#/paths/~1getCurrentGuest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getCurrentGuest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId"
+    },
+    "#/paths/~1getCurrentGuest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getCurrentGuest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type"
+    },
+    "#/paths/~1getCurrentGuest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getCurrentGuest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId"
+    },
+    "#/paths/~1getCurrentGuest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getCurrentGuest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type"
+    },
+    "#/paths/~1getCurrentGuest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getCurrentGuest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format"
+    },
+    "#/paths/~1getCurrentGuest/post/requestBody/content/application~1json/schema/properties/data/properties/userId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getCurrentGuest/post/requestBody/content/application~1json/schema/properties/data/properties/userId"
+    },
+    "#/paths/~1getCurrentGuest/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getCurrentGuest/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0"
+    },
+    "#/paths/~1getCurrentGuest/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getCurrentGuest/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1"
+    },
+    "#/paths/~1getCurrentGuest/post/requestBody/content/application~1json/schema/properties/data/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getCurrentGuest/post/requestBody/content/application~1json/schema/properties/data/additionalProperties"
+    },
+    "#/paths/~1getCurrentGuest/post/requestBody/content/application~1json/schema/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getCurrentGuest/post/requestBody/content/application~1json/schema/additionalProperties"
     },
     "#/paths/~1getCurrentGuest/post/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
-    "#/paths/~1getCurrentGuest/post/responses/default/$ref": {
-      "classification": "explicit-unknown",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+    "#/paths/~1getCurrentGuest/post/responses/default/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getCurrentGuest/post/responses/200/content/application~1json"
+    },
+    "#/paths/~1getCurrentGuest/post/responses/default/content/application~1json/schema/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getCurrentGuest/post/responses/200/content/application~1json/schema/$ref"
+    },
+    "#/paths/~1getCurrentGuest/post/security/0/firebaseBearer": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getCurrentGuest/post/security/0/firebaseBearer"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/operationId": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/operationId"
     },
-    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/parameters/0/$ref": {
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/parameters/0/name": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/parameters/0"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/parameters/0/name"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/parameters/0/in": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/parameters/0/in"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/parameters/0/required": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/parameters/0/required"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/parameters/0/schema/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/parameters/0/schema/type"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
-    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/responses/default/$ref": {
-      "classification": "explicit-unknown",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/responses/default/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/responses/200/content/application~1json"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/responses/default/content/application~1json/schema/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/responses/200/content/application~1json/schema/$ref"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/security/0/firebaseBearer": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/security/0/firebaseBearer"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/servers/0/url": {
       "classification": "typescript-derived-inference",
@@ -625,25 +2396,77 @@
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/operationId"
     },
-    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/0/$ref": {
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/0/name": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/0"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/0/name"
     },
-    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/1/$ref": {
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/0/in": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/1"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/0/in"
     },
-    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/requestBody/$ref": {
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/0/required": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/requestBody"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/0/required"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/0/schema/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/0/schema/type"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/1/name": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/1/name"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/1/in": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/1/in"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/1/required": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/1/required"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/1/schema/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/1/schema/type"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/1/schema/items/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/1/schema/items/type"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/1/style": {
+      "classification": "typescript-derived-inference",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#update-mask-serialization"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/1/explode": {
+      "classification": "typescript-derived-inference",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#update-mask-serialization"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/requestBody/required": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/requestBody/required"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/requestBody/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/requestBody/content/application~1json"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/requestBody/content/application~1json/schema/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/requestBody/content/application~1json/schema/$ref"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
-    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/responses/default/$ref": {
-      "classification": "explicit-unknown",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/responses/default/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/responses/200/content/application~1json"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/responses/default/content/application~1json/schema/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/responses/200/content/application~1json/schema/$ref"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/security/0/firebaseBearer": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/security/0/firebaseBearer"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/servers/0/url": {
       "classification": "typescript-derived-inference",
@@ -653,21 +2476,53 @@
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/operationId"
     },
-    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/parameters/0/$ref": {
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/parameters/0/name": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/parameters/0"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/parameters/0/name"
     },
-    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/parameters/1/$ref": {
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/parameters/0/in": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/parameters/1"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/parameters/0/in"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/parameters/0/required": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/parameters/0/required"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/parameters/0/schema/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/parameters/0/schema/type"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/parameters/1/name": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/parameters/1/name"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/parameters/1/in": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/parameters/1/in"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/parameters/1/required": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/parameters/1/required"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/parameters/1/schema/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/parameters/1/schema/type"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
-    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/responses/default/$ref": {
-      "classification": "explicit-unknown",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/responses/default/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/responses/200/content/application~1json"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/responses/default/content/application~1json/schema/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/responses/200/content/application~1json/schema/$ref"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/security/0/firebaseBearer": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/security/0/firebaseBearer"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/servers/0/url": {
       "classification": "typescript-derived-inference",
@@ -677,25 +2532,73 @@
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/operationId"
     },
-    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/0/$ref": {
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/0/name": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/0"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/0/name"
     },
-    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/1/$ref": {
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/0/in": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/1"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/0/in"
     },
-    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/2/$ref": {
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/0/required": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/2"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/0/required"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/0/schema/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/0/schema/type"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/1/name": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/1/name"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/1/in": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/1/in"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/1/required": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/1/required"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/1/schema/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/1/schema/type"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/1/schema/default": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/1/schema/default"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/2/name": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/2/name"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/2/in": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/2/in"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/2/required": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/2/required"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/2/schema/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/parameters/2/schema/type"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
-    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/responses/default/$ref": {
-      "classification": "explicit-unknown",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/responses/default/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/responses/200/content/application~1json"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/responses/default/content/application~1json/schema/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/responses/200/content/application~1json/schema/$ref"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/security/0/firebaseBearer": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/security/0/firebaseBearer"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/servers/0/url": {
       "classification": "typescript-derived-inference",
@@ -705,17 +2608,65 @@
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1token/post/operationId"
     },
-    "#/paths/~1v1~1token/post/requestBody/$ref": {
+    "#/paths/~1v1~1token/post/requestBody/required": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1token/post/requestBody"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1token/post/requestBody/required"
+    },
+    "#/paths/~1v1~1token/post/requestBody/content/application~1x-www-form-urlencoded": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1token/post/requestBody/content/application~1x-www-form-urlencoded"
+    },
+    "#/paths/~1v1~1token/post/requestBody/content/application~1x-www-form-urlencoded/schema/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1token/post/requestBody/content/application~1x-www-form-urlencoded/schema/type"
+    },
+    "#/paths/~1v1~1token/post/requestBody/content/application~1x-www-form-urlencoded/schema/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1token/post/requestBody/content/application~1x-www-form-urlencoded/schema/required/0"
+    },
+    "#/paths/~1v1~1token/post/requestBody/content/application~1x-www-form-urlencoded/schema/required/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1token/post/requestBody/content/application~1x-www-form-urlencoded/schema/required/1"
+    },
+    "#/paths/~1v1~1token/post/requestBody/content/application~1x-www-form-urlencoded/schema/properties/grant_type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1token/post/requestBody/content/application~1x-www-form-urlencoded/schema/properties/grant_type"
+    },
+    "#/paths/~1v1~1token/post/requestBody/content/application~1x-www-form-urlencoded/schema/properties/grant_type/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1token/post/requestBody/content/application~1x-www-form-urlencoded/schema/properties/grant_type/type"
+    },
+    "#/paths/~1v1~1token/post/requestBody/content/application~1x-www-form-urlencoded/schema/properties/grant_type/enum/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1token/post/requestBody/content/application~1x-www-form-urlencoded/schema/properties/grant_type/enum/0"
+    },
+    "#/paths/~1v1~1token/post/requestBody/content/application~1x-www-form-urlencoded/schema/properties/refresh_token": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1token/post/requestBody/content/application~1x-www-form-urlencoded/schema/properties/refresh_token"
+    },
+    "#/paths/~1v1~1token/post/requestBody/content/application~1x-www-form-urlencoded/schema/properties/refresh_token/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1token/post/requestBody/content/application~1x-www-form-urlencoded/schema/properties/refresh_token/type"
+    },
+    "#/paths/~1v1~1token/post/requestBody/content/application~1x-www-form-urlencoded/schema/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1token/post/requestBody/content/application~1x-www-form-urlencoded/schema/additionalProperties"
     },
     "#/paths/~1v1~1token/post/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
-    "#/paths/~1v1~1token/post/responses/default/$ref": {
-      "classification": "explicit-unknown",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+    "#/paths/~1v1~1token/post/responses/default/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1token/post/responses/200/content/application~1json"
+    },
+    "#/paths/~1v1~1token/post/responses/default/content/application~1json/schema/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1token/post/responses/200/content/application~1json/schema/$ref"
+    },
+    "#/paths/~1v1~1token/post/security/0/firebaseApiKey": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1token/post/security/0/firebaseApiKey"
     },
     "#/paths/~1v1~1token/post/servers/0/url": {
       "classification": "typescript-derived-inference",
@@ -725,49 +2676,373 @@
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post/operationId"
     },
-    "#/paths/~1sendAuthCodeTrusted/post/requestBody/$ref": {
+    "#/paths/~1sendAuthCodeTrusted/post/requestBody/required": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post/requestBody"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post/requestBody/required"
+    },
+    "#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json"
+    },
+    "#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/type"
+    },
+    "#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/required/0"
+    },
+    "#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data"
+    },
+    "#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/type"
+    },
+    "#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/required/0"
+    },
+    "#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/required/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/required/1"
+    },
+    "#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/params": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/params"
+    },
+    "#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/params/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/params/type"
+    },
+    "#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0"
+    },
+    "#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/1"
+    },
+    "#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/2": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/2"
+    },
+    "#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/3": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/3"
+    },
+    "#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/4": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/4"
+    },
+    "#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/5": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/5"
+    },
+    "#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/displayName": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/displayName"
+    },
+    "#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/displayName/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/displayName/type"
+    },
+    "#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/phoneNumber": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/phoneNumber"
+    },
+    "#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/phoneNumber/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/phoneNumber/type"
+    },
+    "#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/silent": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/silent"
+    },
+    "#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/silent/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/silent/type"
+    },
+    "#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/channelPreference": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/channelPreference"
+    },
+    "#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/channelPreference/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/channelPreference/type"
+    },
+    "#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/channelPreference/enum/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/channelPreference/enum/0"
+    },
+    "#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/captchaToken": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/captchaToken"
+    },
+    "#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/captchaToken/type/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/captchaToken/type/0"
+    },
+    "#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/captchaToken/type/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/captchaToken/type/1"
+    },
+    "#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/useAppleBusinessUpdates": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/useAppleBusinessUpdates"
+    },
+    "#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/useAppleBusinessUpdates/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/useAppleBusinessUpdates/type"
+    },
+    "#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties"
+    },
+    "#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId"
+    },
+    "#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type"
+    },
+    "#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId"
+    },
+    "#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type"
+    },
+    "#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format"
+    },
+    "#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/properties/data/additionalProperties"
+    },
+    "#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/additionalProperties"
     },
     "#/paths/~1sendAuthCodeTrusted/post/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
-    "#/paths/~1sendAuthCodeTrusted/post/responses/default/$ref": {
-      "classification": "explicit-unknown",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+    "#/paths/~1sendAuthCodeTrusted/post/responses/default/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post/responses/200/content/application~1json"
+    },
+    "#/paths/~1sendAuthCodeTrusted/post/responses/default/content/application~1json/schema/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post/responses/200/content/application~1json/schema/$ref"
     },
     "#/paths/~1getLoginToken/post/operationId": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getLoginToken/post/operationId"
     },
-    "#/paths/~1getLoginToken/post/requestBody/$ref": {
+    "#/paths/~1getLoginToken/post/requestBody/required": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getLoginToken/post/requestBody"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getLoginToken/post/requestBody/required"
+    },
+    "#/paths/~1getLoginToken/post/requestBody/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getLoginToken/post/requestBody/content/application~1json"
+    },
+    "#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/type"
+    },
+    "#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/required/0"
+    },
+    "#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data"
+    },
+    "#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/type"
+    },
+    "#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/required/0"
+    },
+    "#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/required/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/required/1"
+    },
+    "#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/properties/params": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/properties/params"
+    },
+    "#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/properties/params/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/properties/params/type"
+    },
+    "#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0"
+    },
+    "#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/1"
+    },
+    "#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/2": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/2"
+    },
+    "#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/3": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/3"
+    },
+    "#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/phoneNumber": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/phoneNumber"
+    },
+    "#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/phoneNumber/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/phoneNumber/type"
+    },
+    "#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/authCode": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/authCode"
+    },
+    "#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/authCode/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/authCode/type"
+    },
+    "#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/affiliateId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/affiliateId"
+    },
+    "#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/affiliateId/type/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/affiliateId/type/0"
+    },
+    "#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/affiliateId/type/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/affiliateId/type/1"
+    },
+    "#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/utms": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/utms"
+    },
+    "#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/utms/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/utms/type"
+    },
+    "#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/utms/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/utms/additionalProperties"
+    },
+    "#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties"
+    },
+    "#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId"
+    },
+    "#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type"
+    },
+    "#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId"
+    },
+    "#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type"
+    },
+    "#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format"
+    },
+    "#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/properties/data/additionalProperties"
+    },
+    "#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/additionalProperties"
     },
     "#/paths/~1getLoginToken/post/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
-    "#/paths/~1getLoginToken/post/responses/default/$ref": {
-      "classification": "explicit-unknown",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+    "#/paths/~1getLoginToken/post/responses/default/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getLoginToken/post/responses/200/content/application~1json"
+    },
+    "#/paths/~1getLoginToken/post/responses/default/content/application~1json/schema/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getLoginToken/post/responses/200/content/application~1json/schema/$ref"
     },
     "#/paths/~1v1~1accounts:signInWithCustomToken/post/operationId": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1accounts:signInWithCustomToken/post/operationId"
     },
-    "#/paths/~1v1~1accounts:signInWithCustomToken/post/requestBody/$ref": {
+    "#/paths/~1v1~1accounts:signInWithCustomToken/post/requestBody/required": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1accounts:signInWithCustomToken/post/requestBody"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1accounts:signInWithCustomToken/post/requestBody/required"
+    },
+    "#/paths/~1v1~1accounts:signInWithCustomToken/post/requestBody/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1accounts:signInWithCustomToken/post/requestBody/content/application~1json"
+    },
+    "#/paths/~1v1~1accounts:signInWithCustomToken/post/requestBody/content/application~1json/schema/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1accounts:signInWithCustomToken/post/requestBody/content/application~1json/schema/type"
+    },
+    "#/paths/~1v1~1accounts:signInWithCustomToken/post/requestBody/content/application~1json/schema/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1accounts:signInWithCustomToken/post/requestBody/content/application~1json/schema/required/0"
+    },
+    "#/paths/~1v1~1accounts:signInWithCustomToken/post/requestBody/content/application~1json/schema/required/1": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1accounts:signInWithCustomToken/post/requestBody/content/application~1json/schema/required/1"
+    },
+    "#/paths/~1v1~1accounts:signInWithCustomToken/post/requestBody/content/application~1json/schema/properties/token": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1accounts:signInWithCustomToken/post/requestBody/content/application~1json/schema/properties/token"
+    },
+    "#/paths/~1v1~1accounts:signInWithCustomToken/post/requestBody/content/application~1json/schema/properties/token/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1accounts:signInWithCustomToken/post/requestBody/content/application~1json/schema/properties/token/type"
+    },
+    "#/paths/~1v1~1accounts:signInWithCustomToken/post/requestBody/content/application~1json/schema/properties/returnSecureToken": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1accounts:signInWithCustomToken/post/requestBody/content/application~1json/schema/properties/returnSecureToken"
+    },
+    "#/paths/~1v1~1accounts:signInWithCustomToken/post/requestBody/content/application~1json/schema/properties/returnSecureToken/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1accounts:signInWithCustomToken/post/requestBody/content/application~1json/schema/properties/returnSecureToken/type"
+    },
+    "#/paths/~1v1~1accounts:signInWithCustomToken/post/requestBody/content/application~1json/schema/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1accounts:signInWithCustomToken/post/requestBody/content/application~1json/schema/additionalProperties"
     },
     "#/paths/~1v1~1accounts:signInWithCustomToken/post/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
-    "#/paths/~1v1~1accounts:signInWithCustomToken/post/responses/default/$ref": {
-      "classification": "explicit-unknown",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+    "#/paths/~1v1~1accounts:signInWithCustomToken/post/responses/default/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1accounts:signInWithCustomToken/post/responses/200/content/application~1json"
+    },
+    "#/paths/~1v1~1accounts:signInWithCustomToken/post/responses/default/content/application~1json/schema/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1accounts:signInWithCustomToken/post/responses/200/content/application~1json/schema/$ref"
+    },
+    "#/paths/~1v1~1accounts:signInWithCustomToken/post/security/0/firebaseApiKey": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1accounts:signInWithCustomToken/post/security/0/firebaseApiKey"
     },
     "#/paths/~1v1~1accounts:signInWithCustomToken/post/servers/0/url": {
       "classification": "typescript-derived-inference",
@@ -777,17 +3052,49 @@
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1accounts:lookup/post/operationId"
     },
-    "#/paths/~1v1~1accounts:lookup/post/requestBody/$ref": {
+    "#/paths/~1v1~1accounts:lookup/post/requestBody/required": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1accounts:lookup/post/requestBody"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1accounts:lookup/post/requestBody/required"
+    },
+    "#/paths/~1v1~1accounts:lookup/post/requestBody/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1accounts:lookup/post/requestBody/content/application~1json"
+    },
+    "#/paths/~1v1~1accounts:lookup/post/requestBody/content/application~1json/schema/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1accounts:lookup/post/requestBody/content/application~1json/schema/type"
+    },
+    "#/paths/~1v1~1accounts:lookup/post/requestBody/content/application~1json/schema/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1accounts:lookup/post/requestBody/content/application~1json/schema/required/0"
+    },
+    "#/paths/~1v1~1accounts:lookup/post/requestBody/content/application~1json/schema/properties/idToken": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1accounts:lookup/post/requestBody/content/application~1json/schema/properties/idToken"
+    },
+    "#/paths/~1v1~1accounts:lookup/post/requestBody/content/application~1json/schema/properties/idToken/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1accounts:lookup/post/requestBody/content/application~1json/schema/properties/idToken/type"
+    },
+    "#/paths/~1v1~1accounts:lookup/post/requestBody/content/application~1json/schema/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1accounts:lookup/post/requestBody/content/application~1json/schema/additionalProperties"
     },
     "#/paths/~1v1~1accounts:lookup/post/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
-    "#/paths/~1v1~1accounts:lookup/post/responses/default/$ref": {
-      "classification": "explicit-unknown",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+    "#/paths/~1v1~1accounts:lookup/post/responses/default/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1accounts:lookup/post/responses/200/content/application~1json"
+    },
+    "#/paths/~1v1~1accounts:lookup/post/responses/default/content/application~1json/schema/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1accounts:lookup/post/responses/200/content/application~1json/schema/$ref"
+    },
+    "#/paths/~1v1~1accounts:lookup/post/security/0/firebaseApiKey": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1accounts:lookup/post/security/0/firebaseApiKey"
     },
     "#/paths/~1v1~1accounts:lookup/post/servers/0/url": {
       "classification": "typescript-derived-inference",
@@ -805,25 +3112,65 @@
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1uploadPhoto/post/parameters/0/in"
     },
-    "#/paths/~1uploadPhoto/post/parameters/0/schema": {
+    "#/paths/~1uploadPhoto/post/parameters/0/required": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1uploadPhoto/post/parameters/0/schema"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1uploadPhoto/post/parameters/0/required"
     },
     "#/paths/~1uploadPhoto/post/parameters/0/schema/type": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1uploadPhoto/post/parameters/0/schema/type"
     },
-    "#/paths/~1uploadPhoto/post/requestBody/$ref": {
+    "#/paths/~1uploadPhoto/post/parameters/0/schema/enum/0": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1uploadPhoto/post/requestBody"
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1uploadPhoto/post/parameters/0/schema/enum/0"
+    },
+    "#/paths/~1uploadPhoto/post/requestBody/required": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1uploadPhoto/post/requestBody/required"
+    },
+    "#/paths/~1uploadPhoto/post/requestBody/content/multipart~1form-data": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1uploadPhoto/post/requestBody/content/multipart~1form-data"
+    },
+    "#/paths/~1uploadPhoto/post/requestBody/content/multipart~1form-data/schema/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1uploadPhoto/post/requestBody/content/multipart~1form-data/schema/type"
+    },
+    "#/paths/~1uploadPhoto/post/requestBody/content/multipart~1form-data/schema/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1uploadPhoto/post/requestBody/content/multipart~1form-data/schema/required/0"
+    },
+    "#/paths/~1uploadPhoto/post/requestBody/content/multipart~1form-data/schema/properties/file": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1uploadPhoto/post/requestBody/content/multipart~1form-data/schema/properties/file"
+    },
+    "#/paths/~1uploadPhoto/post/requestBody/content/multipart~1form-data/schema/properties/file/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1uploadPhoto/post/requestBody/content/multipart~1form-data/schema/properties/file/type"
+    },
+    "#/paths/~1uploadPhoto/post/requestBody/content/multipart~1form-data/schema/properties/file/format": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1uploadPhoto/post/requestBody/content/multipart~1form-data/schema/properties/file/format"
+    },
+    "#/paths/~1uploadPhoto/post/requestBody/content/multipart~1form-data/schema/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1uploadPhoto/post/requestBody/content/multipart~1form-data/schema/additionalProperties"
     },
     "#/paths/~1uploadPhoto/post/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
-    "#/paths/~1uploadPhoto/post/responses/default/$ref": {
-      "classification": "explicit-unknown",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+    "#/paths/~1uploadPhoto/post/responses/default/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1uploadPhoto/post/responses/200/content/application~1json"
+    },
+    "#/paths/~1uploadPhoto/post/responses/default/content/application~1json/schema/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1uploadPhoto/post/responses/200/content/application~1json/schema/$ref"
+    },
+    "#/paths/~1uploadPhoto/post/security/0/firebaseBearer": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1uploadPhoto/post/security/0/firebaseBearer"
     },
     "#/paths/~1uploadPhoto/post/servers/0/url": {
       "classification": "typescript-derived-inference",
@@ -831,23 +3178,27 @@
     },
     "#/paths/~1posters.json/get/operationId": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1posters.json/get/operationId"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-catalog-fetch"
     },
     "#/paths/~1posters.json/get/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
-    "#/paths/~1posters.json/get/responses/default/$ref": {
-      "classification": "explicit-unknown",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+    "#/paths/~1posters.json/get/responses/default/content/application~1json": {
+      "classification": "typescript-derived-inference",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-catalog-fetch"
+    },
+    "#/paths/~1posters.json/get/responses/default/content/application~1json/schema/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-catalog-fetch"
+    },
+    "#/paths/~1posters.json/get/responses/default/content/application~1json/schema/items/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-catalog-fetch"
     },
     "#/paths/~1posters.json/get/servers/0/url": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1posters.json/get/servers/0/url"
-    },
-    "#/components/securitySchemes/firebaseBearer": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/securitySchemes/firebaseBearer"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-catalog-fetch"
     },
     "#/components/securitySchemes/firebaseBearer/type": {
       "classification": "typescript-derived-inference",
@@ -856,10 +3207,6 @@
     "#/components/securitySchemes/firebaseBearer/scheme": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/components/securitySchemes/firebaseBearer/scheme"
-    },
-    "#/components/securitySchemes/firebaseApiKey": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/securitySchemes/firebaseApiKey"
     },
     "#/components/securitySchemes/firebaseApiKey/type": {
       "classification": "typescript-derived-inference",
@@ -873,569 +3220,297 @@
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/components/securitySchemes/firebaseApiKey/name"
     },
-    "#/components/parameters/EventId": {
+    "#/components/schemas/EventDraft/type": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/type"
     },
-    "#/components/parameters/EventId/name": {
+    "#/components/schemas/EventDraft/required/0": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/required/0"
     },
-    "#/components/parameters/EventId/in": {
+    "#/components/schemas/EventDraft/required/1": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/required/1"
     },
-    "#/components/parameters/EventId/required": {
+    "#/components/schemas/EventDraft/required/2": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/required/2"
     },
-    "#/components/parameters/EventId/schema/type": {
+    "#/components/schemas/EventDraft/required/3": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/required/3"
     },
-    "#/components/parameters/GuestId": {
+    "#/components/schemas/EventDraft/properties/title": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/title"
     },
-    "#/components/parameters/GuestId/name": {
+    "#/components/schemas/EventDraft/properties/startDate": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/startDate"
     },
-    "#/components/parameters/GuestId/in": {
+    "#/components/schemas/EventDraft/properties/startDate/type": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/startDate/type"
     },
-    "#/components/parameters/GuestId/required": {
+    "#/components/schemas/EventDraft/properties/startDate/format": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/startDate/format"
     },
-    "#/components/parameters/GuestId/schema/type": {
+    "#/components/schemas/EventDraft/properties/endDate": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/endDate"
     },
-    "#/components/parameters/CollectionPath": {
+    "#/components/schemas/EventDraft/properties/endDate/type": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/endDate/type"
     },
-    "#/components/parameters/CollectionPath/name": {
+    "#/components/schemas/EventDraft/properties/endDate/format": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/endDate/format"
     },
-    "#/components/parameters/CollectionPath/in": {
+    "#/components/schemas/EventDraft/properties/timezone": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/timezone"
     },
-    "#/components/parameters/CollectionPath/required": {
+    "#/components/schemas/EventDraft/properties/timezone/type": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/timezone/type"
     },
-    "#/components/parameters/CollectionPath/schema/type": {
+    "#/components/schemas/EventDraft/properties/displaySettings": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/displaySettings"
     },
-    "#/components/parameters/UpdateMask": {
+    "#/components/schemas/EventDraft/properties/displaySettings/type": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/displaySettings/type"
     },
-    "#/components/parameters/UpdateMask/name": {
+    "#/components/schemas/EventDraft/properties/displaySettings/additionalProperties": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/displaySettings/additionalProperties"
     },
-    "#/components/parameters/UpdateMask/in": {
+    "#/components/schemas/EventDraft/properties/visibility": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/visibility"
     },
-    "#/components/parameters/UpdateMask/schema/type": {
+    "#/components/schemas/EventDraft/properties/visibility/type": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/visibility/type"
     },
-    "#/components/parameters/PageSize": {
+    "#/components/schemas/EventDraft/properties/visibility/enum/0": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/visibility/enum/0"
     },
-    "#/components/parameters/PageSize/name": {
+    "#/components/schemas/EventDraft/properties/visibility/enum/1": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/visibility/enum/1"
     },
-    "#/components/parameters/PageSize/in": {
+    "#/components/schemas/EventDraft/properties/location": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/location"
     },
-    "#/components/parameters/PageSize/schema/type": {
+    "#/components/schemas/EventDraft/properties/location/type": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/location/type"
     },
-    "#/components/parameters/PageSize/schema/minimum": {
+    "#/components/schemas/EventDraft/properties/address": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/address"
     },
-    "#/components/parameters/PageToken": {
+    "#/components/schemas/EventDraft/properties/address/type": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/address/type"
     },
-    "#/components/parameters/PageToken/name": {
+    "#/components/schemas/EventDraft/properties/description": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/description"
     },
-    "#/components/parameters/PageToken/in": {
+    "#/components/schemas/EventDraft/properties/guestLimit": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/guestLimit"
     },
-    "#/components/parameters/PageToken/schema/type": {
+    "#/components/schemas/EventDraft/properties/guestLimit/type": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/guestLimit/type"
     },
-    "#/components/requestBodies/CallableRequest": {
+    "#/components/schemas/EventDraft/properties/links": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/links"
     },
-    "#/components/requestBodies/CallableRequest/required": {
+    "#/components/schemas/EventDraft/properties/links/type": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/links/type"
     },
-    "#/components/requestBodies/CallableRequest/content/application~1json": {
+    "#/components/schemas/EventDraft/properties/links/items/type": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/links/items/type"
     },
-    "#/components/requestBodies/CallableRequest/content/application~1json/schema/$ref": {
+    "#/components/schemas/EventDraft/properties/links/items/additionalProperties": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/links/items/additionalProperties"
     },
-    "#/components/requestBodies/TextBlastRequest": {
+    "#/components/schemas/EventDraft/properties/image": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/image"
     },
-    "#/components/requestBodies/TextBlastRequest/required": {
+    "#/components/schemas/EventDraft/additionalProperties": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/additionalProperties"
     },
-    "#/components/requestBodies/TextBlastRequest/content/application~1json": {
+    "#/components/schemas/RsvpDraft/type": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/RsvpDraft/type"
     },
-    "#/components/requestBodies/TextBlastRequest/content/application~1json/schema/$ref": {
+    "#/components/schemas/RsvpDraft/required/0": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/RsvpDraft/required/0"
     },
-    "#/components/requestBodies/FirestoreWrite": {
+    "#/components/schemas/RsvpDraft/required/1": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/RsvpDraft/required/1"
     },
-    "#/components/requestBodies/FirestoreWrite/required": {
+    "#/components/schemas/RsvpDraft/required/2": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/RsvpDraft/required/2"
     },
-    "#/components/requestBodies/FirestoreWrite/content/application~1json": {
+    "#/components/schemas/RsvpDraft/required/3": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/RsvpDraft/required/3"
     },
-    "#/components/requestBodies/FirestoreWrite/content/application~1json/schema/$ref": {
+    "#/components/schemas/RsvpDraft/required/4": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/RsvpDraft/required/4"
     },
-    "#/components/requestBodies/RefreshToken": {
+    "#/components/schemas/RsvpDraft/properties/name": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/RsvpDraft/properties/name"
     },
-    "#/components/requestBodies/RefreshToken/required": {
+    "#/components/schemas/RsvpDraft/properties/name/type": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/RsvpDraft/properties/name/type"
     },
-    "#/components/requestBodies/RefreshToken/content/application~1x-www-form-urlencoded": {
+    "#/components/schemas/RsvpDraft/properties/count": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/RsvpDraft/properties/count"
     },
-    "#/components/requestBodies/RefreshToken/content/application~1x-www-form-urlencoded/schema/$ref": {
+    "#/components/schemas/RsvpDraft/properties/count/type": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/RsvpDraft/properties/count/type"
     },
-    "#/components/requestBodies/CustomToken": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
-    },
-    "#/components/requestBodies/CustomToken/required": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
-    },
-    "#/components/requestBodies/CustomToken/content/application~1json": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
-    },
-    "#/components/requestBodies/CustomToken/content/application~1json/schema/$ref": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
-    },
-    "#/components/requestBodies/FirebaseLookup": {
-      "classification": "reviewed-first-party-repository-research",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
-    },
-    "#/components/requestBodies/FirebaseLookup/required": {
-      "classification": "reviewed-first-party-repository-research",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
-    },
-    "#/components/requestBodies/FirebaseLookup/content/application~1json": {
-      "classification": "reviewed-first-party-repository-research",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
-    },
-    "#/components/requestBodies/FirebaseLookup/content/application~1json/schema/$ref": {
-      "classification": "reviewed-first-party-repository-research",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
-    },
-    "#/components/requestBodies/UploadPhoto": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-upload-research"
-    },
-    "#/components/requestBodies/UploadPhoto/required": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-upload-research"
-    },
-    "#/components/requestBodies/UploadPhoto/content/multipart~1form-data": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-upload-research"
-    },
-    "#/components/requestBodies/UploadPhoto/content/multipart~1form-data/schema/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-upload-research"
-    },
-    "#/components/requestBodies/UploadPhoto/content/multipart~1form-data/schema/required/0": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-upload-research"
-    },
-    "#/components/requestBodies/UploadPhoto/content/multipart~1form-data/schema/properties/file": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-upload-research"
-    },
-    "#/components/requestBodies/UploadPhoto/content/multipart~1form-data/schema/properties/file/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-upload-research"
-    },
-    "#/components/requestBodies/UploadPhoto/content/multipart~1form-data/schema/properties/file/format": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-upload-research"
-    },
-    "#/components/responses/CallableResponse": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components"
-    },
-    "#/components/responses/CallableResponse/content/application~1json": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components"
-    },
-    "#/components/responses/CallableResponse/content/application~1json/schema/$ref": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components"
-    },
-    "#/components/responses/FirestoreDocument": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
-    },
-    "#/components/responses/FirestoreDocument/content/application~1json": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
-    },
-    "#/components/responses/FirestoreDocument/content/application~1json/schema/$ref": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
-    },
-    "#/components/responses/FirestoreList": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
-    },
-    "#/components/responses/FirestoreList/content/application~1json": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
-    },
-    "#/components/responses/FirestoreList/content/application~1json/schema/$ref": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
-    },
-    "#/components/responses/RefreshToken": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
-    },
-    "#/components/responses/RefreshToken/content/application~1json": {
+    "#/components/schemas/RsvpDraft/properties/plusOnes": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/RsvpDraft/properties/plusOnes"
     },
-    "#/components/responses/RefreshToken/content/application~1json/schema/$ref": {
+    "#/components/schemas/RsvpDraft/properties/plusOnes/type": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
-    },
-    "#/components/responses/FirebaseSignIn": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
-    },
-    "#/components/responses/FirebaseSignIn/content/application~1json": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
-    },
-    "#/components/responses/FirebaseSignIn/content/application~1json/schema/$ref": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
-    },
-    "#/components/responses/FirebaseLookup": {
-      "classification": "reviewed-first-party-repository-research",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/RsvpDraft/properties/plusOnes/type"
     },
-    "#/components/responses/FirebaseLookup/content/application~1json": {
-      "classification": "reviewed-first-party-repository-research",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
-    },
-    "#/components/responses/FirebaseLookup/content/application~1json/schema/$ref": {
-      "classification": "reviewed-first-party-repository-research",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
-    },
-    "#/components/responses/UploadPhoto": {
+    "#/components/schemas/RsvpDraft/properties/plusOnes/items/type": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-upload-research"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/RsvpDraft/properties/plusOnes/items/type"
     },
-    "#/components/responses/UploadPhoto/content/application~1json": {
+    "#/components/schemas/RsvpDraft/properties/message": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-upload-research"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/RsvpDraft/properties/message"
     },
-    "#/components/responses/UploadPhoto/content/application~1json/schema/$ref": {
+    "#/components/schemas/RsvpDraft/properties/message/type/0": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-upload-research"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/RsvpDraft/properties/message/type/0"
     },
-    "#/components/responses/PosterCatalog": {
+    "#/components/schemas/RsvpDraft/properties/message/type/1": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-catalog-fetch"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/RsvpDraft/properties/message/type/1"
     },
-    "#/components/responses/PosterCatalog/content/application~1json": {
+    "#/components/schemas/RsvpDraft/properties/emailInvitationId": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-catalog-fetch"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/RsvpDraft/properties/emailInvitationId"
     },
-    "#/components/responses/PosterCatalog/content/application~1json/schema/type": {
+    "#/components/schemas/RsvpDraft/properties/emailInvitationId/type/0": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-catalog-fetch"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/RsvpDraft/properties/emailInvitationId/type/0"
     },
-    "#/components/responses/PosterCatalog/content/application~1json/schema/items/$ref": {
+    "#/components/schemas/RsvpDraft/properties/emailInvitationId/type/1": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-catalog-fetch"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/RsvpDraft/properties/emailInvitationId/type/1"
     },
-    "#/components/schemas/CallableRequest": {
+    "#/components/schemas/RsvpDraft/properties/status": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/RsvpDraft/properties/status"
     },
-    "#/components/schemas/CallableRequest/type": {
+    "#/components/schemas/RsvpDraft/properties/status/type": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/RsvpDraft/properties/status/type"
     },
-    "#/components/schemas/CallableRequest/required/0": {
+    "#/components/schemas/RsvpDraft/properties/guestId": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/RsvpDraft/properties/guestId"
     },
-    "#/components/schemas/CallableRequest/properties/data": {
+    "#/components/schemas/RsvpDraft/properties/guestId/type/0": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/RsvpDraft/properties/guestId/type/0"
     },
-    "#/components/schemas/CallableRequest/properties/data/type": {
+    "#/components/schemas/RsvpDraft/properties/guestId/type/1": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/RsvpDraft/properties/guestId/type/1"
     },
-    "#/components/schemas/CallableRequest/properties/data/required/0": {
+    "#/components/schemas/RsvpDraft/properties/timezone": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/RsvpDraft/properties/timezone"
     },
-    "#/components/schemas/CallableRequest/properties/data/required/1": {
+    "#/components/schemas/RsvpDraft/properties/timezone/type": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/RsvpDraft/properties/timezone/type"
     },
-    "#/components/schemas/CallableRequest/properties/data/properties/params": {
+    "#/components/schemas/RsvpDraft/properties/password": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/RsvpDraft/properties/password"
     },
-    "#/components/schemas/CallableRequest/properties/data/properties/params/type": {
+    "#/components/schemas/RsvpDraft/properties/password/type/0": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/RsvpDraft/properties/password/type/0"
     },
-    "#/components/schemas/CallableRequest/properties/data/properties/params/additionalProperties": {
+    "#/components/schemas/RsvpDraft/properties/password/type/1": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/RsvpDraft/properties/password/type/1"
     },
-    "#/components/schemas/CallableRequest/properties/data/properties/amplitudeDeviceId": {
+    "#/components/schemas/RsvpDraft/properties/questionnaireResponse": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/RsvpDraft/properties/questionnaireResponse"
     },
-    "#/components/schemas/CallableRequest/properties/data/properties/amplitudeDeviceId/type": {
+    "#/components/schemas/RsvpDraft/properties/questionnaireResponse/type": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/RsvpDraft/properties/questionnaireResponse/type"
     },
-    "#/components/schemas/CallableRequest/properties/data/properties/amplitudeSessionId": {
+    "#/components/schemas/RsvpDraft/properties/questionnaireResponse/properties/questionnaireVersion": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/RsvpDraft/properties/questionnaireResponse/properties/questionnaireVersion"
     },
-    "#/components/schemas/CallableRequest/properties/data/properties/amplitudeSessionId/type": {
+    "#/components/schemas/RsvpDraft/properties/questionnaireResponse/properties/questionnaireVersion/type": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/RsvpDraft/properties/questionnaireResponse/properties/questionnaireVersion/type"
     },
-    "#/components/schemas/CallableRequest/properties/data/properties/userId": {
+    "#/components/schemas/RsvpDraft/properties/questionnaireResponse/properties/answers": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/RsvpDraft/properties/questionnaireResponse/properties/answers"
     },
-    "#/components/schemas/CallableRequest/properties/data/properties/userId/type/0": {
+    "#/components/schemas/RsvpDraft/properties/questionnaireResponse/properties/answers/type": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/RsvpDraft/properties/questionnaireResponse/properties/answers/type"
     },
-    "#/components/schemas/CallableRequest/properties/data/properties/userId/type/1": {
+    "#/components/schemas/RsvpDraft/properties/questionnaireResponse/properties/answers/additionalProperties/type": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/RsvpDraft/properties/questionnaireResponse/properties/answers/additionalProperties/type"
     },
-    "#/components/schemas/CallableRequest/properties/data/additionalProperties": {
+    "#/components/schemas/RsvpDraft/properties/questionnaireResponse/required/0": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/RsvpDraft/properties/questionnaireResponse/required/0"
     },
-    "#/components/schemas/CallableRequest/additionalProperties": {
+    "#/components/schemas/RsvpDraft/properties/questionnaireResponse/required/1": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas"
-    },
-    "#/components/schemas/TextBlastRequest": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
-    },
-    "#/components/schemas/TextBlastRequest/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
-    },
-    "#/components/schemas/TextBlastRequest/required/0": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
-    },
-    "#/components/schemas/TextBlastRequest/properties/data": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
-    },
-    "#/components/schemas/TextBlastRequest/properties/data/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
-    },
-    "#/components/schemas/TextBlastRequest/properties/data/required/0": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
-    },
-    "#/components/schemas/TextBlastRequest/properties/data/properties/params": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
-    },
-    "#/components/schemas/TextBlastRequest/properties/data/properties/params/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
-    },
-    "#/components/schemas/TextBlastRequest/properties/data/properties/params/required/0": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
-    },
-    "#/components/schemas/TextBlastRequest/properties/data/properties/params/required/1": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
-    },
-    "#/components/schemas/TextBlastRequest/properties/data/properties/params/properties/eventId": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
-    },
-    "#/components/schemas/TextBlastRequest/properties/data/properties/params/properties/eventId/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
-    },
-    "#/components/schemas/TextBlastRequest/properties/data/properties/params/properties/message": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
-    },
-    "#/components/schemas/TextBlastRequest/properties/data/properties/params/properties/message/$ref": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
-    },
-    "#/components/schemas/TextBlastRequest/properties/data/properties/params/additionalProperties": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
-    },
-    "#/components/schemas/TextBlastRequest/properties/data/additionalProperties": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
-    },
-    "#/components/schemas/TextBlastRequest/additionalProperties": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
-    },
-    "#/components/schemas/TextBlastMessage": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
-    },
-    "#/components/schemas/TextBlastMessage/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
-    },
-    "#/components/schemas/TextBlastMessage/required/0": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
-    },
-    "#/components/schemas/TextBlastMessage/required/1": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
-    },
-    "#/components/schemas/TextBlastMessage/required/2": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
-    },
-    "#/components/schemas/TextBlastMessage/properties/text": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
-    },
-    "#/components/schemas/TextBlastMessage/properties/text/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
-    },
-    "#/components/schemas/TextBlastMessage/properties/text/maxLength": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
-    },
-    "#/components/schemas/TextBlastMessage/properties/to": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
-    },
-    "#/components/schemas/TextBlastMessage/properties/to/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
-    },
-    "#/components/schemas/TextBlastMessage/properties/to/items/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
-    },
-    "#/components/schemas/TextBlastMessage/properties/showOnEventPage": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
-    },
-    "#/components/schemas/TextBlastMessage/properties/showOnEventPage/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
-    },
-    "#/components/schemas/TextBlastMessage/properties/images": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
-    },
-    "#/components/schemas/TextBlastMessage/properties/images/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
-    },
-    "#/components/schemas/TextBlastMessage/properties/images/maxItems": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
-    },
-    "#/components/schemas/TextBlastMessage/properties/images/items/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
-    },
-    "#/components/schemas/TextBlastMessage/properties/images/items/additionalProperties": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
-    },
-    "#/components/schemas/TextBlastMessage/additionalProperties": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/RsvpDraft/properties/questionnaireResponse/required/1"
     },
-    "#/components/schemas/CallableResponse": {
+    "#/components/schemas/RsvpDraft/additionalProperties": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/CallableResponse"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/RsvpDraft/additionalProperties"
     },
     "#/components/schemas/CallableResponse/type": {
       "classification": "typescript-derived-inference",
@@ -1461,345 +3536,225 @@
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/CallableResponse/additionalProperties"
     },
-    "#/components/schemas/FirestoreWriteDocument": {
+    "#/components/schemas/FirestoreValue/type": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreValue/type"
     },
-    "#/components/schemas/FirestoreWriteDocument/type": {
+    "#/components/schemas/FirestoreValue/additionalProperties": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
-    },
-    "#/components/schemas/FirestoreWriteDocument/properties/fields": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
-    },
-    "#/components/schemas/FirestoreWriteDocument/properties/fields/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
-    },
-    "#/components/schemas/FirestoreWriteDocument/properties/fields/additionalProperties": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
-    },
-    "#/components/schemas/FirestoreWriteDocument/additionalProperties": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
-    },
-    "#/components/schemas/FirestoreDocument": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreValue/additionalProperties"
     },
     "#/components/schemas/FirestoreDocument/type": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreDocument/type"
     },
     "#/components/schemas/FirestoreDocument/properties/name": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreDocument/properties/name"
     },
     "#/components/schemas/FirestoreDocument/properties/name/type": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreDocument/properties/name/type"
     },
     "#/components/schemas/FirestoreDocument/properties/fields": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreDocument/properties/fields"
     },
     "#/components/schemas/FirestoreDocument/properties/fields/type": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreDocument/properties/fields/type"
     },
-    "#/components/schemas/FirestoreDocument/properties/fields/additionalProperties": {
+    "#/components/schemas/FirestoreDocument/properties/fields/additionalProperties/$ref": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreDocument/properties/fields/additionalProperties/$ref"
     },
     "#/components/schemas/FirestoreDocument/properties/createTime": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreDocument/properties/createTime"
     },
     "#/components/schemas/FirestoreDocument/properties/createTime/type": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreDocument/properties/createTime/type"
+    },
+    "#/components/schemas/FirestoreDocument/properties/createTime/format": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreDocument/properties/createTime/format"
     },
     "#/components/schemas/FirestoreDocument/properties/updateTime": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreDocument/properties/updateTime"
     },
     "#/components/schemas/FirestoreDocument/properties/updateTime/type": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreDocument/properties/updateTime/type"
+    },
+    "#/components/schemas/FirestoreDocument/properties/updateTime/format": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreDocument/properties/updateTime/format"
     },
     "#/components/schemas/FirestoreDocument/additionalProperties": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreDocument/additionalProperties"
     },
-    "#/components/schemas/FirestoreListResponse": {
+    "#/components/schemas/FirestoreWriteDocument/type": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreWriteDocument/type"
+    },
+    "#/components/schemas/FirestoreWriteDocument/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreWriteDocument/required/0"
+    },
+    "#/components/schemas/FirestoreWriteDocument/properties/fields": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreWriteDocument/properties/fields"
+    },
+    "#/components/schemas/FirestoreWriteDocument/properties/fields/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreWriteDocument/properties/fields/type"
+    },
+    "#/components/schemas/FirestoreWriteDocument/properties/fields/additionalProperties/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreWriteDocument/properties/fields/additionalProperties/$ref"
+    },
+    "#/components/schemas/FirestoreWriteDocument/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreWriteDocument/additionalProperties"
     },
     "#/components/schemas/FirestoreListResponse/type": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreListResponse/type"
     },
     "#/components/schemas/FirestoreListResponse/properties/documents": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreListResponse/properties/documents"
     },
     "#/components/schemas/FirestoreListResponse/properties/documents/type": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreListResponse/properties/documents/type"
     },
     "#/components/schemas/FirestoreListResponse/properties/documents/items/$ref": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreListResponse/properties/documents/items/$ref"
     },
     "#/components/schemas/FirestoreListResponse/properties/nextPageToken": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreListResponse/properties/nextPageToken"
     },
     "#/components/schemas/FirestoreListResponse/properties/nextPageToken/type": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreListResponse/properties/nextPageToken/type"
     },
     "#/components/schemas/FirestoreListResponse/additionalProperties": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-firestore-research"
-    },
-    "#/components/schemas/RefreshTokenRequest": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
-    },
-    "#/components/schemas/RefreshTokenRequest/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
-    },
-    "#/components/schemas/RefreshTokenRequest/required/0": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
-    },
-    "#/components/schemas/RefreshTokenRequest/required/1": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
-    },
-    "#/components/schemas/RefreshTokenRequest/properties/grant_type": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
-    },
-    "#/components/schemas/RefreshTokenRequest/properties/grant_type/const": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
-    },
-    "#/components/schemas/RefreshTokenRequest/properties/refresh_token": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
-    },
-    "#/components/schemas/RefreshTokenRequest/properties/refresh_token/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
-    },
-    "#/components/schemas/RefreshTokenResponse": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreListResponse/additionalProperties"
     },
     "#/components/schemas/RefreshTokenResponse/type": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
-    },
-    "#/components/schemas/RefreshTokenResponse/properties/id_token": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
-    },
-    "#/components/schemas/RefreshTokenResponse/properties/id_token/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
-    },
-    "#/components/schemas/RefreshTokenResponse/properties/refresh_token": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
-    },
-    "#/components/schemas/RefreshTokenResponse/properties/refresh_token/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
-    },
-    "#/components/schemas/RefreshTokenResponse/properties/expires_in": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
-    },
-    "#/components/schemas/RefreshTokenResponse/properties/expires_in/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
-    },
-    "#/components/schemas/RefreshTokenResponse/properties/user_id": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
-    },
-    "#/components/schemas/RefreshTokenResponse/properties/user_id/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/RefreshTokenResponse/type"
     },
     "#/components/schemas/RefreshTokenResponse/additionalProperties": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
-    },
-    "#/components/schemas/CustomTokenRequest": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
-    },
-    "#/components/schemas/CustomTokenRequest/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
-    },
-    "#/components/schemas/CustomTokenRequest/required/0": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
-    },
-    "#/components/schemas/CustomTokenRequest/required/1": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
-    },
-    "#/components/schemas/CustomTokenRequest/properties/token": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
-    },
-    "#/components/schemas/CustomTokenRequest/properties/token/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
-    },
-    "#/components/schemas/CustomTokenRequest/properties/returnSecureToken": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
-    },
-    "#/components/schemas/CustomTokenRequest/properties/returnSecureToken/const": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
-    },
-    "#/components/schemas/FirebaseSignInResponse": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/RefreshTokenResponse/additionalProperties"
     },
     "#/components/schemas/FirebaseSignInResponse/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
-    },
-    "#/components/schemas/FirebaseSignInResponse/properties/idToken": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
-    },
-    "#/components/schemas/FirebaseSignInResponse/properties/idToken/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
-    },
-    "#/components/schemas/FirebaseSignInResponse/properties/refreshToken": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
-    },
-    "#/components/schemas/FirebaseSignInResponse/properties/refreshToken/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
-    },
-    "#/components/schemas/FirebaseSignInResponse/properties/expiresIn": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
-    },
-    "#/components/schemas/FirebaseSignInResponse/properties/expiresIn/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
-    },
-    "#/components/schemas/FirebaseSignInResponse/properties/localId": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
-    },
-    "#/components/schemas/FirebaseSignInResponse/properties/localId/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirebaseSignInResponse/type"
     },
     "#/components/schemas/FirebaseSignInResponse/additionalProperties": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation"
-    },
-    "#/components/schemas/FirebaseLookupRequest": {
-      "classification": "reviewed-first-party-repository-research",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
-    },
-    "#/components/schemas/FirebaseLookupRequest/type": {
-      "classification": "reviewed-first-party-repository-research",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
-    },
-    "#/components/schemas/FirebaseLookupRequest/required/0": {
-      "classification": "reviewed-first-party-repository-research",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
-    },
-    "#/components/schemas/FirebaseLookupRequest/properties/idToken": {
-      "classification": "reviewed-first-party-repository-research",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
-    },
-    "#/components/schemas/FirebaseLookupRequest/properties/idToken/type": {
-      "classification": "reviewed-first-party-repository-research",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
-    },
-    "#/components/schemas/FirebaseLookupResponse": {
-      "classification": "reviewed-first-party-repository-research",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirebaseSignInResponse/additionalProperties"
     },
     "#/components/schemas/FirebaseLookupResponse/type": {
-      "classification": "reviewed-first-party-repository-research",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
-    },
-    "#/components/schemas/FirebaseLookupResponse/properties/users": {
-      "classification": "reviewed-first-party-repository-research",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
-    },
-    "#/components/schemas/FirebaseLookupResponse/properties/users/type": {
-      "classification": "reviewed-first-party-repository-research",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
-    },
-    "#/components/schemas/FirebaseLookupResponse/properties/users/items/type": {
-      "classification": "reviewed-first-party-repository-research",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
-    },
-    "#/components/schemas/FirebaseLookupResponse/properties/users/items/additionalProperties": {
-      "classification": "reviewed-first-party-repository-research",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirebaseLookupResponse/type"
     },
     "#/components/schemas/FirebaseLookupResponse/additionalProperties": {
-      "classification": "reviewed-first-party-repository-research",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-callable-and-auth-research"
-    },
-    "#/components/schemas/UploadPhotoResponse": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-upload-research"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirebaseLookupResponse/additionalProperties"
+    },
+    "#/components/schemas/UploadData/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/UploadData/type"
+    },
+    "#/components/schemas/UploadData/required/0": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/UploadData/required/0"
+    },
+    "#/components/schemas/UploadData/properties/url": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/UploadData/properties/url"
+    },
+    "#/components/schemas/UploadData/properties/url/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/UploadData/properties/url/type"
+    },
+    "#/components/schemas/UploadData/properties/url/format": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/UploadData/properties/url/format"
+    },
+    "#/components/schemas/UploadData/properties/contentType": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/UploadData/properties/contentType"
+    },
+    "#/components/schemas/UploadData/properties/contentType/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/UploadData/properties/contentType/type"
+    },
+    "#/components/schemas/UploadData/properties/height": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/UploadData/properties/height"
+    },
+    "#/components/schemas/UploadData/properties/height/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/UploadData/properties/height/type"
+    },
+    "#/components/schemas/UploadData/properties/width": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/UploadData/properties/width"
+    },
+    "#/components/schemas/UploadData/properties/width/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/UploadData/properties/width/type"
+    },
+    "#/components/schemas/UploadData/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/UploadData/additionalProperties"
     },
     "#/components/schemas/UploadPhotoResponse/type": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-upload-research"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/UploadPhotoResponse/type"
     },
     "#/components/schemas/UploadPhotoResponse/properties/uploadData": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-upload-research"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/UploadPhotoResponse/properties/uploadData"
     },
-    "#/components/schemas/UploadPhotoResponse/properties/uploadData/type": {
+    "#/components/schemas/UploadPhotoResponse/properties/uploadData/$ref": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-upload-research"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/UploadPhotoResponse/properties/uploadData/$ref"
     },
-    "#/components/schemas/UploadPhotoResponse/properties/uploadData/properties/url": {
+    "#/components/schemas/UploadPhotoResponse/properties/result": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-upload-research"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/UploadPhotoResponse/properties/result"
     },
-    "#/components/schemas/UploadPhotoResponse/properties/uploadData/properties/url/type": {
+    "#/components/schemas/UploadPhotoResponse/properties/result/type": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-upload-research"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/UploadPhotoResponse/properties/result/type"
     },
-    "#/components/schemas/UploadPhotoResponse/properties/uploadData/additionalProperties": {
+    "#/components/schemas/UploadPhotoResponse/properties/result/properties/uploadData": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-upload-research"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/UploadPhotoResponse/properties/result/properties/uploadData"
+    },
+    "#/components/schemas/UploadPhotoResponse/properties/result/properties/uploadData/$ref": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/UploadPhotoResponse/properties/result/properties/uploadData/$ref"
+    },
+    "#/components/schemas/UploadPhotoResponse/properties/result/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/UploadPhotoResponse/properties/result/additionalProperties"
     },
     "#/components/schemas/UploadPhotoResponse/additionalProperties": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#typescript-upload-research"
-    },
-    "#/components/schemas/Poster": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
+      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/UploadPhotoResponse/additionalProperties"
     },
     "#/components/schemas/Poster/type": {
       "classification": "typescript-derived-inference",
@@ -1829,19 +3784,23 @@
       "classification": "typescript-derived-inference",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
     },
+    "#/components/schemas/Poster/properties/url/format": {
+      "classification": "typescript-derived-inference",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
+    },
+    "#/components/schemas/Poster/properties/blurHash": {
+      "classification": "typescript-derived-inference",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
+    },
+    "#/components/schemas/Poster/properties/blurHash/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
+    },
     "#/components/schemas/Poster/properties/contentType": {
       "classification": "typescript-derived-inference",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
     },
     "#/components/schemas/Poster/properties/contentType/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
-    },
-    "#/components/schemas/Poster/properties/width": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
-    },
-    "#/components/schemas/Poster/properties/width/type": {
       "classification": "typescript-derived-inference",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
     },
@@ -1853,13 +3812,41 @@
       "classification": "typescript-derived-inference",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
     },
-    "#/components/schemas/Poster/additionalProperties": {
+    "#/components/schemas/Poster/properties/width": {
       "classification": "typescript-derived-inference",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
     },
-    "#/servers/0/url": {
+    "#/components/schemas/Poster/properties/width/type": {
       "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/servers/0/url"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
+    },
+    "#/components/schemas/Poster/properties/tags": {
+      "classification": "typescript-derived-inference",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
+    },
+    "#/components/schemas/Poster/properties/tags/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
+    },
+    "#/components/schemas/Poster/properties/tags/items/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
+    },
+    "#/components/schemas/Poster/properties/categories": {
+      "classification": "typescript-derived-inference",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
+    },
+    "#/components/schemas/Poster/properties/categories/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
+    },
+    "#/components/schemas/Poster/properties/categories/items/type": {
+      "classification": "typescript-derived-inference",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
+    },
+    "#/components/schemas/Poster/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
     }
   }
 }

--- a/spec/partiful.api-evidence.json
+++ b/spec/partiful.api-evidence.json
@@ -1,0 +1,64 @@
+{
+  "contractRevision": "2026-08-10.1",
+  "contractPath": "spec/partiful.openapi.json",
+  "allowedClassifications": ["dated-live-observation", "reviewed-first-party-repository-research", "typescript-derived-inference", "explicit-unknown"],
+  "sources": {
+    "draft": "Historical draft 17e9800753ada577408074bbbcadbae8cc8eacf0; research input only.",
+    "typescript": "Reviewed TypeScript endpoint registry and transport code in src/lib/; research input only.",
+    "textBlastLive": "docs/research/2026-03-24-text-blast-endpoint.md: browser interception, 2026-03-24.",
+    "authLive": "docs/research/2026-03-24-auth-flow-endpoints.md: browser interception and bundle analysis, 2026-03-24.",
+    "imageLive": "docs/research/2026-03-24-event-image-schema.md: browser interception, 2026-03-24."
+  },
+  "operations": [
+    ["createEvent","typescript-derived-inference"], ["cancelEvent","typescript-derived-inference"], ["getEventInfo","typescript-derived-inference"], ["getContacts","typescript-derived-inference"], ["createTextBlast","dated-live-observation"], ["addInvitedGuestsAsHost","typescript-derived-inference"], ["createCohostRequest","typescript-derived-inference"], ["deleteCohostRequest","typescript-derived-inference"], ["removeCohost","typescript-derived-inference"], ["generateEventCohostLink","typescript-derived-inference"], ["revokeEventCohostLink","typescript-derived-inference"], ["getMyUpcomingEventsForHomePage","typescript-derived-inference"], ["getMyPastEventsForHomePage","typescript-derived-inference"], ["addGuest","typescript-derived-inference"], ["markEventInterest","typescript-derived-inference"], ["getCurrentGuest","typescript-derived-inference"], ["firestoreGetEvent","typescript-derived-inference"], ["firestorePatchEvent","typescript-derived-inference"], ["firestoreGetGuest","typescript-derived-inference"], ["firestoreListDocuments","typescript-derived-inference"], ["refreshToken","typescript-derived-inference"], ["sendAuthCodeTrusted","reviewed-first-party-repository-research"], ["getLoginToken","dated-live-observation"], ["signInWithCustomToken","dated-live-observation"], ["lookupFirebaseUser","reviewed-first-party-repository-research"], ["uploadEventPhoto","typescript-derived-inference"], ["getPosterCatalog","typescript-derived-inference"]
+  ],
+  "schemaClaims": {
+    "CallableRequest": {"classification":"typescript-derived-inference","source":"typescript","scope":"Envelope shape only; callable-specific params are unknown unless separately stated."},
+    "TextBlastRequest": {"classification":"dated-live-observation","source":"textBlastLive","scope":"eventId and nested message shape."},
+    "TextBlastMessage": {"classification":"dated-live-observation","source":"textBlastLive","scope":"text, to, showOnEventPage, optional images; 480-character and one-image limits observed in client research."},
+    "CallableResponse": {"classification":"typescript-derived-inference","source":"typescript","scope":"Envelope only; inner payloads are explicit unknown."},
+    "FirestoreWriteDocument": {"classification":"typescript-derived-inference","source":"typescript","scope":"Wire wrapper; valid event field names and value variants are explicit unknown."},
+    "FirestoreDocument": {"classification":"typescript-derived-inference","source":"typescript","scope":"Non-exhaustive Firestore document wrapper."},
+    "FirestoreListResponse": {"classification":"typescript-derived-inference","source":"typescript","scope":"Non-exhaustive list wrapper."},
+    "RefreshTokenRequest": {"classification":"typescript-derived-inference","source":"typescript","scope":"Form field names and fixed grant type."},
+    "RefreshTokenResponse": {"classification":"typescript-derived-inference","source":"typescript","scope":"Known token fields; no value examples are retained."},
+    "CustomTokenRequest": {"classification":"dated-live-observation","source":"authLive","scope":"Custom-token exchange fields."},
+    "FirebaseSignInResponse": {"classification":"dated-live-observation","source":"authLive","scope":"Known response fields."},
+    "FirebaseLookupRequest": {"classification":"reviewed-first-party-repository-research","source":"typescript","scope":"Request field."},
+    "FirebaseLookupResponse": {"classification":"explicit-unknown","source":"draft","scope":"Only the outer users array is represented; member fields are not claimed."},
+    "UploadPhotoResponse": {"classification":"typescript-derived-inference","source":"typescript","scope":"Only uploadData.url is used by reviewed code; other response fields are unknown."},
+    "Poster": {"classification":"dated-live-observation","source":"imageLive","scope":"Observed catalog fields; other catalog fields remain open."}
+  },
+  "operationClaims": {
+    "default": {"request":"typescript-derived-inference","response":"explicit-unknown","source":"draft"},
+    "createTextBlast": {"request":"dated-live-observation","response":"explicit-unknown","source":"textBlastLive"},
+    "getLoginToken": {"request":"dated-live-observation","response":"dated-live-observation","source":"authLive"},
+    "signInWithCustomToken": {"request":"dated-live-observation","response":"dated-live-observation","source":"authLive"},
+    "sendAuthCodeTrusted": {"request":"reviewed-first-party-repository-research","response":"explicit-unknown","source":"typescript"},
+    "lookupFirebaseUser": {"request":"reviewed-first-party-repository-research","response":"explicit-unknown","source":"typescript"},
+    "getPosterCatalog": {"request":"explicit-unknown","response":"dated-live-observation","source":"imageLive"}
+  },
+  "contradictions": [
+    {
+      "id": "text-blast-message-shape",
+      "status": "resolved",
+      "historicalDraft": "message string with optional recipientStatuses",
+      "primaryEvidence": "Nested message object with text, to, showOnEventPage, and optional images.",
+      "decision": "The contract uses the dated browser-interception shape. recipientStatuses is deliberately absent."
+    },
+    {
+      "id": "upload-host",
+      "status": "resolved",
+      "historicalDraft": "Cloud Functions uploadPhoto endpoint",
+      "typescript": "Same host and path with multipart file and uploadType query parameter",
+      "decision": "No conflict found; retained as TypeScript-derived inference because no safe upload probe was performed."
+    }
+  ],
+  "unresolvedUncertainty": [
+    "Callable-specific parameter sets and result payloads outside createTextBlast and documented auth calls.",
+    "Complete Firestore typed-value grammar, authorization rules, pagination limits, and update-mask semantics.",
+    "Upload accepted media types, size limits, response variants, and whether uploadType values remain stable.",
+    "Poster catalog freshness, complete schema, and cache behavior.",
+    "Status codes and error bodies for every operation."
+  ]
+}

--- a/spec/partiful.openapi.json
+++ b/spec/partiful.openapi.json
@@ -1,0 +1,87 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Partiful remote API contract",
+    "version": "1.0.0",
+    "description": "Versioned, remote-only transport snapshot. Evidence classifications and uncertainty are recorded in spec/partiful.api-evidence.json."
+  },
+  "servers": [{ "url": "https://api.partiful.com", "description": "Partiful callable service" }],
+  "paths": {
+    "/createEvent": { "post": { "operationId": "createEvent", "requestBody": { "$ref": "#/components/requestBodies/CallableRequest" }, "responses": { "200": { "$ref": "#/components/responses/CallableResponse" } }, "security": [{ "firebaseBearer": [] }] } },
+    "/cancelEvent": { "post": { "operationId": "cancelEvent", "requestBody": { "$ref": "#/components/requestBodies/CallableRequest" }, "responses": { "200": { "$ref": "#/components/responses/CallableResponse" } }, "security": [{ "firebaseBearer": [] }] } },
+    "/getEventInfo": { "post": { "operationId": "getEventInfo", "requestBody": { "$ref": "#/components/requestBodies/CallableRequest" }, "responses": { "200": { "$ref": "#/components/responses/CallableResponse" } }, "security": [{ "firebaseBearer": [] }] } },
+    "/getContacts": { "post": { "operationId": "getContacts", "requestBody": { "$ref": "#/components/requestBodies/CallableRequest" }, "responses": { "200": { "$ref": "#/components/responses/CallableResponse" } }, "security": [{ "firebaseBearer": [] }] } },
+    "/createTextBlast": { "post": { "operationId": "createTextBlast", "requestBody": { "$ref": "#/components/requestBodies/TextBlastRequest" }, "responses": { "200": { "$ref": "#/components/responses/CallableResponse" } }, "security": [{ "firebaseBearer": [] }] } },
+    "/addInvitedGuestsAsHost": { "post": { "operationId": "addInvitedGuestsAsHost", "requestBody": { "$ref": "#/components/requestBodies/CallableRequest" }, "responses": { "200": { "$ref": "#/components/responses/CallableResponse" } }, "security": [{ "firebaseBearer": [] }] } },
+    "/createCohostRequest": { "post": { "operationId": "createCohostRequest", "requestBody": { "$ref": "#/components/requestBodies/CallableRequest" }, "responses": { "200": { "$ref": "#/components/responses/CallableResponse" } }, "security": [{ "firebaseBearer": [] }] } },
+    "/deleteCohostRequest": { "post": { "operationId": "deleteCohostRequest", "requestBody": { "$ref": "#/components/requestBodies/CallableRequest" }, "responses": { "200": { "$ref": "#/components/responses/CallableResponse" } }, "security": [{ "firebaseBearer": [] }] } },
+    "/removeCohost": { "post": { "operationId": "removeCohost", "requestBody": { "$ref": "#/components/requestBodies/CallableRequest" }, "responses": { "200": { "$ref": "#/components/responses/CallableResponse" } }, "security": [{ "firebaseBearer": [] }] } },
+    "/generateEventCohostLink": { "post": { "operationId": "generateEventCohostLink", "requestBody": { "$ref": "#/components/requestBodies/CallableRequest" }, "responses": { "200": { "$ref": "#/components/responses/CallableResponse" } }, "security": [{ "firebaseBearer": [] }] } },
+    "/revokeEventCohostLink": { "post": { "operationId": "revokeEventCohostLink", "requestBody": { "$ref": "#/components/requestBodies/CallableRequest" }, "responses": { "200": { "$ref": "#/components/responses/CallableResponse" } }, "security": [{ "firebaseBearer": [] }] } },
+    "/getMyUpcomingEventsForHomePage": { "post": { "operationId": "getMyUpcomingEventsForHomePage", "requestBody": { "$ref": "#/components/requestBodies/CallableRequest" }, "responses": { "200": { "$ref": "#/components/responses/CallableResponse" } }, "security": [{ "firebaseBearer": [] }] } },
+    "/getMyPastEventsForHomePage": { "post": { "operationId": "getMyPastEventsForHomePage", "requestBody": { "$ref": "#/components/requestBodies/CallableRequest" }, "responses": { "200": { "$ref": "#/components/responses/CallableResponse" } }, "security": [{ "firebaseBearer": [] }] } },
+    "/addGuest": { "post": { "operationId": "addGuest", "requestBody": { "$ref": "#/components/requestBodies/CallableRequest" }, "responses": { "200": { "$ref": "#/components/responses/CallableResponse" } }, "security": [{ "firebaseBearer": [] }] } },
+    "/markEventInterest": { "post": { "operationId": "markEventInterest", "requestBody": { "$ref": "#/components/requestBodies/CallableRequest" }, "responses": { "200": { "$ref": "#/components/responses/CallableResponse" } }, "security": [{ "firebaseBearer": [] }] } },
+    "/getCurrentGuest": { "post": { "operationId": "getCurrentGuest", "requestBody": { "$ref": "#/components/requestBodies/CallableRequest" }, "responses": { "200": { "$ref": "#/components/responses/CallableResponse" } }, "security": [{ "firebaseBearer": [] }] } },
+    "/v1/projects/getpartiful/databases/(default)/documents/events/{eventId}": {
+      "get": { "operationId": "firestoreGetEvent", "parameters": [{ "$ref": "#/components/parameters/EventId" }], "responses": { "200": { "$ref": "#/components/responses/FirestoreDocument" } }, "security": [{ "firebaseBearer": [] }], "servers": [{ "url": "https://firestore.googleapis.com" }] },
+      "patch": { "operationId": "firestorePatchEvent", "parameters": [{ "$ref": "#/components/parameters/EventId" }, { "$ref": "#/components/parameters/UpdateMask" }], "requestBody": { "$ref": "#/components/requestBodies/FirestoreWrite" }, "responses": { "200": { "$ref": "#/components/responses/FirestoreDocument" } }, "security": [{ "firebaseBearer": [] }], "servers": [{ "url": "https://firestore.googleapis.com" }] }
+    },
+    "/v1/projects/getpartiful/databases/(default)/documents/events/{eventId}/guests/{guestId}": { "get": { "operationId": "firestoreGetGuest", "parameters": [{ "$ref": "#/components/parameters/EventId" }, { "$ref": "#/components/parameters/GuestId" }], "responses": { "200": { "$ref": "#/components/responses/FirestoreDocument" } }, "security": [{ "firebaseBearer": [] }], "servers": [{ "url": "https://firestore.googleapis.com" }] } },
+    "/v1/projects/getpartiful/databases/(default)/documents/{collectionPath}": { "get": { "operationId": "firestoreListDocuments", "parameters": [{ "$ref": "#/components/parameters/CollectionPath" }, { "$ref": "#/components/parameters/PageSize" }, { "$ref": "#/components/parameters/PageToken" }], "responses": { "200": { "$ref": "#/components/responses/FirestoreList" } }, "security": [{ "firebaseBearer": [] }], "servers": [{ "url": "https://firestore.googleapis.com" }] } },
+    "/v1/token": { "post": { "operationId": "refreshToken", "requestBody": { "$ref": "#/components/requestBodies/RefreshToken" }, "responses": { "200": { "$ref": "#/components/responses/RefreshToken" } }, "security": [{ "firebaseApiKey": [] }], "servers": [{ "url": "https://securetoken.googleapis.com" }] } },
+    "/sendAuthCodeTrusted": { "post": { "operationId": "sendAuthCodeTrusted", "requestBody": { "$ref": "#/components/requestBodies/CallableRequest" }, "responses": { "200": { "$ref": "#/components/responses/CallableResponse" } } } },
+    "/getLoginToken": { "post": { "operationId": "getLoginToken", "requestBody": { "$ref": "#/components/requestBodies/CallableRequest" }, "responses": { "200": { "$ref": "#/components/responses/CallableResponse" } } } },
+    "/v1/accounts:signInWithCustomToken": { "post": { "operationId": "signInWithCustomToken", "requestBody": { "$ref": "#/components/requestBodies/CustomToken" }, "responses": { "200": { "$ref": "#/components/responses/FirebaseSignIn" } }, "security": [{ "firebaseApiKey": [] }], "servers": [{ "url": "https://identitytoolkit.googleapis.com" }] } },
+    "/v1/accounts:lookup": { "post": { "operationId": "lookupFirebaseUser", "requestBody": { "$ref": "#/components/requestBodies/FirebaseLookup" }, "responses": { "200": { "$ref": "#/components/responses/FirebaseLookup" } }, "security": [{ "firebaseApiKey": [] }], "servers": [{ "url": "https://identitytoolkit.googleapis.com" }] } },
+    "/uploadPhoto": { "post": { "operationId": "uploadEventPhoto", "parameters": [{ "name": "uploadType", "in": "query", "schema": { "type": "string" } }], "requestBody": { "$ref": "#/components/requestBodies/UploadPhoto" }, "responses": { "200": { "$ref": "#/components/responses/UploadPhoto" } }, "security": [{ "firebaseBearer": [] }], "servers": [{ "url": "https://us-central1-getpartiful.cloudfunctions.net" }] } },
+    "/posters.json": { "get": { "operationId": "getPosterCatalog", "responses": { "200": { "$ref": "#/components/responses/PosterCatalog" } }, "servers": [{ "url": "https://assets.getpartiful.com" }] } }
+  },
+  "components": {
+    "securitySchemes": { "firebaseBearer": { "type": "http", "scheme": "bearer" }, "firebaseApiKey": { "type": "apiKey", "in": "query", "name": "key" } },
+    "parameters": {
+      "EventId": { "name": "eventId", "in": "path", "required": true, "schema": { "type": "string" } },
+      "GuestId": { "name": "guestId", "in": "path", "required": true, "schema": { "type": "string" } },
+      "CollectionPath": { "name": "collectionPath", "in": "path", "required": true, "schema": { "type": "string" } },
+      "UpdateMask": { "name": "updateMask.fieldPaths", "in": "query", "schema": { "type": "string" } },
+      "PageSize": { "name": "pageSize", "in": "query", "schema": { "type": "integer", "minimum": 1 } },
+      "PageToken": { "name": "pageToken", "in": "query", "schema": { "type": "string" } }
+    },
+    "requestBodies": {
+      "CallableRequest": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/CallableRequest" } } } },
+      "TextBlastRequest": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/TextBlastRequest" } } } },
+      "FirestoreWrite": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/FirestoreWriteDocument" } } } },
+      "RefreshToken": { "required": true, "content": { "application/x-www-form-urlencoded": { "schema": { "$ref": "#/components/schemas/RefreshTokenRequest" } } } },
+      "CustomToken": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/CustomTokenRequest" } } } },
+      "FirebaseLookup": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/FirebaseLookupRequest" } } } },
+      "UploadPhoto": { "required": true, "content": { "multipart/form-data": { "schema": { "type": "object", "required": ["file"], "properties": { "file": { "type": "string", "format": "binary" } } } } } }
+    },
+    "responses": {
+      "CallableResponse": { "description": "Callable response envelope", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/CallableResponse" } } } },
+      "FirestoreDocument": { "description": "Firestore document", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/FirestoreDocument" } } } },
+      "FirestoreList": { "description": "Firestore document list", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/FirestoreListResponse" } } } },
+      "RefreshToken": { "description": "Firebase token refresh response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/RefreshTokenResponse" } } } },
+      "FirebaseSignIn": { "description": "Firebase custom-token sign-in response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/FirebaseSignInResponse" } } } },
+      "FirebaseLookup": { "description": "Firebase user lookup response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/FirebaseLookupResponse" } } } },
+      "UploadPhoto": { "description": "Photo upload response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/UploadPhotoResponse" } } } },
+      "PosterCatalog": { "description": "Poster catalog", "content": { "application/json": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/Poster" } } } } }
+    },
+    "schemas": {
+      "CallableRequest": { "type": "object", "required": ["data"], "properties": { "data": { "type": "object", "required": ["params", "amplitudeDeviceId"], "properties": { "params": { "type": "object", "additionalProperties": true }, "amplitudeDeviceId": { "type": "string" }, "amplitudeSessionId": { "type": "integer" }, "userId": { "type": ["string", "null"] } }, "additionalProperties": true } }, "additionalProperties": true },
+      "TextBlastRequest": { "type": "object", "required": ["data"], "properties": { "data": { "type": "object", "required": ["params"], "properties": { "params": { "type": "object", "required": ["eventId", "message"], "properties": { "eventId": { "type": "string" }, "message": { "$ref": "#/components/schemas/TextBlastMessage" } }, "additionalProperties": true } }, "additionalProperties": true } }, "additionalProperties": true },
+      "TextBlastMessage": { "type": "object", "required": ["text", "to", "showOnEventPage"], "properties": { "text": { "type": "string", "maxLength": 480 }, "to": { "type": "array", "items": { "type": "string" } }, "showOnEventPage": { "type": "boolean" }, "images": { "type": "array", "maxItems": 1, "items": { "type": "object", "additionalProperties": true } } }, "additionalProperties": true },
+      "CallableResponse": { "type": "object", "properties": { "result": { "type": "object", "properties": { "data": {} }, "additionalProperties": true } }, "additionalProperties": true },
+      "FirestoreWriteDocument": { "type": "object", "properties": { "fields": { "type": "object", "additionalProperties": true } }, "additionalProperties": true },
+      "FirestoreDocument": { "type": "object", "properties": { "name": { "type": "string" }, "fields": { "type": "object", "additionalProperties": true }, "createTime": { "type": "string" }, "updateTime": { "type": "string" } }, "additionalProperties": true },
+      "FirestoreListResponse": { "type": "object", "properties": { "documents": { "type": "array", "items": { "$ref": "#/components/schemas/FirestoreDocument" } }, "nextPageToken": { "type": "string" } }, "additionalProperties": true },
+      "RefreshTokenRequest": { "type": "object", "required": ["grant_type", "refresh_token"], "properties": { "grant_type": { "const": "refresh_token" }, "refresh_token": { "type": "string" } } },
+      "RefreshTokenResponse": { "type": "object", "properties": { "id_token": { "type": "string" }, "refresh_token": { "type": "string" }, "expires_in": { "type": "string" }, "user_id": { "type": "string" } }, "additionalProperties": true },
+      "CustomTokenRequest": { "type": "object", "required": ["token", "returnSecureToken"], "properties": { "token": { "type": "string" }, "returnSecureToken": { "const": true } } },
+      "FirebaseSignInResponse": { "type": "object", "properties": { "idToken": { "type": "string" }, "refreshToken": { "type": "string" }, "expiresIn": { "type": "string" }, "localId": { "type": "string" } }, "additionalProperties": true },
+      "FirebaseLookupRequest": { "type": "object", "required": ["idToken"], "properties": { "idToken": { "type": "string" } } },
+      "FirebaseLookupResponse": { "type": "object", "properties": { "users": { "type": "array", "items": { "type": "object", "additionalProperties": true } } }, "additionalProperties": true },
+      "UploadPhotoResponse": { "type": "object", "properties": { "uploadData": { "type": "object", "properties": { "url": { "type": "string" } }, "additionalProperties": true } }, "additionalProperties": true },
+      "Poster": { "type": "object", "properties": { "id": { "type": "string" }, "name": { "type": "string" }, "url": { "type": "string" }, "contentType": { "type": "string" }, "width": { "type": "integer" }, "height": { "type": "integer" } }, "additionalProperties": true }
+    }
+  }
+}

--- a/spec/partiful.openapi.json
+++ b/spec/partiful.openapi.json
@@ -16,11 +16,73 @@
       "post": {
         "operationId": "createEvent",
         "requestBody": {
-          "$ref": "#/components/requestBodies/CallableRequest"
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "params",
+                      "amplitudeDeviceId"
+                    ],
+                    "properties": {
+                      "params": {
+                        "type": "object",
+                        "properties": {
+                          "event": {
+                            "$ref": "#/components/schemas/EventDraft"
+                          },
+                          "cohostIds": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "event",
+                          "cohostIds"
+                        ]
+                      },
+                      "amplitudeDeviceId": {
+                        "type": "string"
+                      },
+                      "amplitudeSessionId": {
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "userId": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
         },
         "responses": {
           "default": {
-            "$ref": "#/components/responses/CallableResponse"
+            "description": "Response status is unknown; body shape follows cited research where present.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallableResponse"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -34,11 +96,66 @@
       "post": {
         "operationId": "cancelEvent",
         "requestBody": {
-          "$ref": "#/components/requestBodies/CallableRequest"
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "params",
+                      "amplitudeDeviceId"
+                    ],
+                    "properties": {
+                      "params": {
+                        "type": "object",
+                        "properties": {
+                          "eventId": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "eventId"
+                        ]
+                      },
+                      "amplitudeDeviceId": {
+                        "type": "string"
+                      },
+                      "amplitudeSessionId": {
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "userId": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
         },
         "responses": {
           "default": {
-            "$ref": "#/components/responses/CallableResponse"
+            "description": "Response status is unknown; body shape follows cited research where present.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallableResponse"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -52,11 +169,66 @@
       "post": {
         "operationId": "getEventInfo",
         "requestBody": {
-          "$ref": "#/components/requestBodies/CallableRequest"
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "params",
+                      "amplitudeDeviceId"
+                    ],
+                    "properties": {
+                      "params": {
+                        "type": "object",
+                        "properties": {
+                          "eventId": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "eventId"
+                        ]
+                      },
+                      "amplitudeDeviceId": {
+                        "type": "string"
+                      },
+                      "amplitudeSessionId": {
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "userId": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
         },
         "responses": {
           "default": {
-            "$ref": "#/components/responses/CallableResponse"
+            "description": "Response status is unknown; body shape follows cited research where present.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallableResponse"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -70,11 +242,59 @@
       "post": {
         "operationId": "getContacts",
         "requestBody": {
-          "$ref": "#/components/requestBodies/CallableRequest"
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "params",
+                      "amplitudeDeviceId"
+                    ],
+                    "properties": {
+                      "params": {
+                        "type": "object",
+                        "properties": {},
+                        "additionalProperties": false
+                      },
+                      "amplitudeDeviceId": {
+                        "type": "string"
+                      },
+                      "amplitudeSessionId": {
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "userId": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
         },
         "responses": {
           "default": {
-            "$ref": "#/components/responses/CallableResponse"
+            "description": "Response status is unknown; body shape follows cited research where present.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallableResponse"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -88,11 +308,98 @@
       "post": {
         "operationId": "createTextBlast",
         "requestBody": {
-          "$ref": "#/components/requestBodies/TextBlastRequest"
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "params",
+                      "amplitudeDeviceId"
+                    ],
+                    "properties": {
+                      "params": {
+                        "type": "object",
+                        "required": [
+                          "eventId",
+                          "message"
+                        ],
+                        "properties": {
+                          "eventId": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "object",
+                            "required": [
+                              "text",
+                              "to",
+                              "showOnEventPage"
+                            ],
+                            "properties": {
+                              "text": {
+                                "type": "string",
+                                "maxLength": 480
+                              },
+                              "to": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "showOnEventPage": {
+                                "type": "boolean"
+                              },
+                              "images": {
+                                "type": "array",
+                                "maxItems": 1,
+                                "items": {
+                                  "type": "object",
+                                  "additionalProperties": true
+                                }
+                              }
+                            },
+                            "additionalProperties": true
+                          }
+                        },
+                        "additionalProperties": true
+                      },
+                      "amplitudeDeviceId": {
+                        "type": "string"
+                      },
+                      "amplitudeSessionId": {
+                        "type": "integer"
+                      },
+                      "userId": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "additionalProperties": true
+                  }
+                },
+                "additionalProperties": true
+              }
+            }
+          }
         },
         "responses": {
           "default": {
-            "$ref": "#/components/responses/CallableResponse"
+            "description": "Response status is unknown; body shape follows cited research where present.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallableResponse"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -106,11 +413,74 @@
       "post": {
         "operationId": "addInvitedGuestsAsHost",
         "requestBody": {
-          "$ref": "#/components/requestBodies/CallableRequest"
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "params",
+                      "amplitudeDeviceId"
+                    ],
+                    "properties": {
+                      "params": {
+                        "type": "object",
+                        "properties": {
+                          "eventId": {
+                            "type": "string"
+                          },
+                          "guests": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "additionalProperties": true
+                            }
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "eventId",
+                          "guests"
+                        ]
+                      },
+                      "amplitudeDeviceId": {
+                        "type": "string"
+                      },
+                      "amplitudeSessionId": {
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "userId": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
         },
         "responses": {
           "default": {
-            "$ref": "#/components/responses/CallableResponse"
+            "description": "Response status is unknown; body shape follows cited research where present.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallableResponse"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -124,11 +494,70 @@
       "post": {
         "operationId": "createCohostRequest",
         "requestBody": {
-          "$ref": "#/components/requestBodies/CallableRequest"
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "params",
+                      "amplitudeDeviceId"
+                    ],
+                    "properties": {
+                      "params": {
+                        "type": "object",
+                        "properties": {
+                          "eventId": {
+                            "type": "string"
+                          },
+                          "targetUserId": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "eventId",
+                          "targetUserId"
+                        ]
+                      },
+                      "amplitudeDeviceId": {
+                        "type": "string"
+                      },
+                      "amplitudeSessionId": {
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "userId": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
         },
         "responses": {
           "default": {
-            "$ref": "#/components/responses/CallableResponse"
+            "description": "Response status is unknown; body shape follows cited research where present.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallableResponse"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -142,11 +571,70 @@
       "post": {
         "operationId": "deleteCohostRequest",
         "requestBody": {
-          "$ref": "#/components/requestBodies/CallableRequest"
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "params",
+                      "amplitudeDeviceId"
+                    ],
+                    "properties": {
+                      "params": {
+                        "type": "object",
+                        "properties": {
+                          "eventId": {
+                            "type": "string"
+                          },
+                          "targetUserId": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "eventId",
+                          "targetUserId"
+                        ]
+                      },
+                      "amplitudeDeviceId": {
+                        "type": "string"
+                      },
+                      "amplitudeSessionId": {
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "userId": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
         },
         "responses": {
           "default": {
-            "$ref": "#/components/responses/CallableResponse"
+            "description": "Response status is unknown; body shape follows cited research where present.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallableResponse"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -160,11 +648,70 @@
       "post": {
         "operationId": "removeCohost",
         "requestBody": {
-          "$ref": "#/components/requestBodies/CallableRequest"
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "params",
+                      "amplitudeDeviceId"
+                    ],
+                    "properties": {
+                      "params": {
+                        "type": "object",
+                        "properties": {
+                          "eventId": {
+                            "type": "string"
+                          },
+                          "targetUserId": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "eventId",
+                          "targetUserId"
+                        ]
+                      },
+                      "amplitudeDeviceId": {
+                        "type": "string"
+                      },
+                      "amplitudeSessionId": {
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "userId": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
         },
         "responses": {
           "default": {
-            "$ref": "#/components/responses/CallableResponse"
+            "description": "Response status is unknown; body shape follows cited research where present.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallableResponse"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -178,11 +725,66 @@
       "post": {
         "operationId": "generateEventCohostLink",
         "requestBody": {
-          "$ref": "#/components/requestBodies/CallableRequest"
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "params",
+                      "amplitudeDeviceId"
+                    ],
+                    "properties": {
+                      "params": {
+                        "type": "object",
+                        "properties": {
+                          "eventId": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "eventId"
+                        ]
+                      },
+                      "amplitudeDeviceId": {
+                        "type": "string"
+                      },
+                      "amplitudeSessionId": {
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "userId": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
         },
         "responses": {
           "default": {
-            "$ref": "#/components/responses/CallableResponse"
+            "description": "Response status is unknown; body shape follows cited research where present.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallableResponse"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -196,11 +798,66 @@
       "post": {
         "operationId": "revokeEventCohostLink",
         "requestBody": {
-          "$ref": "#/components/requestBodies/CallableRequest"
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "params",
+                      "amplitudeDeviceId"
+                    ],
+                    "properties": {
+                      "params": {
+                        "type": "object",
+                        "properties": {
+                          "eventId": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "eventId"
+                        ]
+                      },
+                      "amplitudeDeviceId": {
+                        "type": "string"
+                      },
+                      "amplitudeSessionId": {
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "userId": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
         },
         "responses": {
           "default": {
-            "$ref": "#/components/responses/CallableResponse"
+            "description": "Response status is unknown; body shape follows cited research where present.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallableResponse"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -214,11 +871,59 @@
       "post": {
         "operationId": "getMyUpcomingEventsForHomePage",
         "requestBody": {
-          "$ref": "#/components/requestBodies/CallableRequest"
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "params",
+                      "amplitudeDeviceId"
+                    ],
+                    "properties": {
+                      "params": {
+                        "type": "object",
+                        "properties": {},
+                        "additionalProperties": false
+                      },
+                      "amplitudeDeviceId": {
+                        "type": "string"
+                      },
+                      "amplitudeSessionId": {
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "userId": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
         },
         "responses": {
           "default": {
-            "$ref": "#/components/responses/CallableResponse"
+            "description": "Response status is unknown; body shape follows cited research where present.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallableResponse"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -232,11 +937,59 @@
       "post": {
         "operationId": "getMyPastEventsForHomePage",
         "requestBody": {
-          "$ref": "#/components/requestBodies/CallableRequest"
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "params",
+                      "amplitudeDeviceId"
+                    ],
+                    "properties": {
+                      "params": {
+                        "type": "object",
+                        "properties": {},
+                        "additionalProperties": false
+                      },
+                      "amplitudeDeviceId": {
+                        "type": "string"
+                      },
+                      "amplitudeSessionId": {
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "userId": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
         },
         "responses": {
           "default": {
-            "$ref": "#/components/responses/CallableResponse"
+            "description": "Response status is unknown; body shape follows cited research where present.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallableResponse"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -250,11 +1003,70 @@
       "post": {
         "operationId": "addGuest",
         "requestBody": {
-          "$ref": "#/components/requestBodies/CallableRequest"
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "params",
+                      "amplitudeDeviceId"
+                    ],
+                    "properties": {
+                      "params": {
+                        "type": "object",
+                        "properties": {
+                          "eventId": {
+                            "type": "string"
+                          },
+                          "rsvp": {
+                            "$ref": "#/components/schemas/RsvpDraft"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "eventId",
+                          "rsvp"
+                        ]
+                      },
+                      "amplitudeDeviceId": {
+                        "type": "string"
+                      },
+                      "amplitudeSessionId": {
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "userId": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
         },
         "responses": {
           "default": {
-            "$ref": "#/components/responses/CallableResponse"
+            "description": "Response status is unknown; body shape follows cited research where present.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallableResponse"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -268,11 +1080,74 @@
       "post": {
         "operationId": "markEventInterest",
         "requestBody": {
-          "$ref": "#/components/requestBodies/CallableRequest"
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "params",
+                      "amplitudeDeviceId"
+                    ],
+                    "properties": {
+                      "params": {
+                        "type": "object",
+                        "properties": {
+                          "eventId": {
+                            "type": "string"
+                          },
+                          "interested": {
+                            "type": "boolean"
+                          },
+                          "source": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "eventId",
+                          "interested",
+                          "source"
+                        ]
+                      },
+                      "amplitudeDeviceId": {
+                        "type": "string"
+                      },
+                      "amplitudeSessionId": {
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "userId": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
         },
         "responses": {
           "default": {
-            "$ref": "#/components/responses/CallableResponse"
+            "description": "Response status is unknown; body shape follows cited research where present.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallableResponse"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -286,11 +1161,66 @@
       "post": {
         "operationId": "getCurrentGuest",
         "requestBody": {
-          "$ref": "#/components/requestBodies/CallableRequest"
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "params",
+                      "amplitudeDeviceId"
+                    ],
+                    "properties": {
+                      "params": {
+                        "type": "object",
+                        "properties": {
+                          "eventId": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "eventId"
+                        ]
+                      },
+                      "amplitudeDeviceId": {
+                        "type": "string"
+                      },
+                      "amplitudeSessionId": {
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "userId": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
         },
         "responses": {
           "default": {
-            "$ref": "#/components/responses/CallableResponse"
+            "description": "Response status is unknown; body shape follows cited research where present.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallableResponse"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -305,12 +1235,24 @@
         "operationId": "firestoreGetEvent",
         "parameters": [
           {
-            "$ref": "#/components/parameters/EventId"
+            "name": "eventId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "default": {
-            "$ref": "#/components/responses/FirestoreDocument"
+            "description": "Response status is unknown; body shape follows cited research where present.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FirestoreDocument"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -328,18 +1270,47 @@
         "operationId": "firestorePatchEvent",
         "parameters": [
           {
-            "$ref": "#/components/parameters/EventId"
+            "name": "eventId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           },
           {
-            "$ref": "#/components/parameters/UpdateMask"
+            "name": "updateMask.fieldPaths",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "style": "form",
+            "explode": true
           }
         ],
         "requestBody": {
-          "$ref": "#/components/requestBodies/FirestoreWrite"
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FirestoreWriteDocument"
+              }
+            }
+          }
         },
         "responses": {
           "default": {
-            "$ref": "#/components/responses/FirestoreDocument"
+            "description": "Response status is unknown; body shape follows cited research where present.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FirestoreDocument"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -359,15 +1330,32 @@
         "operationId": "firestoreGetGuest",
         "parameters": [
           {
-            "$ref": "#/components/parameters/EventId"
+            "name": "eventId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           },
           {
-            "$ref": "#/components/parameters/GuestId"
+            "name": "guestId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "default": {
-            "$ref": "#/components/responses/FirestoreDocument"
+            "description": "Response status is unknown; body shape follows cited research where present.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FirestoreDocument"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -387,18 +1375,42 @@
         "operationId": "firestoreListDocuments",
         "parameters": [
           {
-            "$ref": "#/components/parameters/CollectionPath"
+            "name": "collectionPath",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Slash-delimited document collection path; custom client preserves path segments."
           },
           {
-            "$ref": "#/components/parameters/PageSize"
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 100
+            }
           },
           {
-            "$ref": "#/components/parameters/PageToken"
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "default": {
-            "$ref": "#/components/responses/FirestoreList"
+            "description": "Response status is unknown; body shape follows cited research where present.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FirestoreListResponse"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -417,11 +1429,41 @@
       "post": {
         "operationId": "refreshToken",
         "requestBody": {
-          "$ref": "#/components/requestBodies/RefreshToken"
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "grant_type",
+                  "refresh_token"
+                ],
+                "properties": {
+                  "grant_type": {
+                    "type": "string",
+                    "enum": [
+                      "refresh_token"
+                    ]
+                  },
+                  "refresh_token": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
         },
         "responses": {
           "default": {
-            "$ref": "#/components/responses/RefreshToken"
+            "description": "Response status is unknown; body shape follows cited research where present.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RefreshTokenResponse"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -440,11 +1482,86 @@
       "post": {
         "operationId": "sendAuthCodeTrusted",
         "requestBody": {
-          "$ref": "#/components/requestBodies/CallableRequest"
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "params",
+                      "amplitudeDeviceId"
+                    ],
+                    "properties": {
+                      "params": {
+                        "type": "object",
+                        "required": [
+                          "displayName",
+                          "phoneNumber",
+                          "silent",
+                          "channelPreference",
+                          "captchaToken",
+                          "useAppleBusinessUpdates"
+                        ],
+                        "properties": {
+                          "displayName": {
+                            "type": "string"
+                          },
+                          "phoneNumber": {
+                            "type": "string"
+                          },
+                          "silent": {
+                            "type": "boolean"
+                          },
+                          "channelPreference": {
+                            "type": "string",
+                            "enum": [
+                              "sms"
+                            ]
+                          },
+                          "captchaToken": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "useAppleBusinessUpdates": {
+                            "type": "boolean"
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "amplitudeDeviceId": {
+                        "type": "string"
+                      },
+                      "amplitudeSessionId": {
+                        "type": "integer",
+                        "format": "int64"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
         },
         "responses": {
           "default": {
-            "$ref": "#/components/responses/CallableResponse"
+            "description": "Response status is unknown; body shape follows cited research where present.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallableResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -453,11 +1570,76 @@
       "post": {
         "operationId": "getLoginToken",
         "requestBody": {
-          "$ref": "#/components/requestBodies/CallableRequest"
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "params",
+                      "amplitudeDeviceId"
+                    ],
+                    "properties": {
+                      "params": {
+                        "type": "object",
+                        "required": [
+                          "phoneNumber",
+                          "authCode",
+                          "affiliateId",
+                          "utms"
+                        ],
+                        "properties": {
+                          "phoneNumber": {
+                            "type": "string"
+                          },
+                          "authCode": {
+                            "type": "string"
+                          },
+                          "affiliateId": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "utms": {
+                            "type": "object",
+                            "additionalProperties": true
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "amplitudeDeviceId": {
+                        "type": "string"
+                      },
+                      "amplitudeSessionId": {
+                        "type": "integer",
+                        "format": "int64"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
         },
         "responses": {
           "default": {
-            "$ref": "#/components/responses/CallableResponse"
+            "description": "Response status is unknown; body shape follows cited research where present.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallableResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -466,11 +1648,38 @@
       "post": {
         "operationId": "signInWithCustomToken",
         "requestBody": {
-          "$ref": "#/components/requestBodies/CustomToken"
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "token",
+                  "returnSecureToken"
+                ],
+                "properties": {
+                  "token": {
+                    "type": "string"
+                  },
+                  "returnSecureToken": {
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
         },
         "responses": {
           "default": {
-            "$ref": "#/components/responses/FirebaseSignIn"
+            "description": "Response status is unknown; body shape follows cited research where present.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FirebaseSignInResponse"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -489,11 +1698,34 @@
       "post": {
         "operationId": "lookupFirebaseUser",
         "requestBody": {
-          "$ref": "#/components/requestBodies/FirebaseLookup"
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "idToken"
+                ],
+                "properties": {
+                  "idToken": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
         },
         "responses": {
           "default": {
-            "$ref": "#/components/responses/FirebaseLookup"
+            "description": "Response status is unknown; body shape follows cited research where present.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FirebaseLookupResponse"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -515,17 +1747,45 @@
           {
             "name": "uploadType",
             "in": "query",
+            "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "enum": [
+                "event_poster"
+              ]
             }
           }
         ],
         "requestBody": {
-          "$ref": "#/components/requestBodies/UploadPhoto"
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "file"
+                ],
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
         },
         "responses": {
           "default": {
-            "$ref": "#/components/responses/UploadPhoto"
+            "description": "Response status is unknown; body shape follows cited research where present.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UploadPhotoResponse"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -545,7 +1805,17 @@
         "operationId": "getPosterCatalog",
         "responses": {
           "default": {
-            "$ref": "#/components/responses/PosterCatalog"
+            "description": "Response status is unknown; body shape follows cited research where present.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Poster"
+                  }
+                }
+              }
+            }
           }
         },
         "servers": [
@@ -568,321 +1838,136 @@
         "name": "key"
       }
     },
-    "parameters": {
-      "EventId": {
-        "name": "eventId",
-        "in": "path",
-        "required": true,
-        "schema": {
-          "type": "string"
-        }
-      },
-      "GuestId": {
-        "name": "guestId",
-        "in": "path",
-        "required": true,
-        "schema": {
-          "type": "string"
-        }
-      },
-      "CollectionPath": {
-        "name": "collectionPath",
-        "in": "path",
-        "required": true,
-        "schema": {
-          "type": "string"
-        }
-      },
-      "UpdateMask": {
-        "name": "updateMask.fieldPaths",
-        "in": "query",
-        "schema": {
-          "type": "string"
-        }
-      },
-      "PageSize": {
-        "name": "pageSize",
-        "in": "query",
-        "schema": {
-          "type": "integer",
-          "minimum": 1
-        }
-      },
-      "PageToken": {
-        "name": "pageToken",
-        "in": "query",
-        "schema": {
-          "type": "string"
-        }
-      }
-    },
-    "requestBodies": {
-      "CallableRequest": {
-        "required": true,
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/CallableRequest"
-            }
-          }
-        }
-      },
-      "TextBlastRequest": {
-        "required": true,
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/TextBlastRequest"
-            }
-          }
-        }
-      },
-      "FirestoreWrite": {
-        "required": true,
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/FirestoreWriteDocument"
-            }
-          }
-        }
-      },
-      "RefreshToken": {
-        "required": true,
-        "content": {
-          "application/x-www-form-urlencoded": {
-            "schema": {
-              "$ref": "#/components/schemas/RefreshTokenRequest"
-            }
-          }
-        }
-      },
-      "CustomToken": {
-        "required": true,
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/CustomTokenRequest"
-            }
-          }
-        }
-      },
-      "FirebaseLookup": {
-        "required": true,
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/FirebaseLookupRequest"
-            }
-          }
-        }
-      },
-      "UploadPhoto": {
-        "required": true,
-        "content": {
-          "multipart/form-data": {
-            "schema": {
-              "type": "object",
-              "required": [
-                "file"
-              ],
-              "properties": {
-                "file": {
-                  "type": "string",
-                  "format": "binary"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "responses": {
-      "CallableResponse": {
-        "description": "Callable response envelope",
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/CallableResponse"
-            }
-          }
-        }
-      },
-      "FirestoreDocument": {
-        "description": "Firestore document",
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/FirestoreDocument"
-            }
-          }
-        }
-      },
-      "FirestoreList": {
-        "description": "Firestore document list",
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/FirestoreListResponse"
-            }
-          }
-        }
-      },
-      "RefreshToken": {
-        "description": "Firebase token refresh response",
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/RefreshTokenResponse"
-            }
-          }
-        }
-      },
-      "FirebaseSignIn": {
-        "description": "Firebase custom-token sign-in response",
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/FirebaseSignInResponse"
-            }
-          }
-        }
-      },
-      "FirebaseLookup": {
-        "description": "Firebase user lookup response",
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/FirebaseLookupResponse"
-            }
-          }
-        }
-      },
-      "UploadPhoto": {
-        "description": "Photo upload response",
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/UploadPhotoResponse"
-            }
-          }
-        }
-      },
-      "PosterCatalog": {
-        "description": "Poster catalog",
-        "content": {
-          "application/json": {
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Poster"
-              }
-            }
-          }
-        }
-      }
-    },
     "schemas": {
-      "CallableRequest": {
+      "EventDraft": {
         "type": "object",
         "required": [
-          "data"
+          "title",
+          "startDate",
+          "timezone",
+          "displaySettings"
         ],
         "properties": {
-          "data": {
-            "type": "object",
-            "required": [
-              "params",
-              "amplitudeDeviceId"
-            ],
-            "properties": {
-              "params": {
-                "type": "object",
-                "additionalProperties": true
-              },
-              "amplitudeDeviceId": {
-                "type": "string"
-              },
-              "amplitudeSessionId": {
-                "type": "integer"
-              },
-              "userId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              }
-            },
-            "additionalProperties": true
-          }
-        },
-        "additionalProperties": true
-      },
-      "TextBlastRequest": {
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "properties": {
-          "data": {
-            "type": "object",
-            "required": [
-              "params"
-            ],
-            "properties": {
-              "params": {
-                "type": "object",
-                "required": [
-                  "eventId",
-                  "message"
-                ],
-                "properties": {
-                  "eventId": {
-                    "type": "string"
-                  },
-                  "message": {
-                    "$ref": "#/components/schemas/TextBlastMessage"
-                  }
-                },
-                "additionalProperties": true
-              }
-            },
-            "additionalProperties": true
-          }
-        },
-        "additionalProperties": true
-      },
-      "TextBlastMessage": {
-        "type": "object",
-        "required": [
-          "text",
-          "to",
-          "showOnEventPage"
-        ],
-        "properties": {
-          "text": {
-            "type": "string",
-            "maxLength": 480
+          "title": {
+            "type": "string"
           },
-          "to": {
+          "startDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "endDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "timezone": {
+            "type": "string"
+          },
+          "displaySettings": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "visibility": {
+            "type": "string",
+            "enum": [
+              "public",
+              "private"
+            ]
+          },
+          "location": {
+            "type": "string"
+          },
+          "address": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "guestLimit": {
+            "type": "integer"
+          },
+          "links": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "image": {}
+        },
+        "additionalProperties": true
+      },
+      "RsvpDraft": {
+        "type": "object",
+        "required": [
+          "name",
+          "count",
+          "plusOnes",
+          "status",
+          "timezone"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "count": {
+            "type": "integer"
+          },
+          "plusOnes": {
             "type": "array",
             "items": {
               "type": "string"
             }
           },
-          "showOnEventPage": {
-            "type": "boolean"
+          "message": {
+            "type": [
+              "string",
+              "null"
+            ]
           },
-          "images": {
-            "type": "array",
-            "maxItems": 1,
-            "items": {
-              "type": "object",
-              "additionalProperties": true
-            }
+          "emailInvitationId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "status": {
+            "type": "string"
+          },
+          "guestId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "timezone": {
+            "type": "string"
+          },
+          "password": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "questionnaireResponse": {
+            "type": "object",
+            "properties": {
+              "questionnaireVersion": {
+                "type": "integer"
+              },
+              "answers": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": [
+              "questionnaireVersion",
+              "answers"
+            ]
           }
         },
-        "additionalProperties": true
+        "additionalProperties": false
       },
       "CallableResponse": {
         "type": "object",
@@ -897,14 +1982,8 @@
         },
         "additionalProperties": true
       },
-      "FirestoreWriteDocument": {
+      "FirestoreValue": {
         "type": "object",
-        "properties": {
-          "fields": {
-            "type": "object",
-            "additionalProperties": true
-          }
-        },
         "additionalProperties": true
       },
       "FirestoreDocument": {
@@ -915,16 +1994,35 @@
           },
           "fields": {
             "type": "object",
-            "additionalProperties": true
+            "additionalProperties": {
+              "$ref": "#/components/schemas/FirestoreValue"
+            }
           },
           "createTime": {
-            "type": "string"
+            "type": "string",
+            "format": "date-time"
           },
           "updateTime": {
-            "type": "string"
+            "type": "string",
+            "format": "date-time"
           }
         },
         "additionalProperties": true
+      },
+      "FirestoreWriteDocument": {
+        "type": "object",
+        "required": [
+          "fields"
+        ],
+        "properties": {
+          "fields": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/FirestoreValue"
+            }
+          }
+        },
+        "additionalProperties": false
       },
       "FirestoreListResponse": {
         "type": "object",
@@ -941,92 +2039,36 @@
         },
         "additionalProperties": true
       },
-      "RefreshTokenRequest": {
-        "type": "object",
-        "required": [
-          "grant_type",
-          "refresh_token"
-        ],
-        "properties": {
-          "grant_type": {
-            "const": "refresh_token"
-          },
-          "refresh_token": {
-            "type": "string"
-          }
-        }
-      },
       "RefreshTokenResponse": {
         "type": "object",
-        "properties": {
-          "id_token": {
-            "type": "string"
-          },
-          "refresh_token": {
-            "type": "string"
-          },
-          "expires_in": {
-            "type": "string"
-          },
-          "user_id": {
-            "type": "string"
-          }
-        },
         "additionalProperties": true
-      },
-      "CustomTokenRequest": {
-        "type": "object",
-        "required": [
-          "token",
-          "returnSecureToken"
-        ],
-        "properties": {
-          "token": {
-            "type": "string"
-          },
-          "returnSecureToken": {
-            "const": true
-          }
-        }
       },
       "FirebaseSignInResponse": {
         "type": "object",
-        "properties": {
-          "idToken": {
-            "type": "string"
-          },
-          "refreshToken": {
-            "type": "string"
-          },
-          "expiresIn": {
-            "type": "string"
-          },
-          "localId": {
-            "type": "string"
-          }
-        },
         "additionalProperties": true
-      },
-      "FirebaseLookupRequest": {
-        "type": "object",
-        "required": [
-          "idToken"
-        ],
-        "properties": {
-          "idToken": {
-            "type": "string"
-          }
-        }
       },
       "FirebaseLookupResponse": {
         "type": "object",
+        "additionalProperties": true
+      },
+      "UploadData": {
+        "type": "object",
+        "required": [
+          "url"
+        ],
         "properties": {
-          "users": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "additionalProperties": true
-            }
+          "url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "contentType": {
+            "type": "string"
+          },
+          "height": {
+            "type": "integer"
+          },
+          "width": {
+            "type": "integer"
           }
         },
         "additionalProperties": true
@@ -1035,10 +2077,13 @@
         "type": "object",
         "properties": {
           "uploadData": {
+            "$ref": "#/components/schemas/UploadData"
+          },
+          "result": {
             "type": "object",
             "properties": {
-              "url": {
-                "type": "string"
+              "uploadData": {
+                "$ref": "#/components/schemas/UploadData"
               }
             },
             "additionalProperties": true
@@ -1056,16 +2101,32 @@
             "type": "string"
           },
           "url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "blurHash": {
             "type": "string"
           },
           "contentType": {
             "type": "string"
           },
+          "height": {
+            "type": "integer"
+          },
           "width": {
             "type": "integer"
           },
-          "height": {
-            "type": "integer"
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "categories": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "additionalProperties": true

--- a/spec/partiful.openapi.json
+++ b/spec/partiful.openapi.json
@@ -2,86 +2,1074 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Partiful remote API contract",
-    "version": "1.0.0",
-    "description": "Versioned, remote-only transport snapshot. Evidence classifications and uncertainty are recorded in spec/partiful.api-evidence.json."
+    "version": "2026-08-10.1",
+    "description": "Proposed, versioned remote-only transport snapshot pending owner approval. Evidence classifications and uncertainty are recorded in spec/partiful.api-evidence.json."
   },
-  "servers": [{ "url": "https://api.partiful.com", "description": "Partiful callable service" }],
+  "servers": [
+    {
+      "url": "https://api.partiful.com",
+      "description": "Partiful callable service"
+    }
+  ],
   "paths": {
-    "/createEvent": { "post": { "operationId": "createEvent", "requestBody": { "$ref": "#/components/requestBodies/CallableRequest" }, "responses": { "200": { "$ref": "#/components/responses/CallableResponse" } }, "security": [{ "firebaseBearer": [] }] } },
-    "/cancelEvent": { "post": { "operationId": "cancelEvent", "requestBody": { "$ref": "#/components/requestBodies/CallableRequest" }, "responses": { "200": { "$ref": "#/components/responses/CallableResponse" } }, "security": [{ "firebaseBearer": [] }] } },
-    "/getEventInfo": { "post": { "operationId": "getEventInfo", "requestBody": { "$ref": "#/components/requestBodies/CallableRequest" }, "responses": { "200": { "$ref": "#/components/responses/CallableResponse" } }, "security": [{ "firebaseBearer": [] }] } },
-    "/getContacts": { "post": { "operationId": "getContacts", "requestBody": { "$ref": "#/components/requestBodies/CallableRequest" }, "responses": { "200": { "$ref": "#/components/responses/CallableResponse" } }, "security": [{ "firebaseBearer": [] }] } },
-    "/createTextBlast": { "post": { "operationId": "createTextBlast", "requestBody": { "$ref": "#/components/requestBodies/TextBlastRequest" }, "responses": { "200": { "$ref": "#/components/responses/CallableResponse" } }, "security": [{ "firebaseBearer": [] }] } },
-    "/addInvitedGuestsAsHost": { "post": { "operationId": "addInvitedGuestsAsHost", "requestBody": { "$ref": "#/components/requestBodies/CallableRequest" }, "responses": { "200": { "$ref": "#/components/responses/CallableResponse" } }, "security": [{ "firebaseBearer": [] }] } },
-    "/createCohostRequest": { "post": { "operationId": "createCohostRequest", "requestBody": { "$ref": "#/components/requestBodies/CallableRequest" }, "responses": { "200": { "$ref": "#/components/responses/CallableResponse" } }, "security": [{ "firebaseBearer": [] }] } },
-    "/deleteCohostRequest": { "post": { "operationId": "deleteCohostRequest", "requestBody": { "$ref": "#/components/requestBodies/CallableRequest" }, "responses": { "200": { "$ref": "#/components/responses/CallableResponse" } }, "security": [{ "firebaseBearer": [] }] } },
-    "/removeCohost": { "post": { "operationId": "removeCohost", "requestBody": { "$ref": "#/components/requestBodies/CallableRequest" }, "responses": { "200": { "$ref": "#/components/responses/CallableResponse" } }, "security": [{ "firebaseBearer": [] }] } },
-    "/generateEventCohostLink": { "post": { "operationId": "generateEventCohostLink", "requestBody": { "$ref": "#/components/requestBodies/CallableRequest" }, "responses": { "200": { "$ref": "#/components/responses/CallableResponse" } }, "security": [{ "firebaseBearer": [] }] } },
-    "/revokeEventCohostLink": { "post": { "operationId": "revokeEventCohostLink", "requestBody": { "$ref": "#/components/requestBodies/CallableRequest" }, "responses": { "200": { "$ref": "#/components/responses/CallableResponse" } }, "security": [{ "firebaseBearer": [] }] } },
-    "/getMyUpcomingEventsForHomePage": { "post": { "operationId": "getMyUpcomingEventsForHomePage", "requestBody": { "$ref": "#/components/requestBodies/CallableRequest" }, "responses": { "200": { "$ref": "#/components/responses/CallableResponse" } }, "security": [{ "firebaseBearer": [] }] } },
-    "/getMyPastEventsForHomePage": { "post": { "operationId": "getMyPastEventsForHomePage", "requestBody": { "$ref": "#/components/requestBodies/CallableRequest" }, "responses": { "200": { "$ref": "#/components/responses/CallableResponse" } }, "security": [{ "firebaseBearer": [] }] } },
-    "/addGuest": { "post": { "operationId": "addGuest", "requestBody": { "$ref": "#/components/requestBodies/CallableRequest" }, "responses": { "200": { "$ref": "#/components/responses/CallableResponse" } }, "security": [{ "firebaseBearer": [] }] } },
-    "/markEventInterest": { "post": { "operationId": "markEventInterest", "requestBody": { "$ref": "#/components/requestBodies/CallableRequest" }, "responses": { "200": { "$ref": "#/components/responses/CallableResponse" } }, "security": [{ "firebaseBearer": [] }] } },
-    "/getCurrentGuest": { "post": { "operationId": "getCurrentGuest", "requestBody": { "$ref": "#/components/requestBodies/CallableRequest" }, "responses": { "200": { "$ref": "#/components/responses/CallableResponse" } }, "security": [{ "firebaseBearer": [] }] } },
-    "/v1/projects/getpartiful/databases/(default)/documents/events/{eventId}": {
-      "get": { "operationId": "firestoreGetEvent", "parameters": [{ "$ref": "#/components/parameters/EventId" }], "responses": { "200": { "$ref": "#/components/responses/FirestoreDocument" } }, "security": [{ "firebaseBearer": [] }], "servers": [{ "url": "https://firestore.googleapis.com" }] },
-      "patch": { "operationId": "firestorePatchEvent", "parameters": [{ "$ref": "#/components/parameters/EventId" }, { "$ref": "#/components/parameters/UpdateMask" }], "requestBody": { "$ref": "#/components/requestBodies/FirestoreWrite" }, "responses": { "200": { "$ref": "#/components/responses/FirestoreDocument" } }, "security": [{ "firebaseBearer": [] }], "servers": [{ "url": "https://firestore.googleapis.com" }] }
+    "/createEvent": {
+      "post": {
+        "operationId": "createEvent",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/CallableRequest"
+        },
+        "responses": {
+          "default": {
+            "$ref": "#/components/responses/CallableResponse"
+          }
+        },
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ]
+      }
     },
-    "/v1/projects/getpartiful/databases/(default)/documents/events/{eventId}/guests/{guestId}": { "get": { "operationId": "firestoreGetGuest", "parameters": [{ "$ref": "#/components/parameters/EventId" }, { "$ref": "#/components/parameters/GuestId" }], "responses": { "200": { "$ref": "#/components/responses/FirestoreDocument" } }, "security": [{ "firebaseBearer": [] }], "servers": [{ "url": "https://firestore.googleapis.com" }] } },
-    "/v1/projects/getpartiful/databases/(default)/documents/{collectionPath}": { "get": { "operationId": "firestoreListDocuments", "parameters": [{ "$ref": "#/components/parameters/CollectionPath" }, { "$ref": "#/components/parameters/PageSize" }, { "$ref": "#/components/parameters/PageToken" }], "responses": { "200": { "$ref": "#/components/responses/FirestoreList" } }, "security": [{ "firebaseBearer": [] }], "servers": [{ "url": "https://firestore.googleapis.com" }] } },
-    "/v1/token": { "post": { "operationId": "refreshToken", "requestBody": { "$ref": "#/components/requestBodies/RefreshToken" }, "responses": { "200": { "$ref": "#/components/responses/RefreshToken" } }, "security": [{ "firebaseApiKey": [] }], "servers": [{ "url": "https://securetoken.googleapis.com" }] } },
-    "/sendAuthCodeTrusted": { "post": { "operationId": "sendAuthCodeTrusted", "requestBody": { "$ref": "#/components/requestBodies/CallableRequest" }, "responses": { "200": { "$ref": "#/components/responses/CallableResponse" } } } },
-    "/getLoginToken": { "post": { "operationId": "getLoginToken", "requestBody": { "$ref": "#/components/requestBodies/CallableRequest" }, "responses": { "200": { "$ref": "#/components/responses/CallableResponse" } } } },
-    "/v1/accounts:signInWithCustomToken": { "post": { "operationId": "signInWithCustomToken", "requestBody": { "$ref": "#/components/requestBodies/CustomToken" }, "responses": { "200": { "$ref": "#/components/responses/FirebaseSignIn" } }, "security": [{ "firebaseApiKey": [] }], "servers": [{ "url": "https://identitytoolkit.googleapis.com" }] } },
-    "/v1/accounts:lookup": { "post": { "operationId": "lookupFirebaseUser", "requestBody": { "$ref": "#/components/requestBodies/FirebaseLookup" }, "responses": { "200": { "$ref": "#/components/responses/FirebaseLookup" } }, "security": [{ "firebaseApiKey": [] }], "servers": [{ "url": "https://identitytoolkit.googleapis.com" }] } },
-    "/uploadPhoto": { "post": { "operationId": "uploadEventPhoto", "parameters": [{ "name": "uploadType", "in": "query", "schema": { "type": "string" } }], "requestBody": { "$ref": "#/components/requestBodies/UploadPhoto" }, "responses": { "200": { "$ref": "#/components/responses/UploadPhoto" } }, "security": [{ "firebaseBearer": [] }], "servers": [{ "url": "https://us-central1-getpartiful.cloudfunctions.net" }] } },
-    "/posters.json": { "get": { "operationId": "getPosterCatalog", "responses": { "200": { "$ref": "#/components/responses/PosterCatalog" } }, "servers": [{ "url": "https://assets.getpartiful.com" }] } }
+    "/cancelEvent": {
+      "post": {
+        "operationId": "cancelEvent",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/CallableRequest"
+        },
+        "responses": {
+          "default": {
+            "$ref": "#/components/responses/CallableResponse"
+          }
+        },
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ]
+      }
+    },
+    "/getEventInfo": {
+      "post": {
+        "operationId": "getEventInfo",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/CallableRequest"
+        },
+        "responses": {
+          "default": {
+            "$ref": "#/components/responses/CallableResponse"
+          }
+        },
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ]
+      }
+    },
+    "/getContacts": {
+      "post": {
+        "operationId": "getContacts",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/CallableRequest"
+        },
+        "responses": {
+          "default": {
+            "$ref": "#/components/responses/CallableResponse"
+          }
+        },
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ]
+      }
+    },
+    "/createTextBlast": {
+      "post": {
+        "operationId": "createTextBlast",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/TextBlastRequest"
+        },
+        "responses": {
+          "default": {
+            "$ref": "#/components/responses/CallableResponse"
+          }
+        },
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ]
+      }
+    },
+    "/addInvitedGuestsAsHost": {
+      "post": {
+        "operationId": "addInvitedGuestsAsHost",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/CallableRequest"
+        },
+        "responses": {
+          "default": {
+            "$ref": "#/components/responses/CallableResponse"
+          }
+        },
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ]
+      }
+    },
+    "/createCohostRequest": {
+      "post": {
+        "operationId": "createCohostRequest",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/CallableRequest"
+        },
+        "responses": {
+          "default": {
+            "$ref": "#/components/responses/CallableResponse"
+          }
+        },
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ]
+      }
+    },
+    "/deleteCohostRequest": {
+      "post": {
+        "operationId": "deleteCohostRequest",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/CallableRequest"
+        },
+        "responses": {
+          "default": {
+            "$ref": "#/components/responses/CallableResponse"
+          }
+        },
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ]
+      }
+    },
+    "/removeCohost": {
+      "post": {
+        "operationId": "removeCohost",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/CallableRequest"
+        },
+        "responses": {
+          "default": {
+            "$ref": "#/components/responses/CallableResponse"
+          }
+        },
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ]
+      }
+    },
+    "/generateEventCohostLink": {
+      "post": {
+        "operationId": "generateEventCohostLink",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/CallableRequest"
+        },
+        "responses": {
+          "default": {
+            "$ref": "#/components/responses/CallableResponse"
+          }
+        },
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ]
+      }
+    },
+    "/revokeEventCohostLink": {
+      "post": {
+        "operationId": "revokeEventCohostLink",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/CallableRequest"
+        },
+        "responses": {
+          "default": {
+            "$ref": "#/components/responses/CallableResponse"
+          }
+        },
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ]
+      }
+    },
+    "/getMyUpcomingEventsForHomePage": {
+      "post": {
+        "operationId": "getMyUpcomingEventsForHomePage",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/CallableRequest"
+        },
+        "responses": {
+          "default": {
+            "$ref": "#/components/responses/CallableResponse"
+          }
+        },
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ]
+      }
+    },
+    "/getMyPastEventsForHomePage": {
+      "post": {
+        "operationId": "getMyPastEventsForHomePage",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/CallableRequest"
+        },
+        "responses": {
+          "default": {
+            "$ref": "#/components/responses/CallableResponse"
+          }
+        },
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ]
+      }
+    },
+    "/addGuest": {
+      "post": {
+        "operationId": "addGuest",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/CallableRequest"
+        },
+        "responses": {
+          "default": {
+            "$ref": "#/components/responses/CallableResponse"
+          }
+        },
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ]
+      }
+    },
+    "/markEventInterest": {
+      "post": {
+        "operationId": "markEventInterest",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/CallableRequest"
+        },
+        "responses": {
+          "default": {
+            "$ref": "#/components/responses/CallableResponse"
+          }
+        },
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ]
+      }
+    },
+    "/getCurrentGuest": {
+      "post": {
+        "operationId": "getCurrentGuest",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/CallableRequest"
+        },
+        "responses": {
+          "default": {
+            "$ref": "#/components/responses/CallableResponse"
+          }
+        },
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ]
+      }
+    },
+    "/v1/projects/getpartiful/databases/(default)/documents/events/{eventId}": {
+      "get": {
+        "operationId": "firestoreGetEvent",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/EventId"
+          }
+        ],
+        "responses": {
+          "default": {
+            "$ref": "#/components/responses/FirestoreDocument"
+          }
+        },
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "servers": [
+          {
+            "url": "https://firestore.googleapis.com"
+          }
+        ]
+      },
+      "patch": {
+        "operationId": "firestorePatchEvent",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/EventId"
+          },
+          {
+            "$ref": "#/components/parameters/UpdateMask"
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/FirestoreWrite"
+        },
+        "responses": {
+          "default": {
+            "$ref": "#/components/responses/FirestoreDocument"
+          }
+        },
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "servers": [
+          {
+            "url": "https://firestore.googleapis.com"
+          }
+        ]
+      }
+    },
+    "/v1/projects/getpartiful/databases/(default)/documents/events/{eventId}/guests/{guestId}": {
+      "get": {
+        "operationId": "firestoreGetGuest",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/EventId"
+          },
+          {
+            "$ref": "#/components/parameters/GuestId"
+          }
+        ],
+        "responses": {
+          "default": {
+            "$ref": "#/components/responses/FirestoreDocument"
+          }
+        },
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "servers": [
+          {
+            "url": "https://firestore.googleapis.com"
+          }
+        ]
+      }
+    },
+    "/v1/projects/getpartiful/databases/(default)/documents/{collectionPath}": {
+      "get": {
+        "operationId": "firestoreListDocuments",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/CollectionPath"
+          },
+          {
+            "$ref": "#/components/parameters/PageSize"
+          },
+          {
+            "$ref": "#/components/parameters/PageToken"
+          }
+        ],
+        "responses": {
+          "default": {
+            "$ref": "#/components/responses/FirestoreList"
+          }
+        },
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "servers": [
+          {
+            "url": "https://firestore.googleapis.com"
+          }
+        ]
+      }
+    },
+    "/v1/token": {
+      "post": {
+        "operationId": "refreshToken",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/RefreshToken"
+        },
+        "responses": {
+          "default": {
+            "$ref": "#/components/responses/RefreshToken"
+          }
+        },
+        "security": [
+          {
+            "firebaseApiKey": []
+          }
+        ],
+        "servers": [
+          {
+            "url": "https://securetoken.googleapis.com"
+          }
+        ]
+      }
+    },
+    "/sendAuthCodeTrusted": {
+      "post": {
+        "operationId": "sendAuthCodeTrusted",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/CallableRequest"
+        },
+        "responses": {
+          "default": {
+            "$ref": "#/components/responses/CallableResponse"
+          }
+        }
+      }
+    },
+    "/getLoginToken": {
+      "post": {
+        "operationId": "getLoginToken",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/CallableRequest"
+        },
+        "responses": {
+          "default": {
+            "$ref": "#/components/responses/CallableResponse"
+          }
+        }
+      }
+    },
+    "/v1/accounts:signInWithCustomToken": {
+      "post": {
+        "operationId": "signInWithCustomToken",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/CustomToken"
+        },
+        "responses": {
+          "default": {
+            "$ref": "#/components/responses/FirebaseSignIn"
+          }
+        },
+        "security": [
+          {
+            "firebaseApiKey": []
+          }
+        ],
+        "servers": [
+          {
+            "url": "https://identitytoolkit.googleapis.com"
+          }
+        ]
+      }
+    },
+    "/v1/accounts:lookup": {
+      "post": {
+        "operationId": "lookupFirebaseUser",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/FirebaseLookup"
+        },
+        "responses": {
+          "default": {
+            "$ref": "#/components/responses/FirebaseLookup"
+          }
+        },
+        "security": [
+          {
+            "firebaseApiKey": []
+          }
+        ],
+        "servers": [
+          {
+            "url": "https://identitytoolkit.googleapis.com"
+          }
+        ]
+      }
+    },
+    "/uploadPhoto": {
+      "post": {
+        "operationId": "uploadEventPhoto",
+        "parameters": [
+          {
+            "name": "uploadType",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/UploadPhoto"
+        },
+        "responses": {
+          "default": {
+            "$ref": "#/components/responses/UploadPhoto"
+          }
+        },
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "servers": [
+          {
+            "url": "https://us-central1-getpartiful.cloudfunctions.net"
+          }
+        ]
+      }
+    },
+    "/posters.json": {
+      "get": {
+        "operationId": "getPosterCatalog",
+        "responses": {
+          "default": {
+            "$ref": "#/components/responses/PosterCatalog"
+          }
+        },
+        "servers": [
+          {
+            "url": "https://assets.getpartiful.com"
+          }
+        ]
+      }
+    }
   },
   "components": {
-    "securitySchemes": { "firebaseBearer": { "type": "http", "scheme": "bearer" }, "firebaseApiKey": { "type": "apiKey", "in": "query", "name": "key" } },
+    "securitySchemes": {
+      "firebaseBearer": {
+        "type": "http",
+        "scheme": "bearer"
+      },
+      "firebaseApiKey": {
+        "type": "apiKey",
+        "in": "query",
+        "name": "key"
+      }
+    },
     "parameters": {
-      "EventId": { "name": "eventId", "in": "path", "required": true, "schema": { "type": "string" } },
-      "GuestId": { "name": "guestId", "in": "path", "required": true, "schema": { "type": "string" } },
-      "CollectionPath": { "name": "collectionPath", "in": "path", "required": true, "schema": { "type": "string" } },
-      "UpdateMask": { "name": "updateMask.fieldPaths", "in": "query", "schema": { "type": "string" } },
-      "PageSize": { "name": "pageSize", "in": "query", "schema": { "type": "integer", "minimum": 1 } },
-      "PageToken": { "name": "pageToken", "in": "query", "schema": { "type": "string" } }
+      "EventId": {
+        "name": "eventId",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "GuestId": {
+        "name": "guestId",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "CollectionPath": {
+        "name": "collectionPath",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "UpdateMask": {
+        "name": "updateMask.fieldPaths",
+        "in": "query",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "PageSize": {
+        "name": "pageSize",
+        "in": "query",
+        "schema": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      "PageToken": {
+        "name": "pageToken",
+        "in": "query",
+        "schema": {
+          "type": "string"
+        }
+      }
     },
     "requestBodies": {
-      "CallableRequest": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/CallableRequest" } } } },
-      "TextBlastRequest": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/TextBlastRequest" } } } },
-      "FirestoreWrite": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/FirestoreWriteDocument" } } } },
-      "RefreshToken": { "required": true, "content": { "application/x-www-form-urlencoded": { "schema": { "$ref": "#/components/schemas/RefreshTokenRequest" } } } },
-      "CustomToken": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/CustomTokenRequest" } } } },
-      "FirebaseLookup": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/FirebaseLookupRequest" } } } },
-      "UploadPhoto": { "required": true, "content": { "multipart/form-data": { "schema": { "type": "object", "required": ["file"], "properties": { "file": { "type": "string", "format": "binary" } } } } } }
+      "CallableRequest": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/CallableRequest"
+            }
+          }
+        }
+      },
+      "TextBlastRequest": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/TextBlastRequest"
+            }
+          }
+        }
+      },
+      "FirestoreWrite": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/FirestoreWriteDocument"
+            }
+          }
+        }
+      },
+      "RefreshToken": {
+        "required": true,
+        "content": {
+          "application/x-www-form-urlencoded": {
+            "schema": {
+              "$ref": "#/components/schemas/RefreshTokenRequest"
+            }
+          }
+        }
+      },
+      "CustomToken": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/CustomTokenRequest"
+            }
+          }
+        }
+      },
+      "FirebaseLookup": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/FirebaseLookupRequest"
+            }
+          }
+        }
+      },
+      "UploadPhoto": {
+        "required": true,
+        "content": {
+          "multipart/form-data": {
+            "schema": {
+              "type": "object",
+              "required": [
+                "file"
+              ],
+              "properties": {
+                "file": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          }
+        }
+      }
     },
     "responses": {
-      "CallableResponse": { "description": "Callable response envelope", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/CallableResponse" } } } },
-      "FirestoreDocument": { "description": "Firestore document", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/FirestoreDocument" } } } },
-      "FirestoreList": { "description": "Firestore document list", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/FirestoreListResponse" } } } },
-      "RefreshToken": { "description": "Firebase token refresh response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/RefreshTokenResponse" } } } },
-      "FirebaseSignIn": { "description": "Firebase custom-token sign-in response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/FirebaseSignInResponse" } } } },
-      "FirebaseLookup": { "description": "Firebase user lookup response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/FirebaseLookupResponse" } } } },
-      "UploadPhoto": { "description": "Photo upload response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/UploadPhotoResponse" } } } },
-      "PosterCatalog": { "description": "Poster catalog", "content": { "application/json": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/Poster" } } } } }
+      "CallableResponse": {
+        "description": "Callable response envelope",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/CallableResponse"
+            }
+          }
+        }
+      },
+      "FirestoreDocument": {
+        "description": "Firestore document",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/FirestoreDocument"
+            }
+          }
+        }
+      },
+      "FirestoreList": {
+        "description": "Firestore document list",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/FirestoreListResponse"
+            }
+          }
+        }
+      },
+      "RefreshToken": {
+        "description": "Firebase token refresh response",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/RefreshTokenResponse"
+            }
+          }
+        }
+      },
+      "FirebaseSignIn": {
+        "description": "Firebase custom-token sign-in response",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/FirebaseSignInResponse"
+            }
+          }
+        }
+      },
+      "FirebaseLookup": {
+        "description": "Firebase user lookup response",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/FirebaseLookupResponse"
+            }
+          }
+        }
+      },
+      "UploadPhoto": {
+        "description": "Photo upload response",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/UploadPhotoResponse"
+            }
+          }
+        }
+      },
+      "PosterCatalog": {
+        "description": "Poster catalog",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Poster"
+              }
+            }
+          }
+        }
+      }
     },
     "schemas": {
-      "CallableRequest": { "type": "object", "required": ["data"], "properties": { "data": { "type": "object", "required": ["params", "amplitudeDeviceId"], "properties": { "params": { "type": "object", "additionalProperties": true }, "amplitudeDeviceId": { "type": "string" }, "amplitudeSessionId": { "type": "integer" }, "userId": { "type": ["string", "null"] } }, "additionalProperties": true } }, "additionalProperties": true },
-      "TextBlastRequest": { "type": "object", "required": ["data"], "properties": { "data": { "type": "object", "required": ["params"], "properties": { "params": { "type": "object", "required": ["eventId", "message"], "properties": { "eventId": { "type": "string" }, "message": { "$ref": "#/components/schemas/TextBlastMessage" } }, "additionalProperties": true } }, "additionalProperties": true } }, "additionalProperties": true },
-      "TextBlastMessage": { "type": "object", "required": ["text", "to", "showOnEventPage"], "properties": { "text": { "type": "string", "maxLength": 480 }, "to": { "type": "array", "items": { "type": "string" } }, "showOnEventPage": { "type": "boolean" }, "images": { "type": "array", "maxItems": 1, "items": { "type": "object", "additionalProperties": true } } }, "additionalProperties": true },
-      "CallableResponse": { "type": "object", "properties": { "result": { "type": "object", "properties": { "data": {} }, "additionalProperties": true } }, "additionalProperties": true },
-      "FirestoreWriteDocument": { "type": "object", "properties": { "fields": { "type": "object", "additionalProperties": true } }, "additionalProperties": true },
-      "FirestoreDocument": { "type": "object", "properties": { "name": { "type": "string" }, "fields": { "type": "object", "additionalProperties": true }, "createTime": { "type": "string" }, "updateTime": { "type": "string" } }, "additionalProperties": true },
-      "FirestoreListResponse": { "type": "object", "properties": { "documents": { "type": "array", "items": { "$ref": "#/components/schemas/FirestoreDocument" } }, "nextPageToken": { "type": "string" } }, "additionalProperties": true },
-      "RefreshTokenRequest": { "type": "object", "required": ["grant_type", "refresh_token"], "properties": { "grant_type": { "const": "refresh_token" }, "refresh_token": { "type": "string" } } },
-      "RefreshTokenResponse": { "type": "object", "properties": { "id_token": { "type": "string" }, "refresh_token": { "type": "string" }, "expires_in": { "type": "string" }, "user_id": { "type": "string" } }, "additionalProperties": true },
-      "CustomTokenRequest": { "type": "object", "required": ["token", "returnSecureToken"], "properties": { "token": { "type": "string" }, "returnSecureToken": { "const": true } } },
-      "FirebaseSignInResponse": { "type": "object", "properties": { "idToken": { "type": "string" }, "refreshToken": { "type": "string" }, "expiresIn": { "type": "string" }, "localId": { "type": "string" } }, "additionalProperties": true },
-      "FirebaseLookupRequest": { "type": "object", "required": ["idToken"], "properties": { "idToken": { "type": "string" } } },
-      "FirebaseLookupResponse": { "type": "object", "properties": { "users": { "type": "array", "items": { "type": "object", "additionalProperties": true } } }, "additionalProperties": true },
-      "UploadPhotoResponse": { "type": "object", "properties": { "uploadData": { "type": "object", "properties": { "url": { "type": "string" } }, "additionalProperties": true } }, "additionalProperties": true },
-      "Poster": { "type": "object", "properties": { "id": { "type": "string" }, "name": { "type": "string" }, "url": { "type": "string" }, "contentType": { "type": "string" }, "width": { "type": "integer" }, "height": { "type": "integer" } }, "additionalProperties": true }
+      "CallableRequest": {
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "type": "object",
+            "required": [
+              "params",
+              "amplitudeDeviceId"
+            ],
+            "properties": {
+              "params": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "amplitudeDeviceId": {
+                "type": "string"
+              },
+              "amplitudeSessionId": {
+                "type": "integer"
+              },
+              "userId": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": true
+      },
+      "TextBlastRequest": {
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "type": "object",
+            "required": [
+              "params"
+            ],
+            "properties": {
+              "params": {
+                "type": "object",
+                "required": [
+                  "eventId",
+                  "message"
+                ],
+                "properties": {
+                  "eventId": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "$ref": "#/components/schemas/TextBlastMessage"
+                  }
+                },
+                "additionalProperties": true
+              }
+            },
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": true
+      },
+      "TextBlastMessage": {
+        "type": "object",
+        "required": [
+          "text",
+          "to",
+          "showOnEventPage"
+        ],
+        "properties": {
+          "text": {
+            "type": "string",
+            "maxLength": 480
+          },
+          "to": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "showOnEventPage": {
+            "type": "boolean"
+          },
+          "images": {
+            "type": "array",
+            "maxItems": 1,
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        },
+        "additionalProperties": true
+      },
+      "CallableResponse": {
+        "type": "object",
+        "properties": {
+          "result": {
+            "type": "object",
+            "properties": {
+              "data": {}
+            },
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": true
+      },
+      "FirestoreWriteDocument": {
+        "type": "object",
+        "properties": {
+          "fields": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": true
+      },
+      "FirestoreDocument": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "fields": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "createTime": {
+            "type": "string"
+          },
+          "updateTime": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": true
+      },
+      "FirestoreListResponse": {
+        "type": "object",
+        "properties": {
+          "documents": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FirestoreDocument"
+            }
+          },
+          "nextPageToken": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": true
+      },
+      "RefreshTokenRequest": {
+        "type": "object",
+        "required": [
+          "grant_type",
+          "refresh_token"
+        ],
+        "properties": {
+          "grant_type": {
+            "const": "refresh_token"
+          },
+          "refresh_token": {
+            "type": "string"
+          }
+        }
+      },
+      "RefreshTokenResponse": {
+        "type": "object",
+        "properties": {
+          "id_token": {
+            "type": "string"
+          },
+          "refresh_token": {
+            "type": "string"
+          },
+          "expires_in": {
+            "type": "string"
+          },
+          "user_id": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": true
+      },
+      "CustomTokenRequest": {
+        "type": "object",
+        "required": [
+          "token",
+          "returnSecureToken"
+        ],
+        "properties": {
+          "token": {
+            "type": "string"
+          },
+          "returnSecureToken": {
+            "const": true
+          }
+        }
+      },
+      "FirebaseSignInResponse": {
+        "type": "object",
+        "properties": {
+          "idToken": {
+            "type": "string"
+          },
+          "refreshToken": {
+            "type": "string"
+          },
+          "expiresIn": {
+            "type": "string"
+          },
+          "localId": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": true
+      },
+      "FirebaseLookupRequest": {
+        "type": "object",
+        "required": [
+          "idToken"
+        ],
+        "properties": {
+          "idToken": {
+            "type": "string"
+          }
+        }
+      },
+      "FirebaseLookupResponse": {
+        "type": "object",
+        "properties": {
+          "users": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        },
+        "additionalProperties": true
+      },
+      "UploadPhotoResponse": {
+        "type": "object",
+        "properties": {
+          "uploadData": {
+            "type": "object",
+            "properties": {
+              "url": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": true
+      },
+      "Poster": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "contentType": {
+            "type": "string"
+          },
+          "width": {
+            "type": "integer"
+          },
+          "height": {
+            "type": "integer"
+          }
+        },
+        "additionalProperties": true
+      }
     }
   }
 }

--- a/spec/partiful.openapi.json
+++ b/spec/partiful.openapi.json
@@ -75,14 +75,7 @@
         },
         "responses": {
           "default": {
-            "description": "Response status is unknown; body shape follows cited research where present.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CallableResponse"
-                }
-              }
-            }
+            "description": "Response status and body are unknown."
           }
         },
         "security": [
@@ -148,14 +141,7 @@
         },
         "responses": {
           "default": {
-            "description": "Response status is unknown; body shape follows cited research where present.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CallableResponse"
-                }
-              }
-            }
+            "description": "Response status and body are unknown."
           }
         },
         "security": [
@@ -221,14 +207,7 @@
         },
         "responses": {
           "default": {
-            "description": "Response status is unknown; body shape follows cited research where present.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CallableResponse"
-                }
-              }
-            }
+            "description": "Response status and body are unknown."
           }
         },
         "security": [
@@ -287,14 +266,7 @@
         },
         "responses": {
           "default": {
-            "description": "Response status is unknown; body shape follows cited research where present.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CallableResponse"
-                }
-              }
-            }
+            "description": "Response status and body are unknown."
           }
         },
         "security": [
@@ -376,10 +348,7 @@
                         "type": "integer"
                       },
                       "userId": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
+                        "type": "string"
                       }
                     },
                     "additionalProperties": true
@@ -392,14 +361,7 @@
         },
         "responses": {
           "default": {
-            "description": "Response status is unknown; body shape follows cited research where present.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CallableResponse"
-                }
-              }
-            }
+            "description": "Response status and body are unknown."
           }
         },
         "security": [
@@ -473,14 +435,7 @@
         },
         "responses": {
           "default": {
-            "description": "Response status is unknown; body shape follows cited research where present.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CallableResponse"
-                }
-              }
-            }
+            "description": "Response status and body are unknown."
           }
         },
         "security": [
@@ -550,14 +505,7 @@
         },
         "responses": {
           "default": {
-            "description": "Response status is unknown; body shape follows cited research where present.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CallableResponse"
-                }
-              }
-            }
+            "description": "Response status and body are unknown."
           }
         },
         "security": [
@@ -627,14 +575,7 @@
         },
         "responses": {
           "default": {
-            "description": "Response status is unknown; body shape follows cited research where present.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CallableResponse"
-                }
-              }
-            }
+            "description": "Response status and body are unknown."
           }
         },
         "security": [
@@ -704,14 +645,7 @@
         },
         "responses": {
           "default": {
-            "description": "Response status is unknown; body shape follows cited research where present.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CallableResponse"
-                }
-              }
-            }
+            "description": "Response status and body are unknown."
           }
         },
         "security": [
@@ -777,14 +711,7 @@
         },
         "responses": {
           "default": {
-            "description": "Response status is unknown; body shape follows cited research where present.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CallableResponse"
-                }
-              }
-            }
+            "description": "Response status and body are unknown."
           }
         },
         "security": [
@@ -850,14 +777,7 @@
         },
         "responses": {
           "default": {
-            "description": "Response status is unknown; body shape follows cited research where present.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CallableResponse"
-                }
-              }
-            }
+            "description": "Response status and body are unknown."
           }
         },
         "security": [
@@ -916,14 +836,7 @@
         },
         "responses": {
           "default": {
-            "description": "Response status is unknown; body shape follows cited research where present.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CallableResponse"
-                }
-              }
-            }
+            "description": "Response status and body are unknown."
           }
         },
         "security": [
@@ -982,14 +895,7 @@
         },
         "responses": {
           "default": {
-            "description": "Response status is unknown; body shape follows cited research where present.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CallableResponse"
-                }
-              }
-            }
+            "description": "Response status and body are unknown."
           }
         },
         "security": [
@@ -1059,14 +965,7 @@
         },
         "responses": {
           "default": {
-            "description": "Response status is unknown; body shape follows cited research where present.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CallableResponse"
-                }
-              }
-            }
+            "description": "Response status and body are unknown."
           }
         },
         "security": [
@@ -1140,14 +1039,7 @@
         },
         "responses": {
           "default": {
-            "description": "Response status is unknown; body shape follows cited research where present.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CallableResponse"
-                }
-              }
-            }
+            "description": "Response status and body are unknown."
           }
         },
         "security": [
@@ -1213,14 +1105,7 @@
         },
         "responses": {
           "default": {
-            "description": "Response status is unknown; body shape follows cited research where present.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CallableResponse"
-                }
-              }
-            }
+            "description": "Response status and body are unknown."
           }
         },
         "security": [
@@ -1245,14 +1130,7 @@
         ],
         "responses": {
           "default": {
-            "description": "Response status is unknown; body shape follows cited research where present.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FirestoreDocument"
-                }
-              }
-            }
+            "description": "Response status and body are unknown."
           }
         },
         "security": [
@@ -1303,14 +1181,7 @@
         },
         "responses": {
           "default": {
-            "description": "Response status is unknown; body shape follows cited research where present.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FirestoreDocument"
-                }
-              }
-            }
+            "description": "Response status and body are unknown."
           }
         },
         "security": [
@@ -1348,14 +1219,7 @@
         ],
         "responses": {
           "default": {
-            "description": "Response status is unknown; body shape follows cited research where present.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FirestoreDocument"
-                }
-              }
-            }
+            "description": "Response status and body are unknown."
           }
         },
         "security": [
@@ -1380,16 +1244,14 @@
             "required": true,
             "schema": {
               "type": "string"
-            },
-            "description": "Slash-delimited document collection path; custom client preserves path segments."
+            }
           },
           {
             "name": "pageSize",
             "in": "query",
             "required": false,
             "schema": {
-              "type": "integer",
-              "default": 100
+              "type": "integer"
             }
           },
           {
@@ -1403,14 +1265,7 @@
         ],
         "responses": {
           "default": {
-            "description": "Response status is unknown; body shape follows cited research where present.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FirestoreListResponse"
-                }
-              }
-            }
+            "description": "Response status and body are unknown."
           }
         },
         "security": [
@@ -1456,14 +1311,7 @@
         },
         "responses": {
           "default": {
-            "description": "Response status is unknown; body shape follows cited research where present.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RefreshTokenResponse"
-                }
-              }
-            }
+            "description": "Response status and body are unknown."
           }
         },
         "security": [
@@ -1554,14 +1402,7 @@
         },
         "responses": {
           "default": {
-            "description": "Response status is unknown; body shape follows cited research where present.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CallableResponse"
-                }
-              }
-            }
+            "description": "Response status and body are unknown."
           }
         }
       }
@@ -1632,14 +1473,7 @@
         },
         "responses": {
           "default": {
-            "description": "Response status is unknown; body shape follows cited research where present.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CallableResponse"
-                }
-              }
-            }
+            "description": "Response status and body are unknown."
           }
         }
       }
@@ -1672,14 +1506,7 @@
         },
         "responses": {
           "default": {
-            "description": "Response status is unknown; body shape follows cited research where present.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FirebaseSignInResponse"
-                }
-              }
-            }
+            "description": "Response status and body are unknown."
           }
         },
         "security": [
@@ -1718,14 +1545,7 @@
         },
         "responses": {
           "default": {
-            "description": "Response status is unknown; body shape follows cited research where present.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FirebaseLookupResponse"
-                }
-              }
-            }
+            "description": "Response status and body are unknown."
           }
         },
         "security": [
@@ -1778,14 +1598,7 @@
         },
         "responses": {
           "default": {
-            "description": "Response status is unknown; body shape follows cited research where present.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UploadPhotoResponse"
-                }
-              }
-            }
+            "description": "Response status and body are unknown."
           }
         },
         "security": [
@@ -1805,17 +1618,7 @@
         "operationId": "getPosterCatalog",
         "responses": {
           "default": {
-            "description": "Response status is unknown; body shape follows cited research where present.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Poster"
-                  }
-                }
-              }
-            }
+            "description": "Response status and body are unknown."
           }
         },
         "servers": [

--- a/spec/partiful.openapi.json
+++ b/spec/partiful.openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Partiful remote API contract",
     "version": "2026-08-10.1",
-    "description": "Proposed, versioned remote-only transport snapshot pending owner approval. Evidence classifications and uncertainty are recorded in spec/partiful.api-evidence.json."
+    "description": "Owner-reviewed, versioned remote-only transport snapshot. Evidence classifications and uncertainty are recorded in spec/partiful.api-evidence.json."
   },
   "servers": [
     {

--- a/spec/research/historical-27-operation-draft.json
+++ b/spec/research/historical-27-operation-draft.json
@@ -1,0 +1,2251 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Partiful Port API Contract",
+    "version": "2.1.0",
+    "description": "Reverse-engineered transport contract used to port partiful-cli to Go. Covers Firebase callable, Firestore, Firebase authentication, image upload, and poster catalog requests. Command workflows remain a custom compatibility layer above these transports."
+  },
+  "servers": [
+    {
+      "url": "https://api.partiful.com"
+    }
+  ],
+  "paths": {
+    "/createEvent": {
+      "post": {
+        "operationId": "createEvent",
+        "tags": ["events"],
+        "summary": "createEvent",
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["data"],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": ["params", "amplitudeDeviceId"],
+                    "properties": {
+                      "params": {
+                        "type": "object",
+                        "properties": {
+                          "event": {
+                            "$ref": "#/components/schemas/EventDraft"
+                          },
+                          "cohostIds": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": ["event", "cohostIds"]
+                      },
+                      "amplitudeDeviceId": {
+                        "type": "string"
+                      },
+                      "amplitudeSessionId": {
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "userId": {
+                        "type": ["string", "null"]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Firebase callable response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallableResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "429": {
+            "description": "Rate limited"
+          }
+        },
+        "x-pp-resource": "events"
+      }
+    },
+    "/cancelEvent": {
+      "post": {
+        "operationId": "cancelEvent",
+        "tags": ["events"],
+        "summary": "cancelEvent",
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["data"],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": ["params", "amplitudeDeviceId"],
+                    "properties": {
+                      "params": {
+                        "type": "object",
+                        "properties": {
+                          "eventId": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": ["eventId"]
+                      },
+                      "amplitudeDeviceId": {
+                        "type": "string"
+                      },
+                      "amplitudeSessionId": {
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "userId": {
+                        "type": ["string", "null"]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Firebase callable response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallableResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "429": {
+            "description": "Rate limited"
+          }
+        },
+        "x-pp-resource": "events"
+      }
+    },
+    "/getEventInfo": {
+      "post": {
+        "operationId": "getEventInfo",
+        "tags": ["events"],
+        "summary": "getEventInfo",
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["data"],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": ["params", "amplitudeDeviceId"],
+                    "properties": {
+                      "params": {
+                        "type": "object",
+                        "properties": {
+                          "eventId": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": ["eventId"]
+                      },
+                      "amplitudeDeviceId": {
+                        "type": "string"
+                      },
+                      "amplitudeSessionId": {
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "userId": {
+                        "type": ["string", "null"]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Firebase callable response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallableResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "429": {
+            "description": "Rate limited"
+          }
+        },
+        "x-pp-resource": "events"
+      }
+    },
+    "/getContacts": {
+      "post": {
+        "operationId": "getContacts",
+        "tags": ["contacts"],
+        "summary": "getContacts",
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["data"],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": ["params", "amplitudeDeviceId"],
+                    "properties": {
+                      "params": {
+                        "type": "object",
+                        "properties": {},
+                        "additionalProperties": false
+                      },
+                      "amplitudeDeviceId": {
+                        "type": "string"
+                      },
+                      "amplitudeSessionId": {
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "userId": {
+                        "type": ["string", "null"]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Firebase callable response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallableResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "429": {
+            "description": "Rate limited"
+          }
+        },
+        "x-pp-resource": "contacts"
+      }
+    },
+    "/createTextBlast": {
+      "post": {
+        "operationId": "createTextBlast",
+        "tags": ["blasts"],
+        "summary": "createTextBlast",
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["data"],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": ["params", "amplitudeDeviceId"],
+                    "properties": {
+                      "params": {
+                        "type": "object",
+                        "properties": {
+                          "eventId": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "recipientStatuses": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": ["eventId", "message"],
+                        "description": "recipientStatuses is optional; omit it to use the service default audience."
+                      },
+                      "amplitudeDeviceId": {
+                        "type": "string"
+                      },
+                      "amplitudeSessionId": {
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "userId": {
+                        "type": ["string", "null"]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Firebase callable response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallableResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "429": {
+            "description": "Rate limited"
+          }
+        },
+        "x-pp-resource": "blasts"
+      }
+    },
+    "/addInvitedGuestsAsHost": {
+      "post": {
+        "operationId": "addInvitedGuestsAsHost",
+        "tags": ["guests"],
+        "summary": "addInvitedGuestsAsHost",
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["data"],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": ["params", "amplitudeDeviceId"],
+                    "properties": {
+                      "params": {
+                        "type": "object",
+                        "properties": {
+                          "eventId": {
+                            "type": "string"
+                          },
+                          "guests": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "additionalProperties": true
+                            }
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": ["eventId", "guests"]
+                      },
+                      "amplitudeDeviceId": {
+                        "type": "string"
+                      },
+                      "amplitudeSessionId": {
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "userId": {
+                        "type": ["string", "null"]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Firebase callable response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallableResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "429": {
+            "description": "Rate limited"
+          }
+        },
+        "x-pp-resource": "guests"
+      }
+    },
+    "/createCohostRequest": {
+      "post": {
+        "operationId": "createCohostRequest",
+        "tags": ["cohosts"],
+        "summary": "createCohostRequest",
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["data"],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": ["params", "amplitudeDeviceId"],
+                    "properties": {
+                      "params": {
+                        "type": "object",
+                        "properties": {
+                          "eventId": {
+                            "type": "string"
+                          },
+                          "targetUserId": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": ["eventId", "targetUserId"]
+                      },
+                      "amplitudeDeviceId": {
+                        "type": "string"
+                      },
+                      "amplitudeSessionId": {
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "userId": {
+                        "type": ["string", "null"]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Firebase callable response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallableResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "429": {
+            "description": "Rate limited"
+          }
+        },
+        "x-pp-resource": "cohosts"
+      }
+    },
+    "/deleteCohostRequest": {
+      "post": {
+        "operationId": "deleteCohostRequest",
+        "tags": ["cohosts"],
+        "summary": "deleteCohostRequest",
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["data"],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": ["params", "amplitudeDeviceId"],
+                    "properties": {
+                      "params": {
+                        "type": "object",
+                        "properties": {
+                          "eventId": {
+                            "type": "string"
+                          },
+                          "targetUserId": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": ["eventId", "targetUserId"]
+                      },
+                      "amplitudeDeviceId": {
+                        "type": "string"
+                      },
+                      "amplitudeSessionId": {
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "userId": {
+                        "type": ["string", "null"]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Firebase callable response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallableResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "429": {
+            "description": "Rate limited"
+          }
+        },
+        "x-pp-resource": "cohosts"
+      }
+    },
+    "/removeCohost": {
+      "post": {
+        "operationId": "removeCohost",
+        "tags": ["cohosts"],
+        "summary": "removeCohost",
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["data"],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": ["params", "amplitudeDeviceId"],
+                    "properties": {
+                      "params": {
+                        "type": "object",
+                        "properties": {
+                          "eventId": {
+                            "type": "string"
+                          },
+                          "targetUserId": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": ["eventId", "targetUserId"]
+                      },
+                      "amplitudeDeviceId": {
+                        "type": "string"
+                      },
+                      "amplitudeSessionId": {
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "userId": {
+                        "type": ["string", "null"]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Firebase callable response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallableResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "429": {
+            "description": "Rate limited"
+          }
+        },
+        "x-pp-resource": "cohosts"
+      }
+    },
+    "/generateEventCohostLink": {
+      "post": {
+        "operationId": "generateEventCohostLink",
+        "tags": ["cohosts"],
+        "summary": "generateEventCohostLink",
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["data"],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": ["params", "amplitudeDeviceId"],
+                    "properties": {
+                      "params": {
+                        "type": "object",
+                        "properties": {
+                          "eventId": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": ["eventId"]
+                      },
+                      "amplitudeDeviceId": {
+                        "type": "string"
+                      },
+                      "amplitudeSessionId": {
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "userId": {
+                        "type": ["string", "null"]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Firebase callable response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallableResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "429": {
+            "description": "Rate limited"
+          }
+        },
+        "x-pp-resource": "cohosts"
+      }
+    },
+    "/revokeEventCohostLink": {
+      "post": {
+        "operationId": "revokeEventCohostLink",
+        "tags": ["cohosts"],
+        "summary": "revokeEventCohostLink",
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["data"],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": ["params", "amplitudeDeviceId"],
+                    "properties": {
+                      "params": {
+                        "type": "object",
+                        "properties": {
+                          "eventId": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": ["eventId"]
+                      },
+                      "amplitudeDeviceId": {
+                        "type": "string"
+                      },
+                      "amplitudeSessionId": {
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "userId": {
+                        "type": ["string", "null"]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Firebase callable response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallableResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "429": {
+            "description": "Rate limited"
+          }
+        },
+        "x-pp-resource": "cohosts"
+      }
+    },
+    "/getMyUpcomingEventsForHomePage": {
+      "post": {
+        "operationId": "getMyUpcomingEventsForHomePage",
+        "tags": ["events"],
+        "summary": "getMyUpcomingEventsForHomePage",
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["data"],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": ["params", "amplitudeDeviceId"],
+                    "properties": {
+                      "params": {
+                        "type": "object",
+                        "properties": {},
+                        "additionalProperties": false
+                      },
+                      "amplitudeDeviceId": {
+                        "type": "string"
+                      },
+                      "amplitudeSessionId": {
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "userId": {
+                        "type": ["string", "null"]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Firebase callable response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallableResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "429": {
+            "description": "Rate limited"
+          }
+        },
+        "x-pp-resource": "events"
+      }
+    },
+    "/getMyPastEventsForHomePage": {
+      "post": {
+        "operationId": "getMyPastEventsForHomePage",
+        "tags": ["events"],
+        "summary": "getMyPastEventsForHomePage",
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["data"],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": ["params", "amplitudeDeviceId"],
+                    "properties": {
+                      "params": {
+                        "type": "object",
+                        "properties": {},
+                        "additionalProperties": false
+                      },
+                      "amplitudeDeviceId": {
+                        "type": "string"
+                      },
+                      "amplitudeSessionId": {
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "userId": {
+                        "type": ["string", "null"]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Firebase callable response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallableResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "429": {
+            "description": "Rate limited"
+          }
+        },
+        "x-pp-resource": "events"
+      }
+    },
+    "/addGuest": {
+      "post": {
+        "operationId": "addGuest",
+        "tags": ["rsvp"],
+        "summary": "addGuest",
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["data"],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": ["params", "amplitudeDeviceId"],
+                    "properties": {
+                      "params": {
+                        "type": "object",
+                        "properties": {
+                          "eventId": {
+                            "type": "string"
+                          },
+                          "rsvp": {
+                            "$ref": "#/components/schemas/RsvpDraft"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": ["eventId", "rsvp"]
+                      },
+                      "amplitudeDeviceId": {
+                        "type": "string"
+                      },
+                      "amplitudeSessionId": {
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "userId": {
+                        "type": ["string", "null"]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Firebase callable response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallableResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "429": {
+            "description": "Rate limited"
+          }
+        },
+        "x-pp-resource": "rsvp"
+      }
+    },
+    "/markEventInterest": {
+      "post": {
+        "operationId": "markEventInterest",
+        "tags": ["rsvp"],
+        "summary": "markEventInterest",
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["data"],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": ["params", "amplitudeDeviceId"],
+                    "properties": {
+                      "params": {
+                        "type": "object",
+                        "properties": {
+                          "eventId": {
+                            "type": "string"
+                          },
+                          "interested": {
+                            "type": "boolean"
+                          },
+                          "source": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": ["eventId", "interested", "source"]
+                      },
+                      "amplitudeDeviceId": {
+                        "type": "string"
+                      },
+                      "amplitudeSessionId": {
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "userId": {
+                        "type": ["string", "null"]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Firebase callable response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallableResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "429": {
+            "description": "Rate limited"
+          }
+        },
+        "x-pp-resource": "rsvp"
+      }
+    },
+    "/getCurrentGuest": {
+      "post": {
+        "operationId": "getCurrentGuest",
+        "tags": ["rsvp"],
+        "summary": "getCurrentGuest",
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["data"],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": ["params", "amplitudeDeviceId"],
+                    "properties": {
+                      "params": {
+                        "type": "object",
+                        "properties": {
+                          "eventId": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": ["eventId"]
+                      },
+                      "amplitudeDeviceId": {
+                        "type": "string"
+                      },
+                      "amplitudeSessionId": {
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "userId": {
+                        "type": ["string", "null"]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Firebase callable response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallableResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "429": {
+            "description": "Rate limited"
+          }
+        },
+        "x-pp-resource": "rsvp"
+      }
+    },
+    "/v1/projects/getpartiful/databases/(default)/documents/events/{eventId}": {
+      "get": {
+        "operationId": "firestoreGetEvent",
+        "tags": ["firestore"],
+        "x-pp-resource": "firestore",
+        "summary": "firestoreGetEvent",
+        "servers": [
+          {
+            "url": "https://firestore.googleapis.com"
+          }
+        ],
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FirestoreDocument"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "429": {
+            "description": "Rate limited"
+          }
+        },
+        "parameters": [
+          {
+            "name": "eventId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "patch": {
+        "operationId": "firestorePatchEvent",
+        "tags": ["firestore"],
+        "x-pp-resource": "firestore",
+        "summary": "firestorePatchEvent",
+        "servers": [
+          {
+            "url": "https://firestore.googleapis.com"
+          }
+        ],
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FirestoreDocument"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "429": {
+            "description": "Rate limited"
+          }
+        },
+        "parameters": [
+          {
+            "name": "eventId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "updateMask.fieldPaths",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FirestoreWriteDocument"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/projects/getpartiful/databases/(default)/documents/events/{eventId}/guests/{guestId}": {
+      "get": {
+        "operationId": "firestoreGetGuest",
+        "tags": ["firestore"],
+        "x-pp-resource": "firestore",
+        "summary": "firestoreGetGuest",
+        "servers": [
+          {
+            "url": "https://firestore.googleapis.com"
+          }
+        ],
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FirestoreDocument"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "429": {
+            "description": "Rate limited"
+          }
+        },
+        "parameters": [
+          {
+            "name": "eventId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "guestId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/v1/projects/getpartiful/databases/(default)/documents/{collectionPath}": {
+      "get": {
+        "operationId": "firestoreListDocuments",
+        "tags": ["firestore"],
+        "x-pp-resource": "firestore",
+        "summary": "firestoreListDocuments",
+        "servers": [
+          {
+            "url": "https://firestore.googleapis.com"
+          }
+        ],
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FirestoreListResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "429": {
+            "description": "Rate limited"
+          }
+        },
+        "parameters": [
+          {
+            "name": "collectionPath",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Slash-delimited document collection path; custom client preserves path segments."
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 100
+            }
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/v1/token": {
+      "post": {
+        "operationId": "refreshToken",
+        "tags": ["authentication"],
+        "x-pp-resource": "authentication-api",
+        "summary": "refreshToken",
+        "servers": [
+          {
+            "url": "https://securetoken.googleapis.com"
+          }
+        ],
+        "security": [
+          {
+            "firebaseApiKey": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "required": ["grant_type", "refresh_token"],
+                "properties": {
+                  "grant_type": {
+                    "type": "string",
+                    "enum": ["refresh_token"]
+                  },
+                  "refresh_token": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RefreshTokenResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "429": {
+            "description": "Rate limited"
+          }
+        }
+      }
+    },
+    "/sendAuthCodeTrusted": {
+      "post": {
+        "operationId": "sendAuthCodeTrusted",
+        "tags": ["authentication"],
+        "x-pp-resource": "authentication-api",
+        "summary": "sendAuthCodeTrusted",
+        "security": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["data"],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": ["params", "amplitudeDeviceId"],
+                    "properties": {
+                      "params": {
+                        "type": "object",
+                        "required": [
+                          "displayName",
+                          "phoneNumber",
+                          "silent",
+                          "channelPreference",
+                          "captchaToken",
+                          "useAppleBusinessUpdates"
+                        ],
+                        "properties": {
+                          "displayName": {
+                            "type": "string"
+                          },
+                          "phoneNumber": {
+                            "type": "string"
+                          },
+                          "silent": {
+                            "type": "boolean"
+                          },
+                          "channelPreference": {
+                            "type": "string",
+                            "enum": ["sms"]
+                          },
+                          "captchaToken": {
+                            "type": ["string", "null"]
+                          },
+                          "useAppleBusinessUpdates": {
+                            "type": "boolean"
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "amplitudeDeviceId": {
+                        "type": "string"
+                      },
+                      "amplitudeSessionId": {
+                        "type": "integer",
+                        "format": "int64"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallableResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "429": {
+            "description": "Rate limited"
+          }
+        }
+      }
+    },
+    "/getLoginToken": {
+      "post": {
+        "operationId": "getLoginToken",
+        "tags": ["authentication"],
+        "x-pp-resource": "authentication-api",
+        "summary": "getLoginToken",
+        "security": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["data"],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": ["params", "amplitudeDeviceId"],
+                    "properties": {
+                      "params": {
+                        "type": "object",
+                        "required": [
+                          "phoneNumber",
+                          "authCode",
+                          "affiliateId",
+                          "utms"
+                        ],
+                        "properties": {
+                          "phoneNumber": {
+                            "type": "string"
+                          },
+                          "authCode": {
+                            "type": "string"
+                          },
+                          "affiliateId": {
+                            "type": ["string", "null"]
+                          },
+                          "utms": {
+                            "type": "object",
+                            "additionalProperties": true
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "amplitudeDeviceId": {
+                        "type": "string"
+                      },
+                      "amplitudeSessionId": {
+                        "type": "integer",
+                        "format": "int64"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallableResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "429": {
+            "description": "Rate limited"
+          }
+        }
+      }
+    },
+    "/v1/accounts:signInWithCustomToken": {
+      "post": {
+        "operationId": "signInWithCustomToken",
+        "tags": ["authentication"],
+        "x-pp-resource": "authentication-api",
+        "summary": "signInWithCustomToken",
+        "servers": [
+          {
+            "url": "https://identitytoolkit.googleapis.com"
+          }
+        ],
+        "security": [
+          {
+            "firebaseApiKey": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["token", "returnSecureToken"],
+                "properties": {
+                  "token": {
+                    "type": "string"
+                  },
+                  "returnSecureToken": {
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FirebaseSignInResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "429": {
+            "description": "Rate limited"
+          }
+        }
+      }
+    },
+    "/v1/accounts:lookup": {
+      "post": {
+        "operationId": "lookupFirebaseUser",
+        "tags": ["authentication"],
+        "x-pp-resource": "authentication-api",
+        "summary": "lookupFirebaseUser",
+        "servers": [
+          {
+            "url": "https://identitytoolkit.googleapis.com"
+          }
+        ],
+        "security": [
+          {
+            "firebaseApiKey": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["idToken"],
+                "properties": {
+                  "idToken": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FirebaseLookupResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "429": {
+            "description": "Rate limited"
+          }
+        }
+      }
+    },
+    "/uploadPhoto": {
+      "post": {
+        "operationId": "uploadEventPhoto",
+        "tags": ["posters"],
+        "x-pp-resource": "posters",
+        "summary": "uploadEventPhoto",
+        "servers": [
+          {
+            "url": "https://us-central1-getpartiful.cloudfunctions.net"
+          }
+        ],
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "uploadType",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": ["event_poster"]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UploadPhotoResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed"
+          },
+          "429": {
+            "description": "Rate limited"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "required": ["file"],
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      }
+    },
+    "/posters.json": {
+      "get": {
+        "operationId": "getPosterCatalog",
+        "tags": ["posters"],
+        "x-pp-resource": "posters",
+        "summary": "getPosterCatalog",
+        "servers": [
+          {
+            "url": "https://assets.getpartiful.com"
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Poster catalog",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Poster"
+                  }
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limited"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "firebaseBearer": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "Firebase ID token",
+        "description": "Set from PARTIFUL_TOKEN or refreshed Partiful credentials."
+      },
+      "firebaseApiKey": {
+        "type": "apiKey",
+        "in": "query",
+        "name": "key",
+        "description": "Firebase web API key loaded from Partiful client configuration."
+      }
+    },
+    "schemas": {
+      "EventDraft": {
+        "type": "object",
+        "required": ["title", "startDate", "timezone", "displaySettings"],
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "startDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "endDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "timezone": {
+            "type": "string"
+          },
+          "displaySettings": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "visibility": {
+            "type": "string",
+            "enum": ["public", "private"]
+          },
+          "location": {
+            "type": "string"
+          },
+          "address": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "guestLimit": {
+            "type": "integer"
+          },
+          "links": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "image": {}
+        },
+        "additionalProperties": true
+      },
+      "RsvpDraft": {
+        "type": "object",
+        "required": ["name", "count", "plusOnes", "status", "timezone"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "count": {
+            "type": "integer"
+          },
+          "plusOnes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "message": {
+            "type": ["string", "null"]
+          },
+          "emailInvitationId": {
+            "type": ["string", "null"]
+          },
+          "status": {
+            "type": "string"
+          },
+          "guestId": {
+            "type": ["string", "null"]
+          },
+          "timezone": {
+            "type": "string"
+          },
+          "password": {
+            "type": ["string", "null"]
+          },
+          "questionnaireResponse": {
+            "type": "object",
+            "properties": {
+              "questionnaireVersion": {
+                "type": "integer"
+              },
+              "answers": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": ["questionnaireVersion", "answers"]
+          }
+        },
+        "additionalProperties": false
+      },
+      "CallableResponse": {
+        "type": "object",
+        "properties": {
+          "result": {
+            "type": "object",
+            "properties": {
+              "data": {}
+            },
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": true
+      },
+      "FirestoreValue": {
+        "type": "object",
+        "additionalProperties": true
+      },
+      "FirestoreDocument": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "fields": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/FirestoreValue"
+            }
+          },
+          "createTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updateTime": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": true
+      },
+      "FirestoreWriteDocument": {
+        "type": "object",
+        "required": ["fields"],
+        "properties": {
+          "fields": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/FirestoreValue"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "FirestoreListResponse": {
+        "type": "object",
+        "properties": {
+          "documents": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FirestoreDocument"
+            }
+          },
+          "nextPageToken": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": true
+      },
+      "RefreshTokenResponse": {
+        "type": "object",
+        "additionalProperties": true
+      },
+      "FirebaseSignInResponse": {
+        "type": "object",
+        "additionalProperties": true
+      },
+      "FirebaseLookupResponse": {
+        "type": "object",
+        "additionalProperties": true
+      },
+      "UploadData": {
+        "type": "object",
+        "required": ["url"],
+        "properties": {
+          "url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "contentType": {
+            "type": "string"
+          },
+          "height": {
+            "type": "integer"
+          },
+          "width": {
+            "type": "integer"
+          }
+        },
+        "additionalProperties": true
+      },
+      "UploadPhotoResponse": {
+        "type": "object",
+        "properties": {
+          "uploadData": {
+            "$ref": "#/components/schemas/UploadData"
+          },
+          "result": {
+            "type": "object",
+            "properties": {
+              "uploadData": {
+                "$ref": "#/components/schemas/UploadData"
+              }
+            },
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": true
+      },
+      "Poster": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "blurHash": {
+            "type": "string"
+          },
+          "contentType": {
+            "type": "string"
+          },
+          "height": {
+            "type": "integer"
+          },
+          "width": {
+            "type": "integer"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "categories": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "additionalProperties": true
+      }
+    }
+  },
+  "x-auth-env-vars": ["PARTIFUL_TOKEN"],
+  "x-mcp": {
+    "transport": ["stdio", "http"],
+    "endpoint-tools": "hidden",
+    "orchestration": "code"
+  },
+  "x-partiful-port": {
+    "custom-client-required": true,
+    "command-layer": "Preserve TypeScript CLI workflows above generated transports.",
+    "credential-path": "$PARTIFUL_CREDENTIALS_FILE or ~/.config/partiful/auth.json",
+    "dynamic-image-downloads": "Handled by the custom client because URLs are user or API supplied.",
+    "poster-thumbnail-url-template": "https://partiful-posters.imgix.net/{posterId}?fit=max&w=400"
+  }
+}

--- a/tests/remote-api-contract.test.js
+++ b/tests/remote-api-contract.test.js
@@ -4,6 +4,9 @@ import path from 'node:path';
 import evidence from '../spec/partiful.api-evidence.json';
 import spec from '../spec/partiful.openapi.json';
 
+const historicalDraftPath = 'spec/research/historical-27-operation-draft.json';
+const historicalDraft = JSON.parse(fs.readFileSync(historicalDraftPath, 'utf8'));
+const sourceCache = new Map([[historicalDraftPath, historicalDraft]]);
 const methods = new Set(['get', 'post', 'put', 'patch', 'delete']);
 const ignoredKeys = new Set(['description', 'summary', 'title']);
 const materialMapKeys = new Set([
@@ -54,7 +57,7 @@ function materialClaimPointers(value, pointer, parentKey = '') {
 }
 
 function jsonPointerValue(value, pointer) {
-  for (const rawSegment of pointer.replace(/^\//, '').split('/')) {
+  for (const rawSegment of pointer.replace(/^#/, '').replace(/^\//, '').split('/')) {
     if (!rawSegment) continue;
     const segment = rawSegment.replaceAll('~1', '/').replaceAll('~0', '~');
     if (value === null || typeof value !== 'object' || !(segment in value)) return undefined;
@@ -82,11 +85,14 @@ function citationResolves(citation) {
   if (!fs.existsSync(source)) return false;
 
   if (sourcePath.endsWith('.json')) {
-    let value;
-    try {
-      value = JSON.parse(fs.readFileSync(source, 'utf8'));
-    } catch {
-      return false;
+    let value = sourceCache.get(sourcePath);
+    if (!value) {
+      try {
+        value = JSON.parse(fs.readFileSync(source, 'utf8'));
+        sourceCache.set(sourcePath, value);
+      } catch {
+        return false;
+      }
     }
     return jsonPointerValue(value, fragment) !== undefined;
   }
@@ -122,8 +128,9 @@ describe('remote API contract', () => {
       expect(claim, operation.operationId).toBeDefined();
       expect(allowed.has(claim.request)).toBe(true);
       expect(allowed.has(claim.response)).toBe(true);
+      expect(citationResolves(claim.requestCitation), operation.operationId).toBe(true);
+      expect(citationResolves(claim.responseCitation), operation.operationId).toBe(true);
       expect(claim.status).toBe('explicit-unknown');
-      expect(citationResolves(claim.citation), operation.operationId).toBe(true);
       expect(citationResolves(claim.statusCitation), operation.operationId).toBe(true);
     }
     const pointers = new Set([
@@ -131,22 +138,21 @@ describe('remote API contract', () => {
       ...materialClaimPointers(spec.paths, '#/paths', 'paths'),
       ...materialClaimPointers(spec.components, '#/components', 'components'),
     ]);
-    expect(pointers).toHaveLength(876);
+    expect(pointers).toHaveLength(819);
     for (const pointer of pointers) {
       const claim = evidence.claims[pointer];
       expect(claim, pointer).toBeDefined();
       expect(allowed.has(claim.classification), pointer).toBe(true);
       expect(citationResolves(claim.citation), pointer).toBe(true);
-      if (claim.citation.startsWith('spec/research/historical-27-operation-draft.json#')) {
+      if (claim.citation.startsWith(`${historicalDraftPath}#`)) {
         const sourcePointer = claim.citation.slice(
-          'spec/research/historical-27-operation-draft.json'.length,
+          historicalDraftPath.length,
         );
-        const historical = JSON.parse(
-          fs.readFileSync('spec/research/historical-27-operation-draft.json', 'utf8'),
-        );
-        expect(jsonPointerValue(historical, sourcePointer), pointer).toEqual(
-          jsonPointerValue(spec, pointer),
-        );
+        const sourceValue = jsonPointerValue(historicalDraft, sourcePointer);
+        const canonicalValue = jsonPointerValue(spec, pointer);
+        expect(sourceValue, `${pointer} source value`).not.toBeUndefined();
+        expect(canonicalValue, `${pointer} canonical value`).not.toBeUndefined();
+        expect(sourceValue, pointer).toEqual(canonicalValue);
       }
     }
   });
@@ -178,23 +184,26 @@ describe('remote API contract', () => {
   });
 
   it('uses the observed nested text-blast message and excludes the superseded shape', () => {
-    const params = spec.paths['/createTextBlast'].post.requestBody
-      .content['application/json'].schema.properties.data.properties.params;
+    const data = spec.paths['/createTextBlast'].post.requestBody
+      .content['application/json'].schema.properties.data;
+    const params = data.properties.params;
     expect(params.properties.message).toMatchObject({
       type: 'object',
       required: expect.arrayContaining(['text', 'to', 'showOnEventPage']),
     });
+    expect(data.properties.userId).toMatchObject({ type: 'string' });
     expect(params.properties).not.toHaveProperty('recipientStatuses');
     expect(evidence.contradictions.find(({ id }) => id === 'text-blast-message-shape')?.status).toBe('resolved');
   });
 
-  it('separates unknown response status from the response body evidence', () => {
+  it('keeps unknown default responses free of success-body schemas', () => {
     for (const { path, method, operation } of operations()) {
       const base = `#/paths/${escapePointerSegment(path)}/${method}/responses/default`;
       expect(evidence.claims[base].citation).toBe(evidence.sources.unknownStatusDecision);
-      const bodyPointer = `${base}/content/application~1json`;
-      expect(evidence.claims[bodyPointer].citation, operation.operationId)
-        .not.toBe(evidence.sources.unknownStatusDecision);
+      expect(operation.responses.default).not.toHaveProperty('content');
+      const operationClaim = evidence.operationClaims[operation.operationId];
+      expect(operationClaim.response).toBe('explicit-unknown');
+      expect(operationClaim.responseCitation).toBe(evidence.sources.unknownStatusDecision);
     }
   });
 
@@ -245,6 +254,31 @@ describe('remote API contract', () => {
     });
     expect(spec.components.schemas.FirebaseSignInResponse.properties ?? {})
       .not.toHaveProperty('localId');
+  });
+
+  it('does not claim client defaults or client-specific behavior as remote facts', () => {
+    const list = spec.paths[
+      '/v1/projects/getpartiful/databases/(default)/documents/{collectionPath}'
+    ].get;
+    expect(list.parameters.find(({ name }) => name === 'pageSize').schema)
+      .not.toHaveProperty('default');
+    expect(JSON.stringify(spec).toLowerCase()).not.toContain('custom client');
+  });
+
+  it('keeps the human operation summary aligned with machine classifications', () => {
+    const ledger = fs.readFileSync(
+      'docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md',
+      'utf8',
+    );
+    for (const operationId of ['sendAuthCodeTrusted', 'lookupFirebaseUser']) {
+      expect(evidence.operations[operationId].classification).toBe('typescript-derived-inference');
+      expect(ledger).toContain('`' + operationId + '` is a TypeScript-derived inference');
+    }
+  });
+
+  it('rejects missing and mismatched historical evidence values', () => {
+    expect(jsonPointerValue(historicalDraft, '#/not-a-real-pointer')).toBeUndefined();
+    expect(jsonPointerValue(historicalDraft, '#/openapi')).not.toEqual(spec.info.version);
   });
 
   it('does not treat the event-image observation as poster-catalog evidence', () => {

--- a/tests/remote-api-contract.test.js
+++ b/tests/remote-api-contract.test.js
@@ -107,11 +107,11 @@ function citationResolves(citation) {
 }
 
 describe('remote API contract', () => {
-  it('is a proposed, consistently versioned OpenAPI 3.1 document with unique operation IDs', () => {
+  it('is an owner-reviewed, consistently versioned OpenAPI 3.1 document with unique operation IDs', () => {
     expect(spec.openapi).toBe('3.1.0');
     expect(spec.info.version).toBe(evidence.contractRevision);
-    expect(evidence.status).toBe('proposed-pending-owner-approval');
-    expect(spec.info.description).toContain('Proposed');
+    expect(evidence.status).toBe('owner-reviewed');
+    expect(spec.info.description).toContain('Owner-reviewed');
     const ids = operations().map(({ operation }) => operation.operationId);
     expect(ids).toHaveLength(27);
     expect(new Set(ids).size).toBe(ids.length);

--- a/tests/remote-api-contract.test.js
+++ b/tests/remote-api-contract.test.js
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import evidence from '../spec/partiful.api-evidence.json';
+import spec from '../spec/partiful.openapi.json';
+
+const methods = new Set(['get', 'post', 'put', 'patch', 'delete']);
+const hosts = {
+  firebaseCallable: 'https://api.partiful.com',
+  firestore: 'https://firestore.googleapis.com',
+  token: 'https://securetoken.googleapis.com',
+  identity: 'https://identitytoolkit.googleapis.com',
+  upload: 'https://us-central1-getpartiful.cloudfunctions.net',
+  posters: 'https://assets.getpartiful.com',
+};
+
+function operations() {
+  return Object.entries(spec.paths).flatMap(([path, item]) =>
+    Object.entries(item)
+      .filter(([method]) => methods.has(method))
+      .map(([method, operation]) => ({ path, method, operation })),
+  );
+}
+
+describe('remote API contract', () => {
+  it('is a versioned OpenAPI 3.1 document with unique operation IDs', () => {
+    expect(spec.openapi).toBe('3.1.0');
+    expect(spec.info.version).toBe('1.0.0');
+    const ids = operations().map(({ operation }) => operation.operationId);
+    expect(ids).toHaveLength(27);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('covers every operation and material schema with allowed evidence', () => {
+    const allowed = new Set(evidence.allowedClassifications);
+    const operationEvidence = new Map(evidence.operations);
+    for (const { operation } of operations()) {
+      expect(allowed.has(operationEvidence.get(operation.operationId))).toBe(true);
+      const claim = evidence.operationClaims[operation.operationId] ?? evidence.operationClaims.default;
+      expect(allowed.has(claim.request)).toBe(true);
+      expect(allowed.has(claim.response)).toBe(true);
+    }
+    for (const schemaName of Object.keys(spec.components.schemas)) {
+      const claim = evidence.schemaClaims[schemaName];
+      expect(claim, schemaName).toBeDefined();
+      expect(allowed.has(claim.classification), schemaName).toBe(true);
+    }
+  });
+
+  it('contains remote transport facts rather than product or implementation policy', () => {
+    const serialized = JSON.stringify(spec).toLowerCase();
+    for (const forbidden of ['x-mcp', 'x-pp-', 'printing press', 'credential', 'environment variable', 'workflow', 'command layer']) {
+      expect(serialized).not.toContain(forbidden);
+    }
+  });
+
+  it('keeps operation servers consistent with their transport paths', () => {
+    for (const { path, operation } of operations()) {
+      const server = operation.servers?.[0]?.url ?? spec.servers[0].url;
+      if (path.startsWith('/v1/projects/')) expect(server).toBe(hosts.firestore);
+      else if (path === '/v1/token') expect(server).toBe(hosts.token);
+      else if (path.startsWith('/v1/accounts:')) expect(server).toBe(hosts.identity);
+      else if (path === '/uploadPhoto') expect(server).toBe(hosts.upload);
+      else if (path === '/posters.json') expect(server).toBe(hosts.posters);
+      else expect(server).toBe(hosts.firebaseCallable);
+    }
+  });
+
+  it('uses the observed nested text-blast message and excludes the superseded shape', () => {
+    const params = spec.components.schemas.TextBlastRequest.properties.data.properties.params;
+    expect(params.properties.message.$ref).toBe('#/components/schemas/TextBlastMessage');
+    expect(params.properties).not.toHaveProperty('recipientStatuses');
+    expect(spec.components.schemas.TextBlastMessage.required).toEqual(
+      expect.arrayContaining(['text', 'to', 'showOnEventPage']),
+    );
+    expect(evidence.contradictions.find(({ id }) => id === 'text-blast-message-shape')?.status).toBe('resolved');
+  });
+});

--- a/tests/remote-api-contract.test.js
+++ b/tests/remote-api-contract.test.js
@@ -10,10 +10,7 @@ const materialMapKeys = new Set([
   'properties',
   'responses',
   'content',
-  'schemas',
-  'parameters',
-  'requestBodies',
-  'securitySchemes',
+  'security',
 ]);
 const hosts = {
   firebaseCallable: 'https://api.partiful.com',
@@ -41,6 +38,7 @@ function materialClaimPointers(value, pointer, parentKey = '') {
     return ignoredKeys.has(parentKey) ? [] : [pointer];
   }
   if (Array.isArray(value)) {
+    if (value.length === 0) return [pointer];
     return value.flatMap((item, index) =>
       materialClaimPointers(item, `${pointer}/${index}`, parentKey),
     );
@@ -53,6 +51,16 @@ function materialClaimPointers(value, pointer, parentKey = '') {
       ...(ignoredKeys.has(key) ? [] : materialClaimPointers(child, childPointer, key)),
     ];
   });
+}
+
+function jsonPointerValue(value, pointer) {
+  for (const rawSegment of pointer.replace(/^\//, '').split('/')) {
+    if (!rawSegment) continue;
+    const segment = rawSegment.replaceAll('~1', '/').replaceAll('~0', '~');
+    if (value === null || typeof value !== 'object' || !(segment in value)) return undefined;
+    value = value[segment];
+  }
+  return value;
 }
 
 function markdownSlug(value) {
@@ -80,13 +88,7 @@ function citationResolves(citation) {
     } catch {
       return false;
     }
-    for (const rawSegment of fragment.replace(/^\//, '').split('/')) {
-      if (!rawSegment) continue;
-      const segment = rawSegment.replaceAll('~1', '/').replaceAll('~0', '~');
-      if (value === null || typeof value !== 'object' || !(segment in value)) return false;
-      value = value[segment];
-    }
-    return true;
+    return jsonPointerValue(value, fragment) !== undefined;
   }
 
   if (sourcePath.endsWith('.md')) {
@@ -109,7 +111,7 @@ describe('remote API contract', () => {
     expect(new Set(ids).size).toBe(ids.length);
   });
 
-  it('covers all 379 material OpenAPI claims with a resolving citation', () => {
+  it('covers all material OpenAPI claims with resolving and semantically supporting citations', () => {
     const allowed = new Set(evidence.allowedClassifications);
     for (const { operation } of operations()) {
       const operationEvidence = evidence.operations[operation.operationId];
@@ -129,12 +131,23 @@ describe('remote API contract', () => {
       ...materialClaimPointers(spec.paths, '#/paths', 'paths'),
       ...materialClaimPointers(spec.components, '#/components', 'components'),
     ]);
-    expect(pointers).toHaveLength(379);
+    expect(pointers).toHaveLength(876);
     for (const pointer of pointers) {
       const claim = evidence.claims[pointer];
       expect(claim, pointer).toBeDefined();
       expect(allowed.has(claim.classification), pointer).toBe(true);
       expect(citationResolves(claim.citation), pointer).toBe(true);
+      if (claim.citation.startsWith('spec/research/historical-27-operation-draft.json#')) {
+        const sourcePointer = claim.citation.slice(
+          'spec/research/historical-27-operation-draft.json'.length,
+        );
+        const historical = JSON.parse(
+          fs.readFileSync('spec/research/historical-27-operation-draft.json', 'utf8'),
+        );
+        expect(jsonPointerValue(historical, sourcePointer), pointer).toEqual(
+          jsonPointerValue(spec, pointer),
+        );
+      }
     }
   });
 
@@ -165,13 +178,73 @@ describe('remote API contract', () => {
   });
 
   it('uses the observed nested text-blast message and excludes the superseded shape', () => {
-    const params = spec.components.schemas.TextBlastRequest.properties.data.properties.params;
-    expect(params.properties.message.$ref).toBe('#/components/schemas/TextBlastMessage');
+    const params = spec.paths['/createTextBlast'].post.requestBody
+      .content['application/json'].schema.properties.data.properties.params;
+    expect(params.properties.message).toMatchObject({
+      type: 'object',
+      required: expect.arrayContaining(['text', 'to', 'showOnEventPage']),
+    });
     expect(params.properties).not.toHaveProperty('recipientStatuses');
-    expect(spec.components.schemas.TextBlastMessage.required).toEqual(
-      expect.arrayContaining(['text', 'to', 'showOnEventPage']),
-    );
     expect(evidence.contradictions.find(({ id }) => id === 'text-blast-message-shape')?.status).toBe('resolved');
+  });
+
+  it('separates unknown response status from the response body evidence', () => {
+    for (const { path, method, operation } of operations()) {
+      const base = `#/paths/${escapePointerSegment(path)}/${method}/responses/default`;
+      expect(evidence.claims[base].citation).toBe(evidence.sources.unknownStatusDecision);
+      const bodyPointer = `${base}/content/application~1json`;
+      expect(evidence.claims[bodyPointer].citation, operation.operationId)
+        .not.toBe(evidence.sources.unknownStatusDecision);
+    }
+  });
+
+  it('uses each Markdown decision source only for its stated claim category', () => {
+    for (const [pointer, claim] of Object.entries(evidence.claims)) {
+      if (claim.citation === evidence.sources.unknownStatusDecision) {
+        expect(pointer).toMatch(/\/responses\/default$/);
+      }
+      if (claim.citation === evidence.sources.textBlast) {
+        expect(pointer).toContain('~1createTextBlast/post/requestBody');
+      }
+      if (claim.citation === evidence.sources.updateMask) {
+        expect(pointer).toMatch(/updateMask\.fieldPaths|parameters\/1\/(?:style|explode)$/);
+      }
+      if (claim.citation === evidence.sources.posterCatalog) {
+        expect(pointer).toContain('~1posters.json');
+      }
+      if (claim.citation === evidence.sources.posterInterface) {
+        expect(pointer).toContain('/schemas/Poster');
+      }
+    }
+  });
+
+  it('covers every security assignment, including empty scopes', () => {
+    for (const { path, method, operation } of operations()) {
+      if (!operation.security) continue;
+      expect(operation.security.length, operation.operationId).toBeGreaterThan(0);
+      for (let index = 0; index < operation.security.length; index++) {
+        for (const [scheme, scopes] of Object.entries(operation.security[index])) {
+          const pointer = `#/paths/${escapePointerSegment(path)}/${method}/security/${index}/${scheme}`;
+          expect(Array.isArray(scopes), pointer).toBe(true);
+          expect(evidence.claims[pointer], pointer).toBeDefined();
+        }
+      }
+    }
+  });
+
+  it('models update masks as repeated query values and leaves undocumented localId absent', () => {
+    const patch = spec.paths[
+      '/v1/projects/getpartiful/databases/(default)/documents/events/{eventId}'
+    ].patch;
+    const updateMask = patch.parameters.find(({ name }) => name === 'updateMask.fieldPaths');
+    expect(updateMask).toMatchObject({
+      in: 'query',
+      schema: { type: 'array', items: { type: 'string' } },
+      style: 'form',
+      explode: true,
+    });
+    expect(spec.components.schemas.FirebaseSignInResponse.properties ?? {})
+      .not.toHaveProperty('localId');
   });
 
   it('does not treat the event-image observation as poster-catalog evidence', () => {

--- a/tests/remote-api-contract.test.js
+++ b/tests/remote-api-contract.test.js
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
 import evidence from '../spec/partiful.api-evidence.json';
 import spec from '../spec/partiful.openapi.json';
 
@@ -53,6 +55,49 @@ function materialClaimPointers(value, pointer, parentKey = '') {
   });
 }
 
+function markdownSlug(value) {
+  return value
+    .toLowerCase()
+    .replace(/[`*_]/g, '')
+    .replace(/[^a-z0-9 -]/g, '')
+    .trim()
+    .replace(/\s+/g, '-');
+}
+
+function citationResolves(citation) {
+  const separator = citation.indexOf('#');
+  if (separator < 1) return false;
+  const sourcePath = citation.slice(0, separator);
+  const fragment = citation.slice(separator + 1);
+  if (path.isAbsolute(sourcePath) || sourcePath.split('/').includes('..')) return false;
+  const source = path.resolve(process.cwd(), sourcePath);
+  if (!fs.existsSync(source)) return false;
+
+  if (sourcePath.endsWith('.json')) {
+    let value;
+    try {
+      value = JSON.parse(fs.readFileSync(source, 'utf8'));
+    } catch {
+      return false;
+    }
+    for (const rawSegment of fragment.replace(/^\//, '').split('/')) {
+      if (!rawSegment) continue;
+      const segment = rawSegment.replaceAll('~1', '/').replaceAll('~0', '~');
+      if (value === null || typeof value !== 'object' || !(segment in value)) return false;
+      value = value[segment];
+    }
+    return true;
+  }
+
+  if (sourcePath.endsWith('.md')) {
+    const anchors = [...fs.readFileSync(source, 'utf8').matchAll(/^#{1,6}\s+(.+)$/gm)]
+      .map((match) => markdownSlug(match[1]));
+    return anchors.includes(fragment);
+  }
+
+  return false;
+}
+
 describe('remote API contract', () => {
   it('is a proposed, consistently versioned OpenAPI 3.1 document with unique operation IDs', () => {
     expect(spec.openapi).toBe('3.1.0');
@@ -64,29 +109,32 @@ describe('remote API contract', () => {
     expect(new Set(ids).size).toBe(ids.length);
   });
 
-  it('covers every operation and material OpenAPI claim with a precise citation', () => {
+  it('covers all 379 material OpenAPI claims with a resolving citation', () => {
     const allowed = new Set(evidence.allowedClassifications);
     for (const { operation } of operations()) {
       const operationEvidence = evidence.operations[operation.operationId];
       expect(operationEvidence, operation.operationId).toBeDefined();
       expect(allowed.has(operationEvidence.classification)).toBe(true);
-      expect(operationEvidence.citation).toMatch(/(#|#L)/);
+      expect(citationResolves(operationEvidence.citation), operation.operationId).toBe(true);
       const claim = evidence.operationClaims[operation.operationId];
       expect(claim, operation.operationId).toBeDefined();
       expect(allowed.has(claim.request)).toBe(true);
       expect(allowed.has(claim.response)).toBe(true);
+      expect(claim.status).toBe('explicit-unknown');
+      expect(citationResolves(claim.citation), operation.operationId).toBe(true);
+      expect(citationResolves(claim.statusCitation), operation.operationId).toBe(true);
     }
-    const pointers = [
+    const pointers = new Set([
       ...materialClaimPointers(spec.servers, '#/servers', 'servers'),
       ...materialClaimPointers(spec.paths, '#/paths', 'paths'),
       ...materialClaimPointers(spec.components, '#/components', 'components'),
-    ];
-    expect(pointers.length).toBeGreaterThan(0);
+    ]);
+    expect(pointers).toHaveLength(379);
     for (const pointer of pointers) {
       const claim = evidence.claims[pointer];
       expect(claim, pointer).toBeDefined();
       expect(allowed.has(claim.classification), pointer).toBe(true);
-      expect(claim.citation, pointer).toMatch(/(#|#L)/);
+      expect(citationResolves(claim.citation), pointer).toBe(true);
     }
   });
 
@@ -129,7 +177,8 @@ describe('remote API contract', () => {
   it('does not treat the event-image observation as poster-catalog evidence', () => {
     const posterOperation = evidence.operations.getPosterCatalog;
     expect(posterOperation.classification).toBe('typescript-derived-inference');
-    expect(posterOperation.citation).toBe(evidence.sources.posterTransport);
+    expect(posterOperation.citation).toBe(evidence.sources.posterCatalog);
+    expect(evidence.sources).not.toHaveProperty('eventImageObservation');
     for (const [pointer, claim] of Object.entries(evidence.claims)) {
       if (pointer.includes('/posters.json') || pointer.includes('/Poster')) {
         expect(claim.citation).not.toBe(evidence.sources.eventImageObservation);

--- a/tests/remote-api-contract.test.js
+++ b/tests/remote-api-contract.test.js
@@ -3,6 +3,16 @@ import evidence from '../spec/partiful.api-evidence.json';
 import spec from '../spec/partiful.openapi.json';
 
 const methods = new Set(['get', 'post', 'put', 'patch', 'delete']);
+const ignoredKeys = new Set(['description', 'summary', 'title']);
+const materialMapKeys = new Set([
+  'properties',
+  'responses',
+  'content',
+  'schemas',
+  'parameters',
+  'requestBodies',
+  'securitySchemes',
+]);
 const hosts = {
   firebaseCallable: 'https://api.partiful.com',
   firestore: 'https://firestore.googleapis.com',
@@ -20,28 +30,63 @@ function operations() {
   );
 }
 
+function escapePointerSegment(value) {
+  return value.replaceAll('~', '~0').replaceAll('/', '~1');
+}
+
+function materialClaimPointers(value, pointer, parentKey = '') {
+  if (value === null || typeof value !== 'object') {
+    return ignoredKeys.has(parentKey) ? [] : [pointer];
+  }
+  if (Array.isArray(value)) {
+    return value.flatMap((item, index) =>
+      materialClaimPointers(item, `${pointer}/${index}`, parentKey),
+    );
+  }
+  return Object.entries(value).flatMap(([key, child]) => {
+    const childPointer = `${pointer}/${escapePointerSegment(key)}`;
+    const namedClaim = materialMapKeys.has(parentKey) ? [childPointer] : [];
+    return [
+      ...namedClaim,
+      ...(ignoredKeys.has(key) ? [] : materialClaimPointers(child, childPointer, key)),
+    ];
+  });
+}
+
 describe('remote API contract', () => {
-  it('is a versioned OpenAPI 3.1 document with unique operation IDs', () => {
+  it('is a proposed, consistently versioned OpenAPI 3.1 document with unique operation IDs', () => {
     expect(spec.openapi).toBe('3.1.0');
-    expect(spec.info.version).toBe('1.0.0');
+    expect(spec.info.version).toBe(evidence.contractRevision);
+    expect(evidence.status).toBe('proposed-pending-owner-approval');
+    expect(spec.info.description).toContain('Proposed');
     const ids = operations().map(({ operation }) => operation.operationId);
     expect(ids).toHaveLength(27);
     expect(new Set(ids).size).toBe(ids.length);
   });
 
-  it('covers every operation and material schema with allowed evidence', () => {
+  it('covers every operation and material OpenAPI claim with a precise citation', () => {
     const allowed = new Set(evidence.allowedClassifications);
-    const operationEvidence = new Map(evidence.operations);
     for (const { operation } of operations()) {
-      expect(allowed.has(operationEvidence.get(operation.operationId))).toBe(true);
-      const claim = evidence.operationClaims[operation.operationId] ?? evidence.operationClaims.default;
+      const operationEvidence = evidence.operations[operation.operationId];
+      expect(operationEvidence, operation.operationId).toBeDefined();
+      expect(allowed.has(operationEvidence.classification)).toBe(true);
+      expect(operationEvidence.citation).toMatch(/(#|#L)/);
+      const claim = evidence.operationClaims[operation.operationId];
+      expect(claim, operation.operationId).toBeDefined();
       expect(allowed.has(claim.request)).toBe(true);
       expect(allowed.has(claim.response)).toBe(true);
     }
-    for (const schemaName of Object.keys(spec.components.schemas)) {
-      const claim = evidence.schemaClaims[schemaName];
-      expect(claim, schemaName).toBeDefined();
-      expect(allowed.has(claim.classification), schemaName).toBe(true);
+    const pointers = [
+      ...materialClaimPointers(spec.servers, '#/servers', 'servers'),
+      ...materialClaimPointers(spec.paths, '#/paths', 'paths'),
+      ...materialClaimPointers(spec.components, '#/components', 'components'),
+    ];
+    expect(pointers.length).toBeGreaterThan(0);
+    for (const pointer of pointers) {
+      const claim = evidence.claims[pointer];
+      expect(claim, pointer).toBeDefined();
+      expect(allowed.has(claim.classification), pointer).toBe(true);
+      expect(claim.citation, pointer).toMatch(/(#|#L)/);
     }
   });
 
@@ -64,6 +109,13 @@ describe('remote API contract', () => {
     }
   });
 
+  it('does not assert an unknown status code as a success response', () => {
+    for (const { operation } of operations()) {
+      expect(Object.keys(operation.responses)).toEqual(['default']);
+      expect(evidence.operationClaims[operation.operationId].status).toBe('explicit-unknown');
+    }
+  });
+
   it('uses the observed nested text-blast message and excludes the superseded shape', () => {
     const params = spec.components.schemas.TextBlastRequest.properties.data.properties.params;
     expect(params.properties.message.$ref).toBe('#/components/schemas/TextBlastMessage');
@@ -72,5 +124,16 @@ describe('remote API contract', () => {
       expect.arrayContaining(['text', 'to', 'showOnEventPage']),
     );
     expect(evidence.contradictions.find(({ id }) => id === 'text-blast-message-shape')?.status).toBe('resolved');
+  });
+
+  it('does not treat the event-image observation as poster-catalog evidence', () => {
+    const posterOperation = evidence.operations.getPosterCatalog;
+    expect(posterOperation.classification).toBe('typescript-derived-inference');
+    expect(posterOperation.citation).toBe(evidence.sources.posterTransport);
+    for (const [pointer, claim] of Object.entries(evidence.claims)) {
+      if (pointer.includes('/posters.json') || pointer.includes('/Poster')) {
+        expect(claim.citation).not.toBe(evidence.sources.eventImageObservation);
+      }
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Adds **proposed** remote-only OpenAPI 3.1 contract revision `2026-08-10.1` at `spec/partiful.openapi.json`; explicit owner approval is pending.
- Preserves the historical 27-operation draft only as a clearly non-authoritative local research artifact, allowing clean-checkout semantic citation audits without importing product extensions into the canonical contract.
- Audits 819 material claims: 723 historically derived claims must equal their narrow cited JSON source; all comparisons have defined source/canonical values and 0 mismatches. All 24 operation security assignments are covered.
- Resolves the text-blast conflict from dated primary observation; uses schema-free `default` responses while status/error bodies are unknown; separates request/response/status citations; uses repeated query-array serialization for Firestore update masks; and leaves undocumented Firebase `localId` absent.

## Verification
- `npm test -- tests/remote-api-contract.test.js` — passed (14 tests; 1.96s test execution, no timeout).
- `npm run typecheck` — passed
- `git diff --check` — passed
- Full `npm test` was attempted but stopped after severe host-wide slowdown caused unrelated existing suites to exceed their 5s timeouts; no completed baseline comparison is claimed.

No live probe was attempted: `partiful doctor` found no local credentials. No mutation was performed. Owner review/approval remains required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the proposed remote API contract, including evidence standards, review requirements, uncertainty handling, and historical context.
  * Added a research index describing evidence sources and confidence boundaries.

* **New Specifications**
  * Added versioned OpenAPI definitions covering event, guest, authentication, Firestore, upload, and poster catalog operations.
  * Added an evidence ledger documenting operation classifications, citations, resolved conflicts, and unknowns.
  * Added a historical contract draft for reference.

* **Tests**
  * Added comprehensive validation for contract versioning, schemas, security, evidence citations, transport behavior, and unknown response semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->