### PR TITLE
docs(contract): record poster catalog evidence

### DIFF
--- a/docs/REMOTE-API-CONTRACT.md
+++ b/docs/REMOTE-API-CONTRACT.md
@@ -1,6 +1,6 @@
 # Remote API contract
 
-`spec/partiful.openapi.json` is owner-reviewed revision `2026-08-10.1` of the
+`spec/partiful.openapi.json` is owner-reviewed revision `2026-08-11.1` of the
 remote transport snapshot. It describes only network operations and wire
 shapes. It does not prescribe commands, output, credentials, mutation
 safeguards, or implementation architecture.

--- a/docs/research/2026-08-10-contract-evidence-sources.md
+++ b/docs/research/2026-08-10-contract-evidence-sources.md
@@ -78,3 +78,12 @@ catalog observations.
 the JSON array to `Poster[]`. This supports the inferred catalog endpoint and
 array transport only. The dated event-image observation is intentionally not
 used for this claim.
+
+## Dated poster catalog observation
+
+The unauthenticated, read-only observation in
+`docs/research/2026-08-11-poster-catalog-observation.md` establishes the
+catalog's HTTP `200` success, complete JSON-array response, required product
+fields and their observed types, one non-success response, and the facts needed
+to bind bounded local pagination to one response representation. It does not
+claim global catalog exhaustiveness or ordinary-request failure statuses.

--- a/docs/research/2026-08-10-contract-evidence-sources.md
+++ b/docs/research/2026-08-10-contract-evidence-sources.md
@@ -84,6 +84,7 @@ used for this claim.
 The unauthenticated, read-only observation in
 `docs/research/2026-08-11-poster-catalog-observation.md` establishes the
 catalog's HTTP `200` success, complete JSON-array response, required product
-fields and their observed types, one non-success response, and the facts needed
-to bind bounded local pagination to one response representation. It does not
-claim global catalog exhaustiveness or ordinary-request failure statuses.
+fields and their observed types, a `416` specific to an unsatisfiable Range
+request, and the facts needed to bind bounded local pagination to one response
+representation. It does not claim global catalog exhaustiveness, ordinary
+request failure statuses, or rate limiting.

--- a/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
+++ b/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
@@ -1,6 +1,6 @@
 # Partiful remote API contract evidence ledger
 
-**Owner-reviewed contract revision:** `2026-08-10.1`
+**Owner-reviewed contract revision:** `2026-08-11.1`
 **Contract:** `spec/partiful.openapi.json`
 **Machine-readable ledger:** `spec/partiful.api-evidence.json`
 **Stable citation sources:** `docs/research/2026-08-10-contract-evidence-sources.md`
@@ -36,17 +36,24 @@ rules, and limits are **explicit unknown**. Consequently, this proposal uses
 schema-free OpenAPI `default` responses rather than inventing a success status
 or applying a success body to errors.
 
-The 819 material claims are audited by
+The 833 material claims are audited by
 `tests/remote-api-contract.test.js`. Each ledger citation resolves either to a
 JSON Pointer in the committed non-authoritative historical artifact or to a
 heading in the committed stable source index. This keeps the audit independent
 of unreachable historical Git objects in shallow CI checkouts.
 
-The event-image observation establishes fields used for an event's selected
-poster image; it does **not** establish that `/posters.json` returns a catalog
-array or that its entries have that shape. The catalog operation and `Poster`
-schema are therefore TypeScript-derived inferences with citations to
-`src/lib/posters.ts`, not dated live observations.
+The event-image observation remains unrelated to the catalog. The
+unauthenticated August 11 observation directly establishes the public
+`/posters.json` HTTP `200` response as a complete array representation and
+establishes every field needed by the product `Poster`. It also establishes a
+bodyless `416` for an unsatisfiable read range. Exact ordinary-request failure
+statuses remain unknown, so a schema-free `default` response distinguishes
+non-success without inventing an error body.
+
+The observed array contained 2,114 entries and one repeated ID. Local
+pagination must preserve response order and duplicates. Exact resumption can
+bind a cursor to the full payload digest, normalized filters, and next offset;
+it cannot rely on `If-Match`, which was not enforced by the observed endpoint.
 
 ## Resolved conflict
 
@@ -58,7 +65,7 @@ nested `message` object with `text`, `to`, `showOnEventPage`, and optional
 
 ## Open questions
 
-No authenticated live probe was performed for this reviewed revision: `partiful doctor`
-reported no local credentials. Mutation probes were deliberately omitted.
-Future safe observations should update both ledgers, preserve synthetic-only
-examples, and receive owner review before changing the revision.
+No authenticated probe was performed for this reviewed revision. The poster
+observation used only the public catalog endpoint and performed no mutation or
+upload. Future safe observations should update both ledgers, preserve
+privacy-safe evidence, and receive owner review before changing the revision.

--- a/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
+++ b/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
@@ -7,7 +7,8 @@
 
 ## Evidence classes
 
