### PR TITLE
feat(go): establish local runtime

### DIFF
--- a/cmd/partiful/main.go
+++ b/cmd/partiful/main.go
@@ -11,14 +11,15 @@ import (
 )
 
 func main() {
-	credentialsPath, _ := auth.DefaultCredentialsPath()
+	credentialsPath, credentialsPathError := auth.DefaultCredentialsPath()
 	result := app.Execute(context.Background(), app.Request{
 		Argv:  os.Args[1:],
 		Stdin: os.Stdin,
 	}, app.Dependencies{
-		Files:           auth.OSFileSystem{},
-		CredentialsPath: credentialsPath,
-		Now:             time.Now,
+		Files:                auth.OSFileSystem{},
+		CredentialsPath:      credentialsPath,
+		CredentialsPathError: credentialsPathError,
+		Now:                  time.Now,
 	})
 
 	_, _ = io.WriteString(os.Stdout, result.Stdout)

--- a/cmd/partiful/main.go
+++ b/cmd/partiful/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"context"
+	"io"
+	"os"
+	"time"
+
+	"github.com/KalebCole/partiful-cli/internal/app"
+	"github.com/KalebCole/partiful-cli/internal/auth"
+)
+
+func main() {
+	credentialsPath, _ := auth.DefaultCredentialsPath()
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  os.Args[1:],
+		Stdin: os.Stdin,
+	}, app.Dependencies{
+		Files:           auth.OSFileSystem{},
+		CredentialsPath: credentialsPath,
+		Now:             time.Now,
+	})
+
+	_, _ = io.WriteString(os.Stdout, result.Stdout)
+	_, _ = io.WriteString(os.Stderr, result.Stderr)
+	os.Exit(result.ExitCode)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/KalebCole/partiful-cli
+
+go 1.22

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1,0 +1,655 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"slices"
+	"time"
+
+	"github.com/KalebCole/partiful-cli/internal/auth"
+)
+
+const (
+	Version                 = "1.0.0"
+	ProductContractRevision = "2026-08-10.1"
+	RemoteContractRevision  = "2026-08-10.1"
+)
+
+type Request struct {
+	Argv  []string
+	Stdin io.Reader
+}
+
+type Result struct {
+	Stdout   string
+	Stderr   string
+	ExitCode int
+}
+
+type Dependencies struct {
+	Files           auth.FileSystem
+	CredentialsPath string
+	Now             func() time.Time
+}
+
+type commandKind uint8
+
+const (
+	versionCommand commandKind = iota
+	schemaCommand
+	authStatusCommand
+	authLogoutCommand
+	doctorCommand
+)
+
+type commandDefinition struct {
+	path          string
+	invocation    []string
+	kind          commandKind
+	positionals   []positionalDefinition
+	flags         []flagDefinition
+	inputSchema   jsonSchema
+	successSchema jsonSchema
+	failureTypes  []string
+	safety        safetyDefinition
+}
+
+var commandCatalog = []commandDefinition{
+	{
+		path:          "version",
+		invocation:    []string{"--version"},
+		kind:          versionCommand,
+		positionals:   []positionalDefinition{},
+		flags:         []flagDefinition{},
+		inputSchema:   emptyInputSchema(),
+		successSchema: versionSuccessSchema(),
+		failureTypes:  []string{},
+		safety:        readOnlySafety(),
+	},
+	{
+		path:       "schema",
+		invocation: []string{"schema"},
+		kind:       schemaCommand,
+		positionals: []positionalDefinition{{
+			Name:        "command.path",
+			Required:    false,
+			Description: "Completed public command path.",
+		}},
+		flags:         []flagDefinition{},
+		inputSchema:   emptyInputSchema(),
+		successSchema: schemaSuccessSchema(),
+		failureTypes:  []string{"usage.invalid"},
+		safety:        readOnlySafety(),
+	},
+	{
+		path:          "auth.status",
+		invocation:    []string{"auth", "status"},
+		kind:          authStatusCommand,
+		positionals:   []positionalDefinition{},
+		flags:         []flagDefinition{},
+		inputSchema:   emptyInputSchema(),
+		successSchema: authStateSuccessSchema(),
+		failureTypes:  []string{"internal.failure"},
+		safety:        readOnlySafety(),
+	},
+	{
+		path:          "auth.logout",
+		invocation:    []string{"auth", "logout"},
+		kind:          authLogoutCommand,
+		positionals:   []positionalDefinition{},
+		flags:         []flagDefinition{},
+		inputSchema:   emptyInputSchema(),
+		successSchema: authStateSuccessSchema(),
+		failureTypes:  []string{"internal.failure"},
+		safety: safetyDefinition{
+			Kind:                 "local-mutation",
+			PlanRequired:         false,
+			ConfirmationRequired: false,
+		},
+	},
+	{
+		path:          "doctor",
+		invocation:    []string{"doctor"},
+		kind:          doctorCommand,
+		positionals:   []positionalDefinition{},
+		flags:         []flagDefinition{},
+		inputSchema:   emptyInputSchema(),
+		successSchema: doctorSuccessSchema(),
+		failureTypes:  []string{},
+		safety:        readOnlySafety(),
+	},
+}
+
+type positionalDefinition struct {
+	Name        string `json:"name"`
+	Required    bool   `json:"required"`
+	Description string `json:"description"`
+}
+
+type flagDefinition struct {
+	Name        string `json:"name"`
+	Required    bool   `json:"required"`
+	Description string `json:"description"`
+}
+
+type jsonSchema struct {
+	Type                 any                   `json:"type"`
+	AdditionalProperties *bool                 `json:"additionalProperties,omitempty"`
+	Required             []string              `json:"required,omitempty"`
+	Properties           map[string]jsonSchema `json:"properties,omitempty"`
+	Enum                 []string              `json:"enum,omitempty"`
+	Format               string                `json:"format,omitempty"`
+	Items                *jsonSchema           `json:"items,omitempty"`
+	OneOf                []jsonSchema          `json:"oneOf,omitempty"`
+}
+
+type safetyDefinition struct {
+	Kind                 string `json:"kind"`
+	PlanRequired         bool   `json:"planRequired"`
+	ConfirmationRequired bool   `json:"confirmationRequired"`
+}
+
+func emptyInputSchema() jsonSchema {
+	allowAdditional := false
+	return jsonSchema{Type: "object", AdditionalProperties: &allowAdditional}
+}
+
+func objectSchema(required []string, properties map[string]jsonSchema) jsonSchema {
+	allowAdditional := false
+	return jsonSchema{
+		Type:                 "object",
+		AdditionalProperties: &allowAdditional,
+		Required:             required,
+		Properties:           properties,
+	}
+}
+
+func authStateSuccessSchema() jsonSchema {
+	return objectSchema(
+		[]string{"authenticated", "tokenState", "expiresAt"},
+		map[string]jsonSchema{
+			"authenticated": {Type: "boolean"},
+			"tokenState": {
+				Type: "string",
+				Enum: []string{"healthy", "expiring", "expired", "missing"},
+			},
+			"expiresAt": {Type: []string{"string", "null"}, Format: "date-time"},
+		},
+	)
+}
+
+func versionSuccessSchema() jsonSchema {
+	return objectSchema(
+		[]string{"version", "productContractRevision", "remoteContractRevision"},
+		map[string]jsonSchema{
+			"version":                 {Type: "string"},
+			"productContractRevision": {Type: "string"},
+			"remoteContractRevision":  {Type: "string"},
+		},
+	)
+}
+
+func schemaSuccessSchema() jsonSchema {
+	stringItem := jsonSchema{Type: "string"}
+	commandList := objectSchema(
+		[]string{"commands"},
+		map[string]jsonSchema{
+			"commands": {Type: "array", Items: &stringItem},
+		},
+	)
+
+	descriptor := objectSchema(
+		[]string{"name", "required", "description"},
+		map[string]jsonSchema{
+			"name":        {Type: "string"},
+			"required":    {Type: "boolean"},
+			"description": {Type: "string"},
+		},
+	)
+	stringList := jsonSchema{Type: "array", Items: &stringItem}
+	descriptorList := jsonSchema{Type: "array", Items: &descriptor}
+	safety := objectSchema(
+		[]string{"kind", "planRequired", "confirmationRequired"},
+		map[string]jsonSchema{
+			"kind": {
+				Type: "string",
+				Enum: []string{"read-only", "local-mutation"},
+			},
+			"planRequired":         {Type: "boolean"},
+			"confirmationRequired": {Type: "boolean"},
+		},
+	)
+	commandDetail := objectSchema(
+		[]string{
+			"command",
+			"positionals",
+			"flags",
+			"inputSchema",
+			"successSchema",
+			"failureTypes",
+			"safety",
+		},
+		map[string]jsonSchema{
+			"command":       {Type: "string"},
+			"positionals":   descriptorList,
+			"flags":         descriptorList,
+			"inputSchema":   {Type: "object"},
+			"successSchema": {Type: "object"},
+			"failureTypes":  stringList,
+			"safety":        safety,
+		},
+	)
+	return jsonSchema{
+		Type:  "object",
+		OneOf: []jsonSchema{commandList, commandDetail},
+	}
+}
+
+func doctorSuccessSchema() jsonSchema {
+	check := objectSchema(
+		[]string{"name", "status", "message", "remediation"},
+		map[string]jsonSchema{
+			"name":        {Type: "string"},
+			"status":      {Type: "string", Enum: []string{"pass", "warn", "fail"}},
+			"message":     {Type: "string"},
+			"remediation": {Type: []string{"string", "null"}},
+		},
+	)
+	checks := jsonSchema{Type: "array", Items: &check}
+	return objectSchema(
+		[]string{"healthy", "checks"},
+		map[string]jsonSchema{
+			"healthy": {Type: "boolean"},
+			"checks":  checks,
+		},
+	)
+}
+
+func readOnlySafety() safetyDefinition {
+	return safetyDefinition{
+		Kind:                 "read-only",
+		PlanRequired:         false,
+		ConfirmationRequired: false,
+	}
+}
+
+type successEnvelope struct {
+	OK   bool        `json:"ok"`
+	Data any         `json:"data"`
+	Meta successMeta `json:"meta"`
+}
+
+type successMeta struct {
+	Command                 string   `json:"command"`
+	CLIVersion              string   `json:"cliVersion"`
+	ProductContractRevision string   `json:"productContractRevision"`
+	RemoteContractRevision  string   `json:"remoteContractRevision"`
+	Warnings                []string `json:"warnings"`
+}
+
+type versionData struct {
+	Version                 string `json:"version"`
+	ProductContractRevision string `json:"productContractRevision"`
+	RemoteContractRevision  string `json:"remoteContractRevision"`
+}
+
+func Execute(_ context.Context, request Request, provided ...Dependencies) Result {
+	var dependencies Dependencies
+	if len(provided) == 1 {
+		dependencies = provided[0]
+	}
+	argv := make([]string, 0, len(request.Argv))
+	pretty := slices.Contains(request.Argv, "--pretty")
+	seenGlobalFlags := make(map[string]bool)
+	for _, argument := range request.Argv {
+		switch argument {
+		case "--pretty":
+			if seenGlobalFlags[argument] {
+				return repeatedFlagFailure(commandName(request.Argv), argument, pretty)
+			}
+			seenGlobalFlags[argument] = true
+			continue
+		case "--non-interactive":
+			if seenGlobalFlags[argument] {
+				return repeatedFlagFailure(commandName(request.Argv), argument, pretty)
+			}
+			seenGlobalFlags[argument] = true
+			continue
+		}
+		argv = append(argv, argument)
+	}
+	for _, definition := range commandCatalog {
+		if definition.matches(argv) {
+			switch definition.kind {
+			case versionCommand:
+				return success(definition.path, versionData{
+					Version:                 Version,
+					ProductContractRevision: ProductContractRevision,
+					RemoteContractRevision:  RemoteContractRevision,
+				}, pretty)
+			case schemaCommand:
+				if len(argv) == 1 {
+					return success(definition.path, schemaCatalogData(), pretty)
+				}
+				if selected, ok := findDefinition(argv[1]); ok {
+					return success(definition.path, projectSchema(selected), pretty)
+				}
+				return failure(definition.path, 2, errorBody{
+					Type:      "usage.invalid",
+					Code:      "COMMAND_SCHEMA_NOT_FOUND",
+					Message:   "No completed command has that schema path.",
+					Retryable: false,
+					Details:   map[string]any{},
+				}, pretty)
+			case authStatusCommand:
+				now := time.Now()
+				if dependencies.Now != nil {
+					now = dependencies.Now()
+				}
+				state, err := auth.Status(
+					dependencies.Files,
+					dependencies.CredentialsPath,
+					now,
+				)
+				if err != nil {
+					if errors.Is(err, auth.ErrInvalid) {
+						return credentialInvalidFailure(definition.path, pretty)
+					}
+					if errors.Is(err, auth.ErrUnavailable) {
+						return credentialUnavailableFailure(definition.path, pretty)
+					}
+					return internalFailure(definition.path, pretty)
+				}
+				return success(definition.path, state, pretty)
+			case authLogoutCommand:
+				state, err := auth.Logout(
+					dependencies.Files,
+					dependencies.CredentialsPath,
+				)
+				if err != nil {
+					if errors.Is(err, auth.ErrUnavailable) {
+						return credentialUnavailableFailure(definition.path, pretty)
+					}
+					return internalFailure(definition.path, pretty)
+				}
+				return success(definition.path, state, pretty)
+			case doctorCommand:
+				now := time.Now()
+				if dependencies.Now != nil {
+					now = dependencies.Now()
+				}
+				state, err := auth.Status(
+					dependencies.Files,
+					dependencies.CredentialsPath,
+					now,
+				)
+				if err == nil && state.TokenState == "missing" {
+					remediation := "Establish authentication before using commands that require it."
+					return success(definition.path, doctorData{
+						Healthy: false,
+						Checks: []doctorCheck{{
+							Name:        "credentials",
+							Status:      "fail",
+							Message:     "Authentication credentials are missing.",
+							Remediation: &remediation,
+						}},
+					}, pretty)
+				}
+				if err == nil && state.TokenState == "expiring" {
+					remediation := "Refresh authentication before the credentials expire."
+					return success(definition.path, doctorData{
+						Healthy: true,
+						Checks: []doctorCheck{{
+							Name:        "credentials",
+							Status:      "warn",
+							Message:     "Authentication credentials expire soon.",
+							Remediation: &remediation,
+						}},
+					}, pretty)
+				}
+				if err == nil && state.TokenState == "expired" {
+					remediation := "Re-establish authentication."
+					return success(definition.path, doctorData{
+						Healthy: false,
+						Checks: []doctorCheck{{
+							Name:        "credentials",
+							Status:      "fail",
+							Message:     "Authentication credentials have expired.",
+							Remediation: &remediation,
+						}},
+					}, pretty)
+				}
+				if errors.Is(err, auth.ErrInvalid) {
+					remediation := "Remove the invalid credentials and re-establish authentication."
+					return success(definition.path, doctorData{
+						Healthy: false,
+						Checks: []doctorCheck{{
+							Name:        "credentials",
+							Status:      "fail",
+							Message:     "Authentication credentials are invalid.",
+							Remediation: &remediation,
+						}},
+					}, pretty)
+				}
+				if errors.Is(err, auth.ErrUnavailable) {
+					remediation := "Check local credential file permissions."
+					return success(definition.path, doctorData{
+						Healthy: false,
+						Checks: []doctorCheck{{
+							Name:        "credentials",
+							Status:      "fail",
+							Message:     "Credential storage is unavailable.",
+							Remediation: &remediation,
+						}},
+					}, pretty)
+				}
+				if err != nil || state.TokenState != "healthy" {
+					return internalFailure(definition.path, pretty)
+				}
+				return success(definition.path, doctorData{
+					Healthy: true,
+					Checks: []doctorCheck{{
+						Name:        "credentials",
+						Status:      "pass",
+						Message:     "Authentication credentials are available.",
+						Remediation: nil,
+					}},
+				}, pretty)
+			}
+		}
+	}
+	return failure("unknown", 2, errorBody{
+		Type:      "usage.invalid",
+		Code:      "COMMAND_NOT_FOUND",
+		Message:   "Unknown command.",
+		Retryable: false,
+		Details:   map[string]any{},
+	}, pretty)
+}
+
+func (definition commandDefinition) matches(argv []string) bool {
+	if definition.kind == schemaCommand && len(argv) == 2 {
+		return argv[0] == "schema"
+	}
+	return slices.Equal(argv, definition.invocation)
+}
+
+type schemaCatalog struct {
+	Commands []string `json:"commands"`
+}
+
+func schemaCatalogData() schemaCatalog {
+	paths := make([]string, 0, len(commandCatalog))
+	for _, definition := range commandCatalog {
+		paths = append(paths, definition.path)
+	}
+	slices.Sort(paths)
+	return schemaCatalog{Commands: paths}
+}
+
+type commandSchema struct {
+	Command       string                 `json:"command"`
+	Positionals   []positionalDefinition `json:"positionals"`
+	Flags         []flagDefinition       `json:"flags"`
+	InputSchema   jsonSchema             `json:"inputSchema"`
+	SuccessSchema jsonSchema             `json:"successSchema"`
+	FailureTypes  []string               `json:"failureTypes"`
+	Safety        safetyDefinition       `json:"safety"`
+}
+
+type doctorData struct {
+	Healthy bool          `json:"healthy"`
+	Checks  []doctorCheck `json:"checks"`
+}
+
+type doctorCheck struct {
+	Name        string  `json:"name"`
+	Status      string  `json:"status"`
+	Message     string  `json:"message"`
+	Remediation *string `json:"remediation"`
+}
+
+func findDefinition(path string) (commandDefinition, bool) {
+	for _, definition := range commandCatalog {
+		if definition.path == path {
+			return definition, true
+		}
+	}
+	return commandDefinition{}, false
+}
+
+func projectSchema(definition commandDefinition) commandSchema {
+	return commandSchema{
+		Command:       definition.path,
+		Positionals:   definition.positionals,
+		Flags:         definition.flags,
+		InputSchema:   definition.inputSchema,
+		SuccessSchema: definition.successSchema,
+		FailureTypes:  definition.failureTypes,
+		Safety:        definition.safety,
+	}
+}
+
+func commandName(argv []string) string {
+	filtered := make([]string, 0, len(argv))
+	for _, argument := range argv {
+		if argument != "--pretty" && argument != "--non-interactive" {
+			filtered = append(filtered, argument)
+		}
+	}
+	for _, definition := range commandCatalog {
+		if len(filtered) >= len(definition.invocation) &&
+			slices.Equal(filtered[:len(definition.invocation)], definition.invocation) {
+			return definition.path
+		}
+	}
+	return "unknown"
+}
+
+func repeatedFlagFailure(command, flag string, pretty bool) Result {
+	return failure(command, 2, errorBody{
+		Type:      "input.invalid",
+		Code:      "FLAG_REPEATED",
+		Message:   "A scalar flag cannot be repeated.",
+		Retryable: false,
+		Details:   map[string]any{"flag": flag},
+	}, pretty)
+}
+
+func internalFailure(command string, pretty bool) Result {
+	result := failure(command, 10, errorBody{
+		Type:      "internal.failure",
+		Code:      "LOCAL_OPERATION_FAILED",
+		Message:   "The local operation could not be completed.",
+		Retryable: false,
+		Details:   map[string]any{},
+	}, pretty)
+	result.Stderr = "partiful: local operation failed\n"
+	return result
+}
+
+func credentialInvalidFailure(command string, pretty bool) Result {
+	result := failure(command, 10, errorBody{
+		Type:      "internal.failure",
+		Code:      "CREDENTIALS_INVALID",
+		Message:   "Local credentials are invalid.",
+		Retryable: false,
+		Details:   map[string]any{},
+	}, pretty)
+	result.Stderr = "partiful: local operation failed\n"
+	return result
+}
+
+func credentialUnavailableFailure(command string, pretty bool) Result {
+	result := failure(command, 10, errorBody{
+		Type:      "internal.failure",
+		Code:      "CREDENTIAL_STORE_UNAVAILABLE",
+		Message:   "Local credential storage is unavailable.",
+		Retryable: false,
+		Details:   map[string]any{},
+	}, pretty)
+	result.Stderr = "partiful: local operation failed\n"
+	return result
+}
+
+func success(command string, data any, pretty bool) Result {
+	document := encode(successEnvelope{
+		OK:   true,
+		Data: data,
+		Meta: successMeta{
+			Command:                 command,
+			CLIVersion:              Version,
+			ProductContractRevision: ProductContractRevision,
+			RemoteContractRevision:  RemoteContractRevision,
+			Warnings:                []string{},
+		},
+	}, pretty)
+	return Result{Stdout: document}
+}
+
+type failureEnvelope struct {
+	OK    bool        `json:"ok"`
+	Error errorBody   `json:"error"`
+	Meta  failureMeta `json:"meta"`
+}
+
+type errorBody struct {
+	Type      string         `json:"type"`
+	Code      string         `json:"code"`
+	Message   string         `json:"message"`
+	Retryable bool           `json:"retryable"`
+	Details   map[string]any `json:"details"`
+}
+
+type failureMeta struct {
+	Command                 string `json:"command"`
+	CLIVersion              string `json:"cliVersion"`
+	ProductContractRevision string `json:"productContractRevision"`
+	RemoteContractRevision  string `json:"remoteContractRevision"`
+}
+
+func failure(command string, exitCode int, body errorBody, pretty bool) Result {
+	document := encode(failureEnvelope{
+		OK:    false,
+		Error: body,
+		Meta: failureMeta{
+			Command:                 command,
+			CLIVersion:              Version,
+			ProductContractRevision: ProductContractRevision,
+			RemoteContractRevision:  RemoteContractRevision,
+		},
+	}, pretty)
+	return Result{Stdout: document, ExitCode: exitCode}
+}
+
+func encode(value any, pretty bool) string {
+	var document []byte
+	if pretty {
+		document, _ = json.MarshalIndent(value, "", "  ")
+	} else {
+		document, _ = json.Marshal(value)
+	}
+	return string(document) + "\n"
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -296,11 +296,7 @@ type versionData struct {
 	RemoteContractRevision  string `json:"remoteContractRevision"`
 }
 
-func Execute(_ context.Context, request Request, provided ...Dependencies) Result {
-	var dependencies Dependencies
-	if len(provided) == 1 {
-		dependencies = provided[0]
-	}
+func Execute(_ context.Context, request Request, dependencies Dependencies) Result {
 	argv := make([]string, 0, len(request.Argv))
 	pretty := slices.Contains(request.Argv, "--pretty")
 	seenGlobalFlags := make(map[string]bool)
@@ -385,15 +381,14 @@ func Execute(_ context.Context, request Request, provided ...Dependencies) Resul
 			case doctorCommand:
 				if dependencies.CredentialsPathError != nil {
 					remediation := "Set a usable user configuration directory."
-					return success(definition.path, doctorData{
-						Healthy: false,
-						Checks: []doctorCheck{{
-							Name:        "credentials",
-							Status:      "fail",
-							Message:     "Configuration directory is unavailable.",
-							Remediation: &remediation,
-						}},
-					}, pretty)
+					return credentialsDoctorResult(
+						definition.path,
+						false,
+						"fail",
+						"Configuration directory is unavailable.",
+						&remediation,
+						pretty,
+					)
 				}
 				now := time.Now()
 				if dependencies.Now != nil {
@@ -406,76 +401,70 @@ func Execute(_ context.Context, request Request, provided ...Dependencies) Resul
 				)
 				if err == nil && state.TokenState == "missing" {
 					remediation := "Establish authentication before using commands that require it."
-					return success(definition.path, doctorData{
-						Healthy: false,
-						Checks: []doctorCheck{{
-							Name:        "credentials",
-							Status:      "fail",
-							Message:     "Authentication credentials are missing.",
-							Remediation: &remediation,
-						}},
-					}, pretty)
+					return credentialsDoctorResult(
+						definition.path,
+						false,
+						"fail",
+						"Authentication credentials are missing.",
+						&remediation,
+						pretty,
+					)
 				}
 				if err == nil && state.TokenState == "expiring" {
 					remediation := "Refresh authentication before the credentials expire."
-					return success(definition.path, doctorData{
-						Healthy: true,
-						Checks: []doctorCheck{{
-							Name:        "credentials",
-							Status:      "warn",
-							Message:     "Authentication credentials expire soon.",
-							Remediation: &remediation,
-						}},
-					}, pretty)
+					return credentialsDoctorResult(
+						definition.path,
+						true,
+						"warn",
+						"Authentication credentials expire soon.",
+						&remediation,
+						pretty,
+					)
 				}
 				if err == nil && state.TokenState == "expired" {
 					remediation := "Re-establish authentication."
-					return success(definition.path, doctorData{
-						Healthy: false,
-						Checks: []doctorCheck{{
-							Name:        "credentials",
-							Status:      "fail",
-							Message:     "Authentication credentials have expired.",
-							Remediation: &remediation,
-						}},
-					}, pretty)
+					return credentialsDoctorResult(
+						definition.path,
+						false,
+						"fail",
+						"Authentication credentials have expired.",
+						&remediation,
+						pretty,
+					)
 				}
 				if errors.Is(err, auth.ErrInvalid) {
 					remediation := "Remove the invalid credentials and re-establish authentication."
-					return success(definition.path, doctorData{
-						Healthy: false,
-						Checks: []doctorCheck{{
-							Name:        "credentials",
-							Status:      "fail",
-							Message:     "Authentication credentials are invalid.",
-							Remediation: &remediation,
-						}},
-					}, pretty)
+					return credentialsDoctorResult(
+						definition.path,
+						false,
+						"fail",
+						"Authentication credentials are invalid.",
+						&remediation,
+						pretty,
+					)
 				}
 				if errors.Is(err, auth.ErrUnavailable) {
 					remediation := "Check local credential file permissions."
-					return success(definition.path, doctorData{
-						Healthy: false,
-						Checks: []doctorCheck{{
-							Name:        "credentials",
-							Status:      "fail",
-							Message:     "Credential storage is unavailable.",
-							Remediation: &remediation,
-						}},
-					}, pretty)
+					return credentialsDoctorResult(
+						definition.path,
+						false,
+						"fail",
+						"Credential storage is unavailable.",
+						&remediation,
+						pretty,
+					)
 				}
 				if err != nil || state.TokenState != "healthy" {
 					return internalFailure(definition.path, pretty)
 				}
-				return success(definition.path, doctorData{
-					Healthy: true,
-					Checks: []doctorCheck{{
-						Name:        "credentials",
-						Status:      "pass",
-						Message:     "Authentication credentials are available.",
-						Remediation: nil,
-					}},
-				}, pretty)
+				return credentialsDoctorResult(
+					definition.path,
+					true,
+					"pass",
+					"Authentication credentials are available.",
+					nil,
+					pretty,
+				)
 			}
 		}
 	}