-- **Dated live observation:** the March 24 browser-interception research.
+- **Dated live observation:** the March 24 browser-interception research and
+  the August 11 public poster-catalog observation.
 - **Reviewed first-party repository research:** reviewed repository source,
   without claiming it proves current server behavior.
 - **TypeScript-derived inference:** historical draft or TypeScript transport
@@ -16,17 +17,26 @@
 
 ## Operation inventory
 
-The recovered 27 operations remain in the remote inventory. `createTextBlast`,
-`getLoginToken`, and `signInWithCustomToken` have dated live observations.
-`sendAuthCodeTrusted` is a TypeScript-derived inference.
-`lookupFirebaseUser` is a TypeScript-derived inference. The remaining
-operations are TypeScript-derived inferences:
+The recovered 27 operations remain in the remote inventory.
+
+### Dated-live operations
+
+Four operations have dated live observations: `createTextBlast`,
+`getLoginToken`, `signInWithCustomToken`, and `getPosterCatalog`.
+
+### TypeScript-derived operations
+
+The other 23 operations remain TypeScript-derived inferences:
 
 - callable: `createEvent`, `cancelEvent`, `getEventInfo`, `getContacts`,
-  `addInvitedGuestsAsHost`, cohost lifecycle operations, both home-page
-  queries, `addGuest`, `markEventInterest`, and `getCurrentGuest`;
-- Firestore: event and guest reads, event patch, and document listing;
-- Firebase and auxiliary: refresh, photo upload, and poster catalog.
+  `addInvitedGuestsAsHost`, `createCohostRequest`, `deleteCohostRequest`,
+  `removeCohost`, `generateEventCohostLink`, `revokeEventCohostLink`,
+  `getMyUpcomingEventsForHomePage`, `getMyPastEventsForHomePage`, `addGuest`,
+  `markEventInterest`, and `getCurrentGuest`;
+- Firestore: `firestoreGetEvent`, `firestorePatchEvent`, `firestoreGetGuest`,
+  and `firestoreListDocuments`;
+- Firebase and auxiliary: `refreshToken`, `sendAuthCodeTrusted`,
+  `lookupFirebaseUser`, and `uploadEventPhoto`.
 
 Every operation's request and response claim is enumerated by JSON Pointer in
 the JSON ledger, including operation, parameter, content-type, security,

--- a/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
+++ b/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
@@ -46,9 +46,16 @@ The event-image observation remains unrelated to the catalog. The
 unauthenticated August 11 observation directly establishes the public
 `/posters.json` HTTP `200` response as a complete array representation and
 establishes every field needed by the product `Poster`. It also establishes a
-bodyless `416` for an unsatisfiable read range. Exact ordinary-request failure
-statuses remain unknown, so a schema-free `default` response distinguishes
-non-success without inventing an error body.
+bodyless `416` for an unsatisfiable read range, but the implementation will not
+send Range requests and this does not establish ordinary failure mapping.
+Exact ordinary-request failure statuses remain unknown, so the schema-free
+`default` remains explicit unknown.
+
+Only HTTP `200` is recognized as catalog success. Local no-response or network
+failures may map to `remote.unavailable`; any received non-`200` status is
+unrecognized and must fail closed as `contract.protocol_changed`. Rate
+limiting is not claimed. This boundary lets S1 close without guessing while
+preserving the implementation gate until owner approval and merge.
 
 The observed array contained 2,114 entries and one repeated ID. Local
 pagination must preserve response order and duplicates. Exact resumption can

--- a/docs/research/2026-08-11-poster-catalog-observation.md
+++ b/docs/research/2026-08-11-poster-catalog-observation.md
@@ -43,9 +43,14 @@ and a zero-byte body.
 ## Reviewed contract conclusions
 
 The catalog's only accepted success is HTTP `200` with the documented complete
-array representation. Other statuses use the schema-free default response;
-they must not be parsed as catalog success. A `200` body that violates the
-released schema is a protocol change, not a transport failure.
+array representation. The schema-free default response remains an explicit
+unknown. The observed `416` resulted only from a Range request that the
+implementation will not send, so it does not establish ordinary failure
+mapping. A received non-`200` status is unrecognized by this contract revision
+and must fail closed as `contract.protocol_changed`. A no-response or network
+failure may map to `remote.unavailable` as a local transport fact. No
+`remote.rate_limited` mapping is claimed. A `200` body that violates the
+released schema is also `contract.protocol_changed`.
 
 The product mapping is direct and total for its documented output:
 `id` becomes `posterId`; `name`, `url`, `contentType`, `width`, `height`,
@@ -72,4 +77,7 @@ not a claim that the server provides pagination.
 
 These unknowns do not require a runtime fallback. The implementation remains
 gated until this evidence and contract revision receive owner approval and are
-merged.
+merged. Under the fail-closed boundary above, S1 can close without guessing:
+the implementation accepts only the observed `200` representation, maps only
+local no-response/network failures to `remote.unavailable`, and treats every
+received unrecognized status or malformed success body as a protocol change.

--- a/docs/research/2026-08-11-poster-catalog-observation.md
+++ b/docs/research/2026-08-11-poster-catalog-observation.md
@@ -28,10 +28,13 @@ The response included:
 
 Every entry had `id`, `name`, `url`, `contentType`, `width`, `height`, `tags`,
 and `categories`. IDs and names were non-empty strings; URLs were HTTPS
-strings; tags and categories were arrays containing only strings. Width and
-height were integers except that one entry used `null` for both. One ID
-occurred twice at non-adjacent positions; the two entries differed in tags and
-categories. No uniqueness or deduplication claim is supported.
+strings; tags and categories were arrays containing only strings. A repeated
+privacy-safe GET at `01:42:58Z` returned the same byte length and SHA-256;
+every `contentType` was a string and the complete observed value set was
+`image/avif`, `image/gif`, `image/jpeg`, and `image/png`. Width and height were
+integers except that one entry used `null` for both. One ID occurred twice at
+non-adjacent positions; the two entries differed in tags and categories. No
+uniqueness or deduplication claim is supported.
 
 An `If-None-Match` request using the observed ETag returned `304` with no body.
 A deliberately nonmatching `If-Match` request still returned `200` with the

--- a/docs/research/2026-08-11-poster-catalog-observation.md
+++ b/docs/research/2026-08-11-poster-catalog-observation.md
@@ -1,0 +1,75 @@
+# Poster catalog observation
+
+## Scope and provenance
+
+On 2026-08-11 at `01:08:30Z`, an unauthenticated, read-only request was made
+to the contract's public endpoint:
+
+`GET https://assets.getpartiful.com/posters.json`
+
+No credentials, mutations, uploads, personal data, or third-party services
+were used. The response body was inspected locally and then deleted. A raw
+fixture is intentionally not committed: aggregate shape evidence is sufficient
+and avoids retaining a 1.1 MB copy of 2,114 public creative records.
+
+## Direct observations
+
+The unconditional request returned HTTP `200`, `Content-Type:
+application/json`, no `Content-Range`, and a 1,125,932-byte JSON array with
+2,114 entries. Its SHA-256 was
+`35e22005b19dd5795cecf582dee4c4fe4ddc5349e3142f0aae8014f4e471cc6e`.
+The response included:
+
+- `ETag: W/"9dbafb9aedef91b93a1b94e8969ae8b5"`
+- `x-goog-generation: 1786410042765282`
+- `Last-Modified: Tue, 11 Aug 2026 01:00:42 GMT`
+- `Cache-Control: public, max-age=600, s-maxage=600,
+  stale-while-revalidate=86400, stale-if-error=86400`
+
+Every entry had `id`, `name`, `url`, `contentType`, `width`, `height`, `tags`,
+and `categories`. IDs and names were non-empty strings; URLs were HTTPS
+strings; tags and categories were arrays containing only strings. Width and
+height were integers except that one entry used `null` for both. One ID
+occurred twice at non-adjacent positions; the two entries differed in tags and
+categories. No uniqueness or deduplication claim is supported.
+
+An `If-None-Match` request using the observed ETag returned `304` with no body.
+A deliberately nonmatching `If-Match` request still returned `200` with the
+full body, so safe resumption must not depend on that precondition being
+enforced. A read-only request with the unsatisfiable range
+`Range: bytes=999999999-` returned `416`, `Content-Range: bytes */1125932`,
+and a zero-byte body.
+
+## Reviewed contract conclusions
+
+The catalog's only accepted success is HTTP `200` with the documented complete
+array representation. Other statuses use the schema-free default response;
+they must not be parsed as catalog success. A `200` body that violates the
+released schema is a protocol change, not a transport failure.
+
+The product mapping is direct and total for its documented output:
+`id` becomes `posterId`; `name`, `url`, `contentType`, `width`, `height`,
+`tags`, and `categories` retain their wire names. The observation supplies
+every source field on every entry, including the one entry whose dimensions
+are explicitly `null`; no alternate identifier or fallback value is inferred.
+
+The observed response has no remote page envelope or cursor. Bounded local
+pagination is safe by fully materializing the array, preserving order and
+duplicates, and binding an opaque cursor to the payload SHA-256, normalized
+filters, and next array offset. A later payload digest mismatch must reject
+resumption rather than skip, duplicate, or guess items. This is an
+implementation requirement inferred from the complete observed representation,
+not a claim that the server provides pagination.
+
+## Explicit unknowns
+
+- Whether this endpoint contains every poster usable anywhere in Partiful.
+- How often catalog membership or order changes.
+- The semantics of the duplicate ID and nullable dimensions.
+- Status codes and bodies for failures of an ordinary unconditional request.
+- Whether cache validators or storage-generation headers retain their current
+  behavior.
+
+These unknowns do not require a runtime fallback. The implementation remains
+gated until this evidence and contract revision receive owner approval and are
+merged.

--- a/spec/partiful.api-evidence.json
+++ b/spec/partiful.api-evidence.json
@@ -3727,7 +3727,7 @@
     "pagination": {
       "remotePagination": false,
       "localPagination": "full-representation",
-      "resumeBinding": "payload-sha256-and-normalized-filters"
+      "resumeBinding": "payload-sha256-normalized-filters-and-next-offset"
     },
     "failureObservation": {
       "requestCondition": "unsatisfiable-byte-range",

--- a/spec/partiful.api-evidence.json
+++ b/spec/partiful.api-evidence.json
@@ -3636,12 +3636,12 @@
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
     },
     "#/components/schemas/Poster/properties/blurHash": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
+      "classification": "typescript-derived-inference",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
     },
     "#/components/schemas/Poster/properties/blurHash/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
+      "classification": "typescript-derived-inference",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
     },
     "#/components/schemas/Poster/properties/contentType": {
       "classification": "dated-live-observation",
@@ -3700,8 +3700,8 @@
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
     },
     "#/components/schemas/Poster/additionalProperties": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
+      "classification": "typescript-derived-inference",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
     }
   },
   "posterCatalogObservation": {
@@ -3726,6 +3726,11 @@
       "requestCondition": "unsatisfiable-byte-range",
       "status": 416,
       "bodyBytes": 0
+    },
+    "failureBoundary": {
+      "noResponse": "remote.unavailable",
+      "receivedNon200": "contract.protocol_changed",
+      "rateLimiting": "not-claimed"
     }
   }
 }

--- a/spec/partiful.api-evidence.json
+++ b/spec/partiful.api-evidence.json
@@ -1,5 +1,5 @@
 {
-  "contractRevision": "2026-08-10.1",
+  "contractRevision": "2026-08-11.1",
   "contractPath": "spec/partiful.openapi.json",
   "allowedClassifications": [
     "dated-live-observation",
@@ -14,7 +14,8 @@
     "textBlast": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation",
     "authObservation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-authentication-observation",
     "posterInterface": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface",
-    "posterCatalog": "docs/research/2026-08-10-contract-evidence-sources.md#poster-catalog-fetch"
+    "posterCatalog": "docs/research/2026-08-10-contract-evidence-sources.md#poster-catalog-fetch",
+    "posterCatalogObservation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
   },
   "operations": {
     "createEvent": {
@@ -122,8 +123,8 @@
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1uploadPhoto/post"
     },
     "getPosterCatalog": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-catalog-fetch"
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
     }
   },
   "operationClaims": {
@@ -338,10 +339,10 @@
     "getPosterCatalog": {
       "request": "typescript-derived-inference",
       "requestCitation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-catalog-fetch",
-      "response": "explicit-unknown",
-      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
-      "status": "explicit-unknown",
-      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+      "response": "dated-live-observation",
+      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation",
+      "status": "dated-live-observation",
+      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
     }
   },
   "contradictions": [
@@ -364,10 +365,9 @@
     "Callable-specific parameter sets and result payloads outside createTextBlast and documented auth calls.",
     "Complete Firestore typed-value grammar, authorization rules, pagination limits, and update-mask semantics.",
     "Upload accepted media types, size limits, response variants, and whether uploadType values remain stable.",
-    "Poster catalog freshness, complete schema, and cache behavior.",
-    "Status codes and error bodies for every operation.",
-    "The poster event-image observation does not establish the /posters.json response; that operation is TypeScript-derived inference only.",
-    "HTTP success status codes and error bodies are explicit unknown; response body claims are tracked separately."
+    "Poster catalog membership and order can change; exhaustiveness beyond the complete observed endpoint representation is unknown.",
+    "Status codes and error bodies for operations without dated observations.",
+    "Unconditional poster-catalog failure statuses and bodies remain unknown; only HTTP 200 is an accepted catalog success."
   ],
   "status": "owner-reviewed",
   "claims": {
@@ -2987,18 +2987,6 @@
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1uploadPhoto/post/servers/0/url"
     },
-    "#/paths/~1posters.json/get/operationId": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-catalog-fetch"
-    },
-    "#/paths/~1posters.json/get/responses/default": {
-      "classification": "explicit-unknown",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
-    },
-    "#/paths/~1posters.json/get/servers/0/url": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-catalog-fetch"
-    },
     "#/components/securitySchemes/firebaseBearer/type": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/components/securitySchemes/firebaseBearer/type"
@@ -3555,97 +3543,189 @@
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/UploadPhotoResponse/additionalProperties"
     },
+    "#/paths/~1posters.json/get/operationId": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
+    },
+    "#/paths/~1posters.json/get/responses/200": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
+    },
+    "#/paths/~1posters.json/get/responses/200/content/application~1json": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
+    },
+    "#/paths/~1posters.json/get/responses/200/content/application~1json/schema/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
+    },
+    "#/paths/~1posters.json/get/responses/200/content/application~1json/schema/items/$ref": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
+    },
+    "#/paths/~1posters.json/get/responses/default": {
+      "classification": "explicit-unknown",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+    },
+    "#/paths/~1posters.json/get/servers/0/url": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
+    },
     "#/components/schemas/Poster/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
+    },
+    "#/components/schemas/Poster/required/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
+    },
+    "#/components/schemas/Poster/required/1": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
+    },
+    "#/components/schemas/Poster/required/2": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
+    },
+    "#/components/schemas/Poster/required/3": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
+    },
+    "#/components/schemas/Poster/required/4": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
+    },
+    "#/components/schemas/Poster/required/5": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
+    },
+    "#/components/schemas/Poster/required/6": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
+    },
+    "#/components/schemas/Poster/required/7": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
     },
     "#/components/schemas/Poster/properties/id": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
     },
     "#/components/schemas/Poster/properties/id/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
     },
     "#/components/schemas/Poster/properties/name": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
     },
     "#/components/schemas/Poster/properties/name/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
     },
     "#/components/schemas/Poster/properties/url": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
     },
     "#/components/schemas/Poster/properties/url/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
     },
     "#/components/schemas/Poster/properties/url/format": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
     },
     "#/components/schemas/Poster/properties/blurHash": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
     },
     "#/components/schemas/Poster/properties/blurHash/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
     },
     "#/components/schemas/Poster/properties/contentType": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
     },
     "#/components/schemas/Poster/properties/contentType/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
     },
     "#/components/schemas/Poster/properties/height": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
     },
-    "#/components/schemas/Poster/properties/height/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
+    "#/components/schemas/Poster/properties/height/type/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
+    },
+    "#/components/schemas/Poster/properties/height/type/1": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
     },
     "#/components/schemas/Poster/properties/width": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
     },
-    "#/components/schemas/Poster/properties/width/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
+    "#/components/schemas/Poster/properties/width/type/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
+    },
+    "#/components/schemas/Poster/properties/width/type/1": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
     },
     "#/components/schemas/Poster/properties/tags": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
     },
     "#/components/schemas/Poster/properties/tags/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
     },
     "#/components/schemas/Poster/properties/tags/items/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
     },
     "#/components/schemas/Poster/properties/categories": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
     },
     "#/components/schemas/Poster/properties/categories/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
     },
     "#/components/schemas/Poster/properties/categories/items/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
     },
     "#/components/schemas/Poster/additionalProperties": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
+    }
+  },
+  "posterCatalogObservation": {
+    "sourceUrl": "https://assets.getpartiful.com/posters.json",
+    "sourceCitation": "docs/research/2026-08-11-poster-catalog-observation.md#scope-and-provenance",
+    "observedAt": "2026-08-11T01:08:30Z",
+    "status": 200,
+    "mediaType": "application/json",
+    "topLevel": "array",
+    "itemCount": 2114,
+    "payloadBytes": 1125932,
+    "payloadSha256": "35e22005b19dd5795cecf582dee4c4fe4ddc5349e3142f0aae8014f4e471cc6e",
+    "completeRepresentation": true,
+    "allProductFieldsPresent": true,
+    "duplicateIdEntries": 1,
+    "pagination": {
+      "remotePagination": false,
+      "localPagination": "full-representation",
+      "resumeBinding": "payload-sha256-and-normalized-filters"
+    },
+    "failureObservation": {
+      "requestCondition": "unsatisfiable-byte-range",
+      "status": 416,
+      "bodyBytes": 0
     }
   }
 }

--- a/spec/partiful.api-evidence.json
+++ b/spec/partiful.api-evidence.json
@@ -3544,8 +3544,8 @@
       "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/UploadPhotoResponse/additionalProperties"
     },
     "#/paths/~1posters.json/get/operationId": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1posters.json/get/operationId"
     },
     "#/paths/~1posters.json/get/responses/200": {
       "classification": "dated-live-observation",
@@ -3730,6 +3730,7 @@
     "failureBoundary": {
       "noResponse": "remote.unavailable",
       "receivedNon200": "contract.protocol_changed",
+      "malformedSuccess": "contract.protocol_changed",
       "rateLimiting": "not-claimed"
     }
   }

--- a/spec/partiful.api-evidence.json
+++ b/spec/partiful.api-evidence.json
@@ -3717,6 +3717,13 @@
     "completeRepresentation": true,
     "allProductFieldsPresent": true,
     "duplicateIdEntries": 1,
+    "contentTypeVerifiedAt": "2026-08-11T01:42:58Z",
+    "contentTypes": [
+      "image/avif",
+      "image/gif",
+      "image/jpeg",
+      "image/png"
+    ],
     "pagination": {
       "remotePagination": false,
       "localPagination": "full-representation",

--- a/spec/partiful.openapi.json
+++ b/spec/partiful.openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Partiful remote API contract",
-    "version": "2026-08-10.1",
+    "version": "2026-08-11.1",
     "description": "Owner-reviewed, versioned remote-only transport snapshot. Evidence classifications and uncertainty are recorded in spec/partiful.api-evidence.json."
   },
   "servers": [
@@ -1617,6 +1617,19 @@
       "get": {
         "operationId": "getPosterCatalog",
         "responses": {
+          "200": {
+            "description": "Complete poster catalog.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Poster"
+                  }
+                }
+              }
+            }
+          },
           "default": {
             "description": "Response status and body are unknown."
           }
@@ -1914,10 +1927,16 @@
             "type": "string"
           },
           "height": {
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "width": {
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "tags": {
             "type": "array",
@@ -1932,7 +1951,17 @@
             }
           }
         },
-        "additionalProperties": true
+        "additionalProperties": true,
+        "required": [
+          "id",
+          "name",
+          "url",
+          "contentType",
+          "width",
+          "height",
+          "tags",
+          "categories"
+        ]
       }
     }
   }

--- a/tests/remote-api-contract.test.js
+++ b/tests/remote-api-contract.test.js
@@ -386,7 +386,7 @@ describe('remote API contract', () => {
     expect(evidence.posterCatalogObservation.pagination).toEqual({
       remotePagination: false,
       localPagination: 'full-representation',
-      resumeBinding: 'payload-sha256-and-normalized-filters',
+      resumeBinding: 'payload-sha256-normalized-filters-and-next-offset',
     });
     expect(evidence.posterCatalogObservation.failureObservation).toEqual({
       requestCondition: 'unsatisfiable-byte-range',

--- a/tests/remote-api-contract.test.js
+++ b/tests/remote-api-contract.test.js
@@ -130,7 +130,11 @@ describe('remote API contract', () => {
       expect(allowed.has(claim.response)).toBe(true);
       expect(citationResolves(claim.requestCitation), operation.operationId).toBe(true);
       expect(citationResolves(claim.responseCitation), operation.operationId).toBe(true);
-      expect(claim.status).toBe('explicit-unknown');
+      expect(claim.status).toBe(
+        operation.operationId === 'getPosterCatalog'
+          ? 'dated-live-observation'
+          : 'explicit-unknown',
+      );
       expect(citationResolves(claim.statusCitation), operation.operationId).toBe(true);
     }
     const pointers = new Set([
@@ -138,7 +142,7 @@ describe('remote API contract', () => {
       ...materialClaimPointers(spec.paths, '#/paths', 'paths'),
       ...materialClaimPointers(spec.components, '#/components', 'components'),
     ]);
-    expect(pointers).toHaveLength(819);
+    expect(pointers).toHaveLength(833);
     for (const pointer of pointers) {
       const claim = evidence.claims[pointer];
       expect(claim, pointer).toBeDefined();
@@ -178,8 +182,13 @@ describe('remote API contract', () => {
 
   it('does not assert an unknown status code as a success response', () => {
     for (const { operation } of operations()) {
-      expect(Object.keys(operation.responses)).toEqual(['default']);
-      expect(evidence.operationClaims[operation.operationId].status).toBe('explicit-unknown');
+      if (operation.operationId === 'getPosterCatalog') {
+        expect(Object.keys(operation.responses)).toEqual(['200', 'default']);
+        expect(evidence.operationClaims[operation.operationId].status).toBe('dated-live-observation');
+      } else {
+        expect(Object.keys(operation.responses)).toEqual(['default']);
+        expect(evidence.operationClaims[operation.operationId].status).toBe('explicit-unknown');
+      }
     }
   });
 
@@ -202,8 +211,13 @@ describe('remote API contract', () => {
       expect(evidence.claims[base].citation).toBe(evidence.sources.unknownStatusDecision);
       expect(operation.responses.default).not.toHaveProperty('content');
       const operationClaim = evidence.operationClaims[operation.operationId];
-      expect(operationClaim.response).toBe('explicit-unknown');
-      expect(operationClaim.responseCitation).toBe(evidence.sources.unknownStatusDecision);
+      if (operation.operationId === 'getPosterCatalog') {
+        expect(operationClaim.response).toBe('dated-live-observation');
+        expect(operationClaim.responseCitation).toBe(evidence.sources.posterCatalogObservation);
+      } else {
+        expect(operationClaim.response).toBe('explicit-unknown');
+        expect(operationClaim.responseCitation).toBe(evidence.sources.unknownStatusDecision);
+      }
     }
   });
 
@@ -218,11 +232,8 @@ describe('remote API contract', () => {
       if (claim.citation === evidence.sources.updateMask) {
         expect(pointer).toMatch(/updateMask\.fieldPaths|parameters\/1\/(?:style|explode)$/);
       }
-      if (claim.citation === evidence.sources.posterCatalog) {
-        expect(pointer).toContain('~1posters.json');
-      }
-      if (claim.citation === evidence.sources.posterInterface) {
-        expect(pointer).toContain('/schemas/Poster');
+      if (claim.citation === evidence.sources.posterCatalogObservation) {
+        expect(pointer.includes('~1posters.json') || pointer.includes('/schemas/Poster')).toBe(true);
       }
     }
   });
@@ -281,15 +292,72 @@ describe('remote API contract', () => {
     expect(jsonPointerValue(historicalDraft, '#/openapi')).not.toEqual(spec.info.version);
   });
 
-  it('does not treat the event-image observation as poster-catalog evidence', () => {
+  it('records the observed poster catalog without borrowing event-image evidence', () => {
     const posterOperation = evidence.operations.getPosterCatalog;
-    expect(posterOperation.classification).toBe('typescript-derived-inference');
-    expect(posterOperation.citation).toBe(evidence.sources.posterCatalog);
+    expect(posterOperation.classification).toBe('dated-live-observation');
+    expect(posterOperation.citation).toBe(evidence.sources.posterCatalogObservation);
     expect(evidence.sources).not.toHaveProperty('eventImageObservation');
     for (const [pointer, claim] of Object.entries(evidence.claims)) {
       if (pointer.includes('/posters.json') || pointer.includes('/Poster')) {
         expect(claim.citation).not.toBe(evidence.sources.eventImageObservation);
       }
     }
+  });
+
+  it('captures the complete poster response needed for bounded local pagination', () => {
+    const operation = spec.paths['/posters.json'].get;
+    expect(operation.responses['200']).toEqual({
+      description: 'Complete poster catalog.',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/Poster' },
+          },
+        },
+      },
+    });
+    expect(operation.responses.default).not.toHaveProperty('content');
+
+    const poster = spec.components.schemas.Poster;
+    expect(poster.required).toEqual([
+      'id',
+      'name',
+      'url',
+      'contentType',
+      'width',
+      'height',
+      'tags',
+      'categories',
+    ]);
+    expect(poster.properties.width.type).toEqual(['integer', 'null']);
+    expect(poster.properties.height.type).toEqual(['integer', 'null']);
+    expect(poster.properties.tags.items.type).toBe('string');
+    expect(poster.properties.categories.items.type).toBe('string');
+
+    expect(evidence.posterCatalogObservation).toMatchObject({
+      sourceCitation: 'docs/research/2026-08-11-poster-catalog-observation.md#scope-and-provenance',
+      observedAt: '2026-08-11T01:08:30Z',
+      status: 200,
+      mediaType: 'application/json',
+      topLevel: 'array',
+      itemCount: 2114,
+      payloadBytes: 1125932,
+      payloadSha256: '35e22005b19dd5795cecf582dee4c4fe4ddc5349e3142f0aae8014f4e471cc6e',
+      completeRepresentation: true,
+      allProductFieldsPresent: true,
+      duplicateIdEntries: 1,
+    });
+    expect(citationResolves(evidence.posterCatalogObservation.sourceCitation)).toBe(true);
+    expect(evidence.posterCatalogObservation.pagination).toEqual({
+      remotePagination: false,
+      localPagination: 'full-representation',
+      resumeBinding: 'payload-sha256-and-normalized-filters',
+    });
+    expect(evidence.posterCatalogObservation.failureObservation).toEqual({
+      requestCondition: 'unsatisfiable-byte-range',
+      status: 416,
+      bodyBytes: 0,
+    });
   });
 });

--- a/tests/remote-api-contract.test.js
+++ b/tests/remote-api-contract.test.js
@@ -335,6 +335,11 @@ describe('remote API contract', () => {
       },
     });
     expect(operation.responses.default).not.toHaveProperty('content');
+    expect(evidence.claims['#/paths/~1posters.json/get/operationId']).toEqual({
+      classification: 'typescript-derived-inference',
+      citation:
+        'spec/research/historical-27-operation-draft.json#/paths/~1posters.json/get/operationId',
+    });
 
     const poster = spec.components.schemas.Poster;
     expect(poster.required).toEqual([
@@ -389,6 +394,7 @@ describe('remote API contract', () => {
     expect(evidence.posterCatalogObservation.failureBoundary).toEqual({
       noResponse: 'remote.unavailable',
       receivedNon200: 'contract.protocol_changed',
+      malformedSuccess: 'contract.protocol_changed',
       rateLimiting: 'not-claimed',
     });
   });

--- a/tests/remote-api-contract.test.js
+++ b/tests/remote-api-contract.test.js
@@ -334,6 +334,16 @@ describe('remote API contract', () => {
     expect(poster.properties.height.type).toEqual(['integer', 'null']);
     expect(poster.properties.tags.items.type).toBe('string');
     expect(poster.properties.categories.items.type).toBe('string');
+    for (const pointer of [
+      '#/components/schemas/Poster/properties/blurHash',
+      '#/components/schemas/Poster/properties/blurHash/type',
+      '#/components/schemas/Poster/additionalProperties',
+    ]) {
+      expect(evidence.claims[pointer]).toEqual({
+        classification: 'typescript-derived-inference',
+        citation: evidence.sources.posterInterface,
+      });
+    }
 
     expect(evidence.posterCatalogObservation).toMatchObject({
       sourceCitation: 'docs/research/2026-08-11-poster-catalog-observation.md#scope-and-provenance',
@@ -358,6 +368,11 @@ describe('remote API contract', () => {
       requestCondition: 'unsatisfiable-byte-range',
       status: 416,
       bodyBytes: 0,
+    });
+    expect(evidence.posterCatalogObservation.failureBoundary).toEqual({
+      noResponse: 'remote.unavailable',
+      receivedNon200: 'contract.protocol_changed',
+      rateLimiting: 'not-claimed',
     });
   });
 });

--- a/tests/remote-api-contract.test.js
+++ b/tests/remote-api-contract.test.js
@@ -379,6 +379,8 @@ describe('remote API contract', () => {
       completeRepresentation: true,
       allProductFieldsPresent: true,
       duplicateIdEntries: 1,
+      contentTypeVerifiedAt: '2026-08-11T01:42:58Z',
+      contentTypes: ['image/avif', 'image/gif', 'image/jpeg', 'image/png'],
     });
     expect(citationResolves(evidence.posterCatalogObservation.sourceCitation)).toBe(true);
     expect(evidence.posterCatalogObservation.pagination).toEqual({

--- a/tests/remote-api-contract.test.js
+++ b/tests/remote-api-contract.test.js
@@ -281,9 +281,26 @@ describe('remote API contract', () => {
       'docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md',
       'utf8',
     );
-    for (const operationId of ['sendAuthCodeTrusted', 'lookupFirebaseUser']) {
-      expect(evidence.operations[operationId].classification).toBe('typescript-derived-inference');
-      expect(ledger).toContain('`' + operationId + '` is a TypeScript-derived inference');
+    const knownOperationIds = new Set(Object.keys(evidence.operations));
+    const documentedOperations = (heading) => {
+      const marker = `### ${heading}\n`;
+      const start = ledger.indexOf(marker);
+      expect(start, heading).toBeGreaterThanOrEqual(0);
+      const section = ledger.slice(start + marker.length).split(/\n#{2,6} /)[0];
+      return [...section.matchAll(/`([^`]+)`/g)]
+        .map((match) => match[1])
+        .filter((operationId) => knownOperationIds.has(operationId))
+        .sort();
+    };
+    for (const [heading, classification] of [
+      ['Dated-live operations', 'dated-live-observation'],
+      ['TypeScript-derived operations', 'typescript-derived-inference'],
+    ]) {
+      const machineOperations = Object.entries(evidence.operations)
+        .filter(([, operation]) => operation.classification === classification)
+        .map(([operationId]) => operationId)
+        .sort();
+      expect(documentedOperations(heading)).toEqual(machineOperations);
     }
   });
 


### PR DESCRIPTION
## Summary

- proposes remote contract revision `2026-08-11.1` for the S1 evidence prerequisite in #162
- records an unauthenticated, privacy-safe observation of the approved public poster catalog endpoint
- contracts HTTP 200 as the only recognized success and its complete JSON-array body
- requires every product Poster source field, including nullable dimensions
- retains `blurHash` and `additionalProperties: true` as TypeScript-derived inferences
- records digest-bound bounded local pagination and a fail-closed status boundary
- adds no Go implementation; owner approval and merge remain mandatory before S1 implementation begins

## Observation

At `2026-08-11T01:08:30Z`, `GET https://assets.getpartiful.com/posters.json` returned:

- HTTP `200`, `Content-Type: application/json`
- 1,125,932 bytes; SHA-256 `35e22005b19dd5795cecf582dee4c4fe4ddc5349e3142f0aae8014f4e471cc6e`
- a complete top-level array of 2,114 entries
- all required fields on every entry: `id`, `name`, `url`, `contentType`, `width`, `height`, `tags`, `categories`
- one entry with null width/height and one duplicated ID (response order and duplicates must be preserved)

A read-only unsatisfiable Range request returned HTTP `416` with no body. The implementation will not send Range requests, so this does not establish ordinary failure mapping. `If-None-Match` returned `304`; a deliberately nonmatching `If-Match` was not enforced and returned the full `200`, so pagination cannot depend on that precondition.

## Gate assessment

The evidence is sufficient to propose closing S1's remote evidence gate without guessing: a cursor can bind the full payload digest, normalized filters, and next offset, and reject digest changes.

The failure boundary is deliberately fail-closed:

- only received HTTP `200` is recognized as success
- no-response/network failures may map to `remote.unavailable` as local transport facts
- every received non-200 status is unrecognized and maps to `contract.protocol_changed`
- malformed HTTP 200 bodies map to `contract.protocol_changed`
- rate limiting is not claimed
- the schema-free default response remains explicit unknown

Explicit unknowns remain documented: global catalog exhaustiveness, catalog change frequency/order, duplicate-ID semantics, nullable-dimension semantics, ordinary unconditional failure statuses/bodies, and future cache-validator behavior. None is used as a runtime fallback.

Owner approval and merge of this contract revision are still required. This PR must not be treated as approval by itself.

## Verification

- `npm test -- tests/remote-api-contract.test.js` — 15 passed
- `npm run typecheck` — passed
- `go test ./...` — passed
- `TZ=America/Los_Angeles npm test` — 336 passed, 6 skipped
- `git diff --check` — passed
- added-line privacy scan — no credentials or personal data found

No credentials, authenticated probes, mutations, uploads, or third-party services were used.