@@ -528,6 +517,25 @@ type doctorCheck struct {
 	Status      string  `json:"status"`
 	Message     string  `json:"message"`
 	Remediation *string `json:"remediation"`
+}
+
+func credentialsDoctorResult(
+	command string,
+	healthy bool,
+	status string,
+	message string,
+	remediation *string,
+	pretty bool,
+) Result {
+	return success(command, doctorData{
+		Healthy: healthy,
+		Checks: []doctorCheck{{
+			Name:        "credentials",
+			Status:      status,
+			Message:     message,
+			Remediation: remediation,
+		}},
+	}, pretty)
 }
 
 func findDefinition(path string) (commandDefinition, bool) {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -29,9 +29,10 @@ type Result struct {
 }
 
 type Dependencies struct {
-	Files           auth.FileSystem
-	CredentialsPath string
-	Now             func() time.Time
+	Files                auth.FileSystem
+	CredentialsPath      string
+	CredentialsPathError error
+	Now                  func() time.Time
 }
 
 type commandKind uint8
@@ -344,6 +345,9 @@ func Execute(_ context.Context, request Request, provided ...Dependencies) Resul
 					Details:   map[string]any{},
 				}, pretty)
 			case authStatusCommand:
+				if dependencies.CredentialsPathError != nil {
+					return configurationDirectoryFailure(definition.path, pretty)
+				}
 				now := time.Now()
 				if dependencies.Now != nil {
 					now = dependencies.Now()
@@ -364,6 +368,9 @@ func Execute(_ context.Context, request Request, provided ...Dependencies) Resul
 				}
 				return success(definition.path, state, pretty)
 			case authLogoutCommand:
+				if dependencies.CredentialsPathError != nil {
+					return configurationDirectoryFailure(definition.path, pretty)
+				}
 				state, err := auth.Logout(
 					dependencies.Files,
 					dependencies.CredentialsPath,
@@ -376,6 +383,18 @@ func Execute(_ context.Context, request Request, provided ...Dependencies) Resul
 				}
 				return success(definition.path, state, pretty)
 			case doctorCommand:
+				if dependencies.CredentialsPathError != nil {
+					remediation := "Set a usable user configuration directory."
+					return success(definition.path, doctorData{
+						Healthy: false,
+						Checks: []doctorCheck{{
+							Name:        "credentials",
+							Status:      "fail",
+							Message:     "Configuration directory is unavailable.",
+							Remediation: &remediation,
+						}},
+					}, pretty)
+				}
 				now := time.Now()
 				if dependencies.Now != nil {
 					now = dependencies.Now()
@@ -460,7 +479,7 @@ func Execute(_ context.Context, request Request, provided ...Dependencies) Resul
 			}
 		}
 	}
-	return failure("unknown", 2, errorBody{
+	return failure(commandName(request.Argv), 2, errorBody{
 		Type:      "usage.invalid",
 		Code:      "COMMAND_NOT_FOUND",
 		Message:   "Unknown command.",
@@ -587,6 +606,18 @@ func credentialUnavailableFailure(command string, pretty bool) Result {
 		Type:      "internal.failure",
 		Code:      "CREDENTIAL_STORE_UNAVAILABLE",
 		Message:   "Local credential storage is unavailable.",
+		Retryable: false,
+		Details:   map[string]any{},
+	}, pretty)
+	result.Stderr = "partiful: local operation failed\n"
+	return result
+}
+
+func configurationDirectoryFailure(command string, pretty bool) Result {
+	result := failure(command, 10, errorBody{
+		Type:      "internal.failure",
+		Code:      "CONFIG_DIRECTORY_UNAVAILABLE",
+		Message:   "Local configuration directory is unavailable.",
 		Retryable: false,
 		Details:   map[string]any{},
 	}, pretty)

--- a/internal/app/execute_test.go
+++ b/internal/app/execute_test.go
@@ -1,0 +1,782 @@
+package app_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KalebCole/partiful-cli/internal/app"
+)
+
+func TestExecuteVersion(t *testing.T) {
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"--version"},
+		Stdin: strings.NewReader(""),
+	})
+
+	const want = `{"ok":true,"data":{"version":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-10.1"},"meta":{"command":"version","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-10.1","warnings":[]}}` + "\n"
+	if result.ExitCode != 0 {
+		t.Fatalf("exit code = %d, want 0", result.ExitCode)
+	}
+	if result.Stdout != want {
+		t.Fatalf("stdout = %q, want %q", result.Stdout, want)
+	}
+	if result.Stderr != "" {
+		t.Fatalf("stderr = %q, want empty", result.Stderr)
+	}
+}
+
+func TestExecuteRejectsUnknownCommand(t *testing.T) {
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"events", "list"},
+		Stdin: strings.NewReader(""),
+	})
+
+	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_NOT_FOUND","message":"Unknown command.","retryable":false,"details":{}},"meta":{"command":"unknown","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-10.1"}}` + "\n"
+	if result.ExitCode != 2 {
+		t.Fatalf("exit code = %d, want 2", result.ExitCode)
+	}
+	if result.Stdout != want {
+		t.Fatalf("stdout = %q, want %q", result.Stdout, want)
+	}
+	if result.Stderr != "" {
+		t.Fatalf("stderr = %q, want empty", result.Stderr)
+	}
+}
+
+func TestExecutePrettyPrintsOneCompleteEnvelope(t *testing.T) {
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"--pretty", "--version"},
+		Stdin: strings.NewReader(""),
+	})
+
+	const want = `{
+  "ok": true,
+  "data": {
+    "version": "1.0.0",
+    "productContractRevision": "2026-08-10.1",
+    "remoteContractRevision": "2026-08-10.1"
+  },
+  "meta": {
+    "command": "version",
+    "cliVersion": "1.0.0",
+    "productContractRevision": "2026-08-10.1",
+    "remoteContractRevision": "2026-08-10.1",
+    "warnings": []
+  }
+}
+`
+	if result.ExitCode != 0 {
+		t.Fatalf("exit code = %d, want 0", result.ExitCode)
+	}
+	if result.Stdout != want {
+		t.Fatalf("stdout = %q, want %q", result.Stdout, want)
+	}
+	if result.Stderr != "" {
+		t.Fatalf("stderr = %q, want empty", result.Stderr)
+	}
+}
+
+func TestExecuteAcceptsNonInteractiveGlobalFlag(t *testing.T) {
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"--version", "--non-interactive"},
+		Stdin: strings.NewReader(""),
+	})
+
+	const want = `{"ok":true,"data":{"version":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-10.1"},"meta":{"command":"version","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-10.1","warnings":[]}}` + "\n"
+	if result.ExitCode != 0 {
+		t.Fatalf("exit code = %d, want 0", result.ExitCode)
+	}
+	if result.Stdout != want {
+		t.Fatalf("stdout = %q, want %q", result.Stdout, want)
+	}
+	if result.Stderr != "" {
+		t.Fatalf("stderr = %q, want empty", result.Stderr)
+	}
+}
+
+func TestExecuteRejectsRepeatedScalarFlag(t *testing.T) {
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"--pretty", "--version", "--pretty"},
+		Stdin: strings.NewReader(""),
+	})
+
+	const want = `{
+  "ok": false,
+  "error": {
+    "type": "input.invalid",
+    "code": "FLAG_REPEATED",
+    "message": "A scalar flag cannot be repeated.",
+    "retryable": false,
+    "details": {
+      "flag": "--pretty"
+    }
+  },
+  "meta": {
+    "command": "version",
+    "cliVersion": "1.0.0",
+    "productContractRevision": "2026-08-10.1",
+    "remoteContractRevision": "2026-08-10.1"
+  }
+}
+`
+	if result.ExitCode != 2 {
+		t.Fatalf("exit code = %d, want 2", result.ExitCode)
+	}
+	if result.Stdout != want {
+		t.Fatalf("stdout = %q, want %q", result.Stdout, want)
+	}
+	if result.Stderr != "" {
+		t.Fatalf("stderr = %q, want empty", result.Stderr)
+	}
+}
+
+func TestExecuteSchemaListsOnlyCompletedCatalog(t *testing.T) {
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"schema"},
+		Stdin: strings.NewReader(""),
+	})
+
+	const want = `{"ok":true,"data":{"commands":["auth.logout","auth.status","doctor","schema","version"]},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-10.1","warnings":[]}}` + "\n"
+	if result.ExitCode != 0 {
+		t.Fatalf("exit code = %d, want 0", result.ExitCode)
+	}
+	if result.Stdout != want {
+		t.Fatalf("stdout = %q, want %q", result.Stdout, want)
+	}
+	if result.Stderr != "" {
+		t.Fatalf("stderr = %q, want empty", result.Stderr)
+	}
+}
+
+func TestExecuteSchemaProjectsExecutableDefinition(t *testing.T) {
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"schema", "auth.status"},
+		Stdin: strings.NewReader(""),
+	})
+
+	const want = `{"ok":true,"data":{"command":"auth.status","positionals":[],"flags":[],"inputSchema":{"type":"object","additionalProperties":false},"successSchema":{"type":"object","additionalProperties":false,"required":["authenticated","tokenState","expiresAt"],"properties":{"authenticated":{"type":"boolean"},"expiresAt":{"type":["string","null"],"format":"date-time"},"tokenState":{"type":"string","enum":["healthy","expiring","expired","missing"]}}},"failureTypes":["internal.failure"],"safety":{"kind":"read-only","planRequired":false,"confirmationRequired":false}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-10.1","warnings":[]}}` + "\n"
+	if result.ExitCode != 0 {
+		t.Fatalf("exit code = %d, want 0", result.ExitCode)
+	}
+	if result.Stdout != want {
+		t.Fatalf("stdout = %q, want %q", result.Stdout, want)
+	}
+	if result.Stderr != "" {
+		t.Fatalf("stderr = %q, want empty", result.Stderr)
+	}
+}
+
+func TestExecuteRejectsUnknownSchemaPathWithoutEchoingInput(t *testing.T) {
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"schema", "secret-private-value"},
+		Stdin: strings.NewReader(""),
+	})
+
+	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_SCHEMA_NOT_FOUND","message":"No completed command has that schema path.","retryable":false,"details":{}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-10.1"}}` + "\n"
+	if result.ExitCode != 2 {
+		t.Fatalf("exit code = %d, want 2", result.ExitCode)
+	}
+	if result.Stdout != want {
+		t.Fatalf("stdout = %q, want %q", result.Stdout, want)
+	}
+	if result.Stderr != "" {
+		t.Fatalf("stderr = %q, want empty", result.Stderr)
+	}
+	if strings.Contains(result.Stdout+result.Stderr, "secret-private-value") {
+		t.Fatal("output echoed untrusted command input")
+	}
+}
+
+func TestExecuteAuthStatusWhenCredentialsAreMissing(t *testing.T) {
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"auth", "status"},
+		Stdin: strings.NewReader(""),
+	}, app.Dependencies{
+		Files: fakeFilesystem{
+			readFile: func(string) ([]byte, error) {
+				return nil, fs.ErrNotExist
+			},
+		},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+	})
+
+	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"missing","expiresAt":null},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-10.1","warnings":[]}}` + "\n"
+	if result.ExitCode != 0 {
+		t.Fatalf("exit code = %d, want 0", result.ExitCode)
+	}
+	if result.Stdout != want {
+		t.Fatalf("stdout = %q, want %q", result.Stdout, want)
+	}
+	if result.Stderr != "" {
+		t.Fatalf("stderr = %q, want empty", result.Stderr)
+	}
+}
+
+type fakeFilesystem struct {
+	readFile func(string) ([]byte, error)
+	remove   func(string) error
+}
+
+func (filesystem fakeFilesystem) ReadFile(path string) ([]byte, error) {
+	return filesystem.readFile(path)
+}
+
+func (filesystem fakeFilesystem) Remove(path string) error {
+	if filesystem.remove != nil {
+		return filesystem.remove(path)
+	}
+	return nil
+}
+
+func TestExecuteAuthStatusRedactsHealthyCredentials(t *testing.T) {
+	const credentials = `{"accessToken":"secret-token-value","refreshToken":"secret-refresh-value","userId":"private-user-value","expiresAt":"2026-08-11T02:00:00Z"}`
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"auth", "status"},
+		Stdin: strings.NewReader(""),
+	}, app.Dependencies{
+		Files: fakeFilesystem{
+			readFile: func(string) ([]byte, error) {
+				return []byte(credentials), nil
+			},
+		},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+	})
+
+	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T02:00:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-10.1","warnings":[]}}` + "\n"
+	if result.ExitCode != 0 {
+		t.Fatalf("exit code = %d, want 0", result.ExitCode)
+	}
+	if result.Stdout != want {
+		t.Fatalf("stdout = %q, want %q", result.Stdout, want)
+	}
+	if result.Stderr != "" {
+		t.Fatalf("stderr = %q, want empty", result.Stderr)
+	}
+	for _, privateValue := range []string{"secret-token-value", "secret-refresh-value", "private-user-value"} {
+		if strings.Contains(result.Stdout+result.Stderr, privateValue) {
+			t.Fatalf("output contains private credential value %q", privateValue)
+		}
+	}
+}
+
+func TestExecuteAuthStatusReportsExpiringToken(t *testing.T) {
+	const credentials = `{"accessToken":"secret-token-value","expiresAt":"2026-08-11T00:04:00Z"}`
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"auth", "status"},
+		Stdin: strings.NewReader(""),
+	}, app.Dependencies{
+		Files: fakeFilesystem{
+			readFile: func(string) ([]byte, error) {
+				return []byte(credentials), nil
+			},
+		},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+	})
+
+	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"expiring","expiresAt":"2026-08-11T00:04:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-10.1","warnings":[]}}` + "\n"
+	if result.ExitCode != 0 {
+		t.Fatalf("exit code = %d, want 0", result.ExitCode)
+	}
+	if result.Stdout != want {
+		t.Fatalf("stdout = %q, want %q", result.Stdout, want)
+	}
+	if result.Stderr != "" {
+		t.Fatalf("stderr = %q, want empty", result.Stderr)
+	}
+}
+
+func TestExecuteAuthStatusReportsExpiredToken(t *testing.T) {
+	const credentials = `{"accessToken":"secret-token-value","expiresAt":"2026-08-10T23:59:00Z"}`
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"auth", "status"},
+		Stdin: strings.NewReader(""),
+	}, app.Dependencies{
+		Files: fakeFilesystem{
+			readFile: func(string) ([]byte, error) {
+				return []byte(credentials), nil
+			},
+		},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+	})
+
+	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"expired","expiresAt":"2026-08-10T23:59:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-10.1","warnings":[]}}` + "\n"
+	if result.ExitCode != 0 {
+		t.Fatalf("exit code = %d, want 0", result.ExitCode)
+	}
+	if result.Stdout != want {
+		t.Fatalf("stdout = %q, want %q", result.Stdout, want)
+	}
+	if result.Stderr != "" {
+		t.Fatalf("stderr = %q, want empty", result.Stderr)
+	}
+}
+
+func TestExecuteAuthStatusFailureDoesNotRevealCredentialContents(t *testing.T) {
+	const privateContents = "secret-token-content private-user-identifier"
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"auth", "status"},
+		Stdin: strings.NewReader(""),
+	}, app.Dependencies{
+		Files: fakeFilesystem{
+			readFile: func(string) ([]byte, error) {
+				return []byte(privateContents), nil
+			},
+		},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+	})
+
+	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIALS_INVALID","message":"Local credentials are invalid.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-10.1"}}` + "\n"
+	const wantStderr = "partiful: local operation failed\n"
+	if result.ExitCode != 10 {
+		t.Fatalf("exit code = %d, want 10", result.ExitCode)
+	}
+	if result.Stdout != wantStdout {
+		t.Fatalf("stdout = %q, want %q", result.Stdout, wantStdout)
+	}
+	if result.Stderr != wantStderr {
+		t.Fatalf("stderr = %q, want %q", result.Stderr, wantStderr)
+	}
+	if strings.Contains(result.Stdout+result.Stderr, privateContents) {
+		t.Fatal("failure output revealed credential file contents")
+	}
+}
+
+func TestExecuteAuthLogoutAtomicallyRemovesCredentials(t *testing.T) {
+	const credentialsPath = "/config/partiful/credentials.json"
+	files := &memoryFilesystem{
+		files: map[string][]byte{
+			credentialsPath: []byte(`{"accessToken":"secret-token-value","expiresAt":"2026-08-11T02:00:00Z"}`),
+		},
+	}
+	dependencies := app.Dependencies{
+		Files:           files,
+		CredentialsPath: credentialsPath,
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+	}
+
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"auth", "logout"},
+		Stdin: strings.NewReader(""),
+	}, dependencies)
+
+	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"missing","expiresAt":null},"meta":{"command":"auth.logout","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-10.1","warnings":[]}}` + "\n"
+	if result.ExitCode != 0 {
+		t.Fatalf("exit code = %d, want 0", result.ExitCode)
+	}
+	if result.Stdout != want {
+		t.Fatalf("stdout = %q, want %q", result.Stdout, want)
+	}
+	if result.Stderr != "" {
+		t.Fatalf("stderr = %q, want empty", result.Stderr)
+	}
+
+	status := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"auth", "status"},
+		Stdin: strings.NewReader(""),
+	}, dependencies)
+	if !strings.Contains(status.Stdout, `"authenticated":false,"tokenState":"missing","expiresAt":null`) {
+		t.Fatalf("status after logout = %q, want missing credentials", status.Stdout)
+	}
+}
+
+type memoryFilesystem struct {
+	files map[string][]byte
+}
+
+func (filesystem *memoryFilesystem) ReadFile(path string) ([]byte, error) {
+	document, ok := filesystem.files[path]
+	if !ok {
+		return nil, fs.ErrNotExist
+	}
+	return append([]byte(nil), document...), nil
+}
+
+func (filesystem *memoryFilesystem) Remove(path string) error {
+	if _, ok := filesystem.files[path]; !ok {
+		return fs.ErrNotExist
+	}
+	delete(filesystem.files, path)
+	return nil
+}
+
+func TestExecuteAuthLogoutFailureLeavesCredentialsAvailableAndRedactsError(t *testing.T) {
+	const privateValue = "private-user-identifier"
+	const credentials = `{"accessToken":"secret-token-value","expiresAt":"2026-08-11T02:00:00Z"}`
+	files := fakeFilesystem{
+		readFile: func(string) ([]byte, error) {
+			return []byte(credentials), nil
+		},
+		remove: func(string) error {
+			return errors.New("filesystem failure involving " + privateValue)
+		},
+	}
+	dependencies := app.Dependencies{
+		Files:           files,
+		CredentialsPath: "/config/partiful/credentials.json",
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+	}
+
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"auth", "logout"},
+		Stdin: strings.NewReader(""),
+	}, dependencies)
+
+	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIAL_STORE_UNAVAILABLE","message":"Local credential storage is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.logout","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-10.1"}}` + "\n"
+	if result.ExitCode != 10 {
+		t.Fatalf("exit code = %d, want 10", result.ExitCode)
+	}
+	if result.Stdout != wantStdout {
+		t.Fatalf("stdout = %q, want %q", result.Stdout, wantStdout)
+	}
+	if strings.Contains(result.Stdout+result.Stderr, privateValue) {
+		t.Fatal("logout failure output revealed a private identifier")
+	}
+
+	status := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"auth", "status"},
+		Stdin: strings.NewReader(""),
+	}, dependencies)
+	if !strings.Contains(status.Stdout, `"authenticated":true,"tokenState":"healthy"`) {
+		t.Fatalf("status after failed logout = %q, want credentials preserved", status.Stdout)
+	}
+}
+
+func TestExecuteDoctorReportsHealthyCredentialsWithoutPrivateData(t *testing.T) {
+	const credentials = `{"accessToken":"secret-token-value","userId":"private-user-identifier","expiresAt":"2026-08-11T02:00:00Z"}`
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"doctor"},
+		Stdin: strings.NewReader(""),
+	}, app.Dependencies{
+		Files: fakeFilesystem{
+			readFile: func(string) ([]byte, error) {
+				return []byte(credentials), nil
+			},
+		},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+	})
+
+	const want = `{"ok":true,"data":{"healthy":true,"checks":[{"name":"credentials","status":"pass","message":"Authentication credentials are available.","remediation":null}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-10.1","warnings":[]}}` + "\n"
+	if result.ExitCode != 0 {
+		t.Fatalf("exit code = %d, want 0", result.ExitCode)
+	}
+	if result.Stdout != want {
+		t.Fatalf("stdout = %q, want %q", result.Stdout, want)
+	}
+	if result.Stderr != "" {
+		t.Fatalf("stderr = %q, want empty", result.Stderr)
+	}
+	for _, privateValue := range []string{"secret-token-value", "private-user-identifier"} {
+		if strings.Contains(result.Stdout+result.Stderr, privateValue) {
+			t.Fatalf("doctor output contains private value %q", privateValue)
+		}
+	}
+}
+
+func TestExecuteDoctorReportsMissingCredentialsAsARedactedCheck(t *testing.T) {
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"doctor"},
+		Stdin: strings.NewReader(""),
+	}, app.Dependencies{
+		Files: fakeFilesystem{
+			readFile: func(string) ([]byte, error) {
+				return nil, fs.ErrNotExist
+			},
+		},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+	})
+
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials are missing.","remediation":"Establish authentication before using commands that require it."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-10.1","warnings":[]}}` + "\n"
+	if result.ExitCode != 0 {
+		t.Fatalf("exit code = %d, want 0", result.ExitCode)
+	}
+	if result.Stdout != want {
+		t.Fatalf("stdout = %q, want %q", result.Stdout, want)
+	}
+	if result.Stderr != "" {
+		t.Fatalf("stderr = %q, want empty", result.Stderr)
+	}
+}
+
+func TestExecuteDoctorWarnsWhenCredentialsExpireSoon(t *testing.T) {
+	const credentials = `{"accessToken":"secret-token-value","expiresAt":"2026-08-11T00:04:00Z"}`
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"doctor"},
+		Stdin: strings.NewReader(""),
+	}, app.Dependencies{
+		Files: fakeFilesystem{
+			readFile: func(string) ([]byte, error) {
+				return []byte(credentials), nil
+			},
+		},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+	})
+
+	const want = `{"ok":true,"data":{"healthy":true,"checks":[{"name":"credentials","status":"warn","message":"Authentication credentials expire soon.","remediation":"Refresh authentication before the credentials expire."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-10.1","warnings":[]}}` + "\n"
+	if result.ExitCode != 0 {
+		t.Fatalf("exit code = %d, want 0", result.ExitCode)
+	}
+	if result.Stdout != want {
+		t.Fatalf("stdout = %q, want %q", result.Stdout, want)
+	}
+	if result.Stderr != "" {
+		t.Fatalf("stderr = %q, want empty", result.Stderr)
+	}
+}
+
+func TestExecuteDoctorFailsExpiredCredentialsCheck(t *testing.T) {
+	const credentials = `{"accessToken":"secret-token-value","expiresAt":"2026-08-10T23:59:00Z"}`
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"doctor"},
+		Stdin: strings.NewReader(""),
+	}, app.Dependencies{
+		Files: fakeFilesystem{
+			readFile: func(string) ([]byte, error) {
+				return []byte(credentials), nil
+			},
+		},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+	})
+
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials have expired.","remediation":"Re-establish authentication."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-10.1","warnings":[]}}` + "\n"
+	if result.ExitCode != 0 {
+		t.Fatalf("exit code = %d, want 0", result.ExitCode)
+	}
+	if result.Stdout != want {
+		t.Fatalf("stdout = %q, want %q", result.Stdout, want)
+	}
+	if result.Stderr != "" {
+		t.Fatalf("stderr = %q, want empty", result.Stderr)
+	}
+}
+
+func TestExecuteDoctorRedactsInvalidCredentialFile(t *testing.T) {
+	const privateContents = "secret-token-content private-user-identifier"
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"doctor"},
+		Stdin: strings.NewReader(""),
+	}, app.Dependencies{
+		Files: fakeFilesystem{
+			readFile: func(string) ([]byte, error) {
+				return []byte(privateContents), nil
+			},
+		},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+	})
+
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials are invalid.","remediation":"Remove the invalid credentials and re-establish authentication."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-10.1","warnings":[]}}` + "\n"
+	if result.ExitCode != 0 {
+		t.Fatalf("exit code = %d, want 0", result.ExitCode)
+	}
+	if result.Stdout != want {
+		t.Fatalf("stdout = %q, want %q", result.Stdout, want)
+	}
+	if result.Stderr != "" {
+		t.Fatalf("stderr = %q, want empty", result.Stderr)
+	}
+	if strings.Contains(result.Stdout+result.Stderr, privateContents) {
+		t.Fatal("doctor output revealed credential file contents")
+	}
+}
+
+func TestExecuteDoctorRedactsCredentialStorageFailure(t *testing.T) {
+	const privateError = "permission failure for private-user-identifier"
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"doctor"},
+		Stdin: strings.NewReader(""),
+	}, app.Dependencies{
+		Files: fakeFilesystem{
+			readFile: func(string) ([]byte, error) {
+				return nil, errors.New(privateError)
+			},
+		},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+	})
+
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Credential storage is unavailable.","remediation":"Check local credential file permissions."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-10.1","warnings":[]}}` + "\n"
+	if result.ExitCode != 0 {
+		t.Fatalf("exit code = %d, want 0", result.ExitCode)
+	}
+	if result.Stdout != want {
+		t.Fatalf("stdout = %q, want %q", result.Stdout, want)
+	}
+	if result.Stderr != "" {
+		t.Fatalf("stderr = %q, want empty", result.Stderr)
+	}
+	if strings.Contains(result.Stdout+result.Stderr, privateError) {
+		t.Fatal("doctor output revealed filesystem error contents")
+	}
+}
+
+func TestExecuteSchemaDescribesBothDiscoveryResultShapes(t *testing.T) {
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"schema", "schema"},
+		Stdin: strings.NewReader(""),
+	})
+	if result.ExitCode != 0 {
+		t.Fatalf("exit code = %d, want 0", result.ExitCode)
+	}
+
+	var envelope struct {
+		Data struct {
+			SuccessSchema any `json:"successSchema"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(result.Stdout), &envelope); err != nil {
+		t.Fatalf("decode stdout: %v", err)
+	}
+
+	const expectedLiteral = `{
+		"type": "object",
+		"oneOf": [
+			{
+				"type": "object",
+				"additionalProperties": false,
+				"required": ["commands"],
+				"properties": {
+					"commands": {"type": "array", "items": {"type": "string"}}
+				}
+			},
+			{
+				"type": "object",
+				"additionalProperties": false,
+				"required": ["command", "positionals", "flags", "inputSchema", "successSchema", "failureTypes", "safety"],
+				"properties": {
+					"command": {"type": "string"},
+					"positionals": {
+						"type": "array",
+						"items": {
+							"type": "object",
+							"additionalProperties": false,
+							"required": ["name", "required", "description"],
+							"properties": {
+								"name": {"type": "string"},
+								"required": {"type": "boolean"},
+								"description": {"type": "string"}
+							}
+						}
+					},
+					"flags": {
+						"type": "array",
+						"items": {
+							"type": "object",
+							"additionalProperties": false,
+							"required": ["name", "required", "description"],
+							"properties": {
+								"name": {"type": "string"},
+								"required": {"type": "boolean"},
+								"description": {"type": "string"}
+							}
+						}
+					},
+					"inputSchema": {"type": "object"},
+					"successSchema": {"type": "object"},
+					"failureTypes": {"type": "array", "items": {"type": "string"}},
+					"safety": {
+						"type": "object",
+						"additionalProperties": false,
+						"required": ["kind", "planRequired", "confirmationRequired"],
+						"properties": {
+							"kind": {"type": "string", "enum": ["read-only", "local-mutation"]},
+							"planRequired": {"type": "boolean"},
+							"confirmationRequired": {"type": "boolean"}
+						}
+					}
+				}
+			}
+		]
+	}`
+	var expected any
+	if err := json.Unmarshal([]byte(expectedLiteral), &expected); err != nil {
+		t.Fatalf("decode expected schema: %v", err)
+	}
+	if !reflect.DeepEqual(envelope.Data.SuccessSchema, expected) {
+		t.Fatalf("success schema = %#v, want %#v", envelope.Data.SuccessSchema, expected)
+	}
+}
+
+func TestExecuteUsesDefinitionForFlagFailureCommandMetadata(t *testing.T) {
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"auth", "status", "--non-interactive", "--non-interactive"},
+		Stdin: strings.NewReader(""),
+	})
+
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"FLAG_REPEATED","message":"A scalar flag cannot be repeated.","retryable":false,"details":{"flag":"--non-interactive"}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-10.1"}}` + "\n"
+	if result.ExitCode != 2 {
+		t.Fatalf("exit code = %d, want 2", result.ExitCode)
+	}
+	if result.Stdout != want {
+		t.Fatalf("stdout = %q, want %q", result.Stdout, want)
+	}
+	if result.Stderr != "" {
+		t.Fatalf("stderr = %q, want empty", result.Stderr)
+	}
+}
+
+func TestExecutePrettyAppliesWhenItFollowsInvalidGlobalFlag(t *testing.T) {
+	result := app.Execute(context.Background(), app.Request{
+		Argv: []string{
+			"auth",
+			"status",
+			"--non-interactive",
+			"--non-interactive",
+			"--pretty",
+		},
+		Stdin: strings.NewReader(""),
+	})
+
+	if result.ExitCode != 2 {
+		t.Fatalf("exit code = %d, want 2", result.ExitCode)
+	}
+	if !strings.HasPrefix(result.Stdout, "{\n  \"ok\": false,") {
+		t.Fatalf("stdout = %q, want indented failure envelope", result.Stdout)
+	}
+	if !strings.Contains(result.Stdout, `"command": "auth.status"`) {
+		t.Fatalf("stdout = %q, want command auth.status", result.Stdout)
+	}
+	if result.Stderr != "" {
+		t.Fatalf("stderr = %q, want empty", result.Stderr)
+	}
+}

--- a/internal/app/execute_test.go
+++ b/internal/app/execute_test.go
@@ -17,7 +17,7 @@ func TestExecuteVersion(t *testing.T) {
 	result := app.Execute(context.Background(), app.Request{
 		Argv:  []string{"--version"},
 		Stdin: strings.NewReader(""),
-	})
+	}, app.Dependencies{})
 
 	const want = `{"ok":true,"data":{"version":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-10.1"},"meta":{"command":"version","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-10.1","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
@@ -35,7 +35,7 @@ func TestExecuteRejectsUnknownCommand(t *testing.T) {
 	result := app.Execute(context.Background(), app.Request{
 		Argv:  []string{"events", "list"},
 		Stdin: strings.NewReader(""),
-	})
+	}, app.Dependencies{})
 
 	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_NOT_FOUND","message":"Unknown command.","retryable":false,"details":{}},"meta":{"command":"unknown","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-10.1"}}` + "\n"
 	if result.ExitCode != 2 {
@@ -53,7 +53,7 @@ func TestExecutePrettyPrintsOneCompleteEnvelope(t *testing.T) {
 	result := app.Execute(context.Background(), app.Request{
 		Argv:  []string{"--pretty", "--version"},
 		Stdin: strings.NewReader(""),
-	})
+	}, app.Dependencies{})
 
 	const want = `{
   "ok": true,
@@ -86,7 +86,7 @@ func TestExecuteAcceptsNonInteractiveGlobalFlag(t *testing.T) {
 	result := app.Execute(context.Background(), app.Request{
 		Argv:  []string{"--version", "--non-interactive"},
 		Stdin: strings.NewReader(""),
-	})
+	}, app.Dependencies{})
 
 	const want = `{"ok":true,"data":{"version":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-10.1"},"meta":{"command":"version","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-10.1","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
@@ -104,7 +104,7 @@ func TestExecuteRejectsRepeatedScalarFlag(t *testing.T) {
 	result := app.Execute(context.Background(), app.Request{
 		Argv:  []string{"--pretty", "--version", "--pretty"},
 		Stdin: strings.NewReader(""),
-	})
+	}, app.Dependencies{})
 
 	const want = `{
   "ok": false,
@@ -140,7 +140,7 @@ func TestExecuteSchemaListsOnlyCompletedCatalog(t *testing.T) {
 	result := app.Execute(context.Background(), app.Request{
 		Argv:  []string{"schema"},
 		Stdin: strings.NewReader(""),
-	})
+	}, app.Dependencies{})
 
 	const want = `{"ok":true,"data":{"commands":["auth.logout","auth.status","doctor","schema","version"]},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-10.1","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
@@ -158,7 +158,7 @@ func TestExecuteSchemaProjectsExecutableDefinition(t *testing.T) {
 	result := app.Execute(context.Background(), app.Request{
 		Argv:  []string{"schema", "auth.status"},
 		Stdin: strings.NewReader(""),
-	})
+	}, app.Dependencies{})
 
 	const want = `{"ok":true,"data":{"command":"auth.status","positionals":[],"flags":[],"inputSchema":{"type":"object","additionalProperties":false},"successSchema":{"type":"object","additionalProperties":false,"required":["authenticated","tokenState","expiresAt"],"properties":{"authenticated":{"type":"boolean"},"expiresAt":{"type":["string","null"],"format":"date-time"},"tokenState":{"type":"string","enum":["healthy","expiring","expired","missing"]}}},"failureTypes":["internal.failure"],"safety":{"kind":"read-only","planRequired":false,"confirmationRequired":false}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-10.1","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
@@ -176,7 +176,7 @@ func TestExecuteRejectsUnknownSchemaPathWithoutEchoingInput(t *testing.T) {
 	result := app.Execute(context.Background(), app.Request{
 		Argv:  []string{"schema", "secret-private-value"},
 		Stdin: strings.NewReader(""),
-	})
+	}, app.Dependencies{})
 
 	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_SCHEMA_NOT_FOUND","message":"No completed command has that schema path.","retryable":false,"details":{}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-10.1"}}` + "\n"
 	if result.ExitCode != 2 {
@@ -654,7 +654,7 @@ func TestExecuteSchemaDescribesBothDiscoveryResultShapes(t *testing.T) {
 	result := app.Execute(context.Background(), app.Request{
 		Argv:  []string{"schema", "schema"},
 		Stdin: strings.NewReader(""),
-	})
+	}, app.Dependencies{})
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -741,7 +741,7 @@ func TestExecuteUsesDefinitionForFlagFailureCommandMetadata(t *testing.T) {
 	result := app.Execute(context.Background(), app.Request{
 		Argv:  []string{"auth", "status", "--non-interactive", "--non-interactive"},
 		Stdin: strings.NewReader(""),
-	})
+	}, app.Dependencies{})
 
 	const want = `{"ok":false,"error":{"type":"input.invalid","code":"FLAG_REPEATED","message":"A scalar flag cannot be repeated.","retryable":false,"details":{"flag":"--non-interactive"}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-10.1"}}` + "\n"
 	if result.ExitCode != 2 {
@@ -765,7 +765,7 @@ func TestExecutePrettyAppliesWhenItFollowsInvalidGlobalFlag(t *testing.T) {
 			"--pretty",
 		},
 		Stdin: strings.NewReader(""),
-	})
+	}, app.Dependencies{})
 
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
@@ -785,7 +785,7 @@ func TestExecuteUsesKnownCommandMetadataForInvalidArity(t *testing.T) {
 	result := app.Execute(context.Background(), app.Request{
 		Argv:  []string{"schema", "auth.status", "extra-private-value"},
 		Stdin: strings.NewReader(""),
-	})
+	}, app.Dependencies{})
 
 	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_NOT_FOUND","message":"Unknown command.","retryable":false,"details":{}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-10.1"}}` + "\n"
 	if result.ExitCode != 2 {

--- a/internal/app/execute_test.go
+++ b/internal/app/execute_test.go
@@ -317,7 +317,7 @@ func TestExecuteAuthStatusReportsExpiredToken(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"expired","expiresAt":"2026-08-10T23:59:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-10.1","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"expired","expiresAt":"2026-08-10T23:59:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-10.1","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -778,5 +778,76 @@ func TestExecutePrettyAppliesWhenItFollowsInvalidGlobalFlag(t *testing.T) {
 	}
 	if result.Stderr != "" {
 		t.Fatalf("stderr = %q, want empty", result.Stderr)
+	}
+}
+
+func TestExecuteUsesKnownCommandMetadataForInvalidArity(t *testing.T) {
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"schema", "auth.status", "extra-private-value"},
+		Stdin: strings.NewReader(""),
+	})
+
+	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_NOT_FOUND","message":"Unknown command.","retryable":false,"details":{}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-10.1"}}` + "\n"
+	if result.ExitCode != 2 {
+		t.Fatalf("exit code = %d, want 2", result.ExitCode)
+	}
+	if result.Stdout != want {
+		t.Fatalf("stdout = %q, want %q", result.Stdout, want)
+	}
+	if strings.Contains(result.Stdout+result.Stderr, "extra-private-value") {
+		t.Fatal("invalid-arity output echoed untrusted input")
+	}
+}
+
+func TestExecuteAuthStatusReportsConfigurationDirectoryFailure(t *testing.T) {
+	const privateError = "configuration error containing private-user-identifier"
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"auth", "status"},
+		Stdin: strings.NewReader(""),
+	}, app.Dependencies{
+		Files:                fakeFilesystem{},
+		CredentialsPathError: errors.New(privateError),
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+	})
+
+	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CONFIG_DIRECTORY_UNAVAILABLE","message":"Local configuration directory is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-10.1"}}` + "\n"
+	if result.ExitCode != 10 {
+		t.Fatalf("exit code = %d, want 10", result.ExitCode)
+	}
+	if result.Stdout != wantStdout {
+		t.Fatalf("stdout = %q, want %q", result.Stdout, wantStdout)
+	}
+	if strings.Contains(result.Stdout+result.Stderr, privateError) {
+		t.Fatal("configuration failure output revealed private error contents")
+	}
+}
+
+func TestExecuteDoctorDiagnosesConfigurationDirectoryFailure(t *testing.T) {
+	const privateError = "configuration error containing private-user-identifier"
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"doctor"},
+		Stdin: strings.NewReader(""),
+	}, app.Dependencies{
+		Files:                fakeFilesystem{},
+		CredentialsPathError: errors.New(privateError),
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+	})
+
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Configuration directory is unavailable.","remediation":"Set a usable user configuration directory."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-10.1","warnings":[]}}` + "\n"
+	if result.ExitCode != 0 {
+		t.Fatalf("exit code = %d, want 0", result.ExitCode)
+	}
+	if result.Stdout != want {
+		t.Fatalf("stdout = %q, want %q", result.Stdout, want)
+	}
+	if result.Stderr != "" {
+		t.Fatalf("stderr = %q, want empty", result.Stderr)
+	}
+	if strings.Contains(result.Stdout+result.Stderr, privateError) {
+		t.Fatal("doctor output revealed configuration error contents")
 	}
 }

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -1,0 +1,92 @@
+package auth
+
+import (
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"time"
+)
+
+var (
+	ErrNotConfigured = errors.New("credential storage is not configured")
+	ErrUnavailable   = errors.New("credential storage is unavailable")
+	ErrInvalid       = errors.New("credential record is invalid")
+)
+
+type FileSystem interface {
+	ReadFile(string) ([]byte, error)
+	Remove(string) error
+}
+
+type State struct {
+	Authenticated bool       `json:"authenticated"`
+	TokenState    string     `json:"tokenState"`
+	ExpiresAt     *time.Time `json:"expiresAt"`
+}
+
+type credentialRecord struct {
+	AccessToken string    `json:"accessToken"`
+	ExpiresAt   time.Time `json:"expiresAt"`
+}
+
+func Status(files FileSystem, path string, now time.Time) (State, error) {
+	if files == nil || path == "" {
+		return State{}, ErrNotConfigured
+	}
+	document, err := files.ReadFile(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return State{
+			Authenticated: false,
+			TokenState:    "missing",
+			ExpiresAt:     nil,
+		}, nil
+	}
+	if err != nil {
+		return State{}, ErrUnavailable
+	}
+
+	var credentials credentialRecord
+	if err := json.Unmarshal(document, &credentials); err != nil ||
+		credentials.AccessToken == "" ||
+		credentials.ExpiresAt.IsZero() {
+		return State{}, ErrInvalid
+	}
+	if credentials.ExpiresAt.After(now.Add(5 * time.Minute)) {
+		expiresAt := credentials.ExpiresAt.UTC()
+		return State{
+			Authenticated: true,
+			TokenState:    "healthy",
+			ExpiresAt:     &expiresAt,
+		}, nil
+	}
+
+	if credentials.ExpiresAt.After(now) {
+		expiresAt := credentials.ExpiresAt.UTC()
+		return State{
+			Authenticated: true,
+			TokenState:    "expiring",
+			ExpiresAt:     &expiresAt,
+		}, nil
+	}
+	expiresAt := credentials.ExpiresAt.UTC()
+	return State{
+		Authenticated: true,
+		TokenState:    "expired",
+		ExpiresAt:     &expiresAt,
+	}, nil
+}
+
+func Logout(files FileSystem, path string) (State, error) {
+	if files == nil || path == "" {
+		return State{}, ErrNotConfigured
+	}
+	err := files.Remove(path)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return State{}, ErrUnavailable
+	}
+	return State{
+		Authenticated: false,
+		TokenState:    "missing",
+		ExpiresAt:     nil,
+	}, nil
+}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -70,7 +70,7 @@ func Status(files FileSystem, path string, now time.Time) (State, error) {
 	}
 	expiresAt := credentials.ExpiresAt.UTC()
 	return State{
-		Authenticated: true,
+		Authenticated: false,
 		TokenState:    "expired",
 		ExpiresAt:     &expiresAt,
 	}, nil

--- a/internal/auth/os_files.go
+++ b/internal/auth/os_files.go
@@ -1,0 +1,24 @@
+package auth
+
+import (
+	"os"
+	"path/filepath"
+)
+
+type OSFileSystem struct{}
+
+func (OSFileSystem) ReadFile(path string) ([]byte, error) {
+	return os.ReadFile(path)
+}
+
+func (OSFileSystem) Remove(path string) error {
+	return os.Remove(path)
+}
+
+func DefaultCredentialsPath() (string, error) {
+	configDirectory, err := os.UserConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(configDirectory, "partiful", "credentials.json"), nil
+}


### PR DESCRIPTION
## Summary
- add the greenfield Go module and composition-only `cmd/partiful` executable
- expose the `app.Execute` seam with a typed S0 command catalog, schema projection, and complete JSON envelopes
- implement local auth status, atomic logout, and redacted doctor diagnostics without remote calls

## Validation
- `go test ./...`
- `go vet ./...`
- `npm run typecheck`
- `npm test -- tests/remote-api-contract.test.js` (14 passed)
- `TZ=America/Los_Angeles npm test` (335 passed, 6 skipped)
- `scripts/pii-guard.sh`

Closes #161

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line interface with version, schema, authentication, logout, and diagnostic commands.
  * Added credential status checks for missing, valid, expiring, expired, and invalid credentials.
  * Added secure credential logout and redacted sensitive data from output.
  * Added structured output, pretty-printing, validation, exit codes, and schema discovery.
  * Added automatic credentials-path detection and filesystem support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->