### PR TITLE
feat(auth): implement human authentication and session lifecycle (#163)

### DIFF
--- a/cmd/partiful/main.go
+++ b/cmd/partiful/main.go
@@ -26,6 +26,11 @@ func main() {
 		HTTP:                 remote.NewHTTPClient(nil),
 		CursorKeys:           app.FileCursorKeyProvider{Path: cursorKeyPath},
 		CursorRandom:         rand.Reader,
+		AuthRandom:           rand.Reader,
+		Terminal: auth.OSTerminal{
+			Input:  os.Stdin,
+			Output: os.Stderr,
+		},
 	})
 
 	_, _ = io.WriteString(os.Stdout, result.Stdout)

--- a/docs/CLI-PRODUCT-CONTRACT.md
+++ b/docs/CLI-PRODUCT-CONTRACT.md
@@ -2,7 +2,7 @@
 
 **Status:** Approved product contract  
 **Product contract revision:** `2026-08-10.1`  
-**Remote API contract revision:** `2026-08-11.1`
+**Remote API contract revision:** `2026-08-11.4`
 
 This document defines the public behavior of the greenfield Go `partiful` CLI.
 It is the authority for commands, inputs, JSON outputs, failures, and mutation
@@ -78,7 +78,7 @@ Every successful command returns:
     "command": "events.get",
     "cliVersion": "1.0.0",
     "productContractRevision": "2026-08-10.1",
-    "remoteContractRevision": "2026-08-11.1",
+    "remoteContractRevision": "2026-08-11.4",
     "warnings": []
   }
 }
@@ -102,7 +102,7 @@ Every failed command returns:
     "command": "guests.list",
     "cliVersion": "1.0.0",
     "productContractRevision": "2026-08-10.1",
-    "remoteContractRevision": "2026-08-11.1"
+    "remoteContractRevision": "2026-08-11.4"
   }
 }
 ```
@@ -150,7 +150,7 @@ Collection commands return:
     "command": "events.list",
     "cliVersion": "1.0.0",
     "productContractRevision": "2026-08-10.1",
-    "remoteContractRevision": "2026-08-11.1",
+    "remoteContractRevision": "2026-08-11.4",
     "warnings": [],
     "page": {
       "limit": 25,
@@ -203,7 +203,7 @@ remote mutation:
     "command": "events.update",
     "cliVersion": "1.0.0",
     "productContractRevision": "2026-08-10.1",
-    "remoteContractRevision": "2026-08-11.1",
+    "remoteContractRevision": "2026-08-11.4",
     "warnings": []
   }
 }
@@ -283,7 +283,14 @@ Returns:
 ```
 
 `tokenState` is `healthy`, `expiring`, `expired`, or `missing`. The command
-does not return identity details or credentials.
+does not return identity details or credentials. When stored credentials have
+a refresh token and are within five minutes of expiry, `auth status`
+deterministically refreshes and atomically replaces them before reporting
+`healthy`. This makes the command a local mutation. A rejected refresh returns
+`auth.expired`; an unavailable authentication service returns
+`remote.unavailable`; and an unrecognized released response returns
+`contract.protocol_changed`. Credentials without a refresh token continue to
+report `expiring` or `expired`.
 
 ### `partiful auth logout`
 
@@ -300,6 +307,10 @@ Deletes local credentials and returns:
 Token refresh, custom-token exchange, and Firebase account lookup are internal
 authentication steps. Other commands never start login or prompt. They return
 an authentication failure so an agent can hand control to a human.
+
+Authentication response bodies are limited to 64 KiB. A larger successful or
+error response does not enter output and fails closed as
+`contract.protocol_changed`.
 
 ## Public commands
 

--- a/docs/CLI-PRODUCT-CONTRACT.md
+++ b/docs/CLI-PRODUCT-CONTRACT.md
@@ -313,6 +313,10 @@ Authentication response bodies are limited to 64 KiB. A larger successful or
 error response does not enter output and fails closed as
 `contract.protocol_changed`.
 
+A successful token lifetime must exceed the five-minute refresh window so
+login and refresh can return `healthy`. A shorter lifetime fails closed as
+`contract.protocol_changed` rather than creating a refresh loop.
+
 ## Public commands
 
 ### Events

--- a/docs/CLI-PRODUCT-CONTRACT.md
+++ b/docs/CLI-PRODUCT-CONTRACT.md
@@ -284,9 +284,10 @@ Returns:
 
 `tokenState` is `healthy`, `expiring`, `expired`, or `missing`. The command
 does not return identity details or credentials. When stored credentials have
-a refresh token and are within five minutes of expiry, `auth status`
-deterministically refreshes and atomically replaces them before reporting
-`healthy`. This makes the command a local mutation. A rejected refresh returns
+a refresh token and are within five minutes of expiry or already expired,
+`auth status` deterministically refreshes and atomically replaces them before
+reporting `healthy`. This makes the command a local mutation. A rejected
+refresh returns
 `auth.expired`; an unavailable authentication service returns
 `remote.unavailable`; and an unrecognized released response returns
 `contract.protocol_changed`. Credentials without a refresh token continue to
@@ -631,7 +632,7 @@ Without a path, returns every public command path. With a path such as
   "flags": [],
   "inputSchema": {},
   "successSchema": {},
-  "failureTypes": [],
+  "failureTypes": ["usage.invalid", "input.invalid"],
   "safety": {
     "kind": "standard-mutation",
     "planRequired": true,
@@ -640,9 +641,10 @@ Without a path, returns every public command path. With a path such as
 }
 ```
 
-The real arrays and schemas contain the complete contract. This command is
-generated from the same command definitions used by execution; it is not a
-second handwritten description.
+The example shows the default invocation failures. Real arrays add each
+command-specific failure, and the schemas contain the complete contract. This
+command is generated from the same command definitions used by execution; it
+is not a second handwritten description.
 
 #### `partiful doctor`
 

--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,4 @@ go 1.22
 
 require golang.org/x/term v0.29.0
 
-require golang.org/x/sys v0.30.0 // indirect
+require golang.org/x/sys v0.30.0

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,7 @@
 module github.com/KalebCole/partiful-cli
 
 go 1.22
+
+require golang.org/x/term v0.29.0
+
+require golang.org/x/sys v0.30.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
+golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/term v0.29.0 h1:L6pJp37ocefwRRtYPKSWOWzOtWSxVajvz2ldH/xi3iU=
+golang.org/x/term v0.29.0/go.mod h1:6bl4lRlvVuDgSf3179VpIxBF0o10JUpXWOnI7nErv7s=

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -533,10 +533,10 @@ func Execute(ctx context.Context, request Request, dependencies Dependencies) Re
 					if errors.Is(err, auth.ErrInputInvalid) {
 						return authenticationInputInvalidFailure(definition.path, pretty)
 					}
-					if errors.Is(err, remote.ErrAuthCodeRejected) {
+					if errors.Is(err, auth.ErrAuthCodeRejected) {
 						return authCodeRejectedFailure(definition.path, pretty)
 					}
-					if errors.Is(err, remote.ErrAuthExpired) {
+					if errors.Is(err, auth.ErrRemoteTokenExpired) {
 						return authenticationExpiredFailure(
 							definition.path,
 							"INVALID_CUSTOM_TOKEN",
@@ -544,10 +544,10 @@ func Execute(ctx context.Context, request Request, dependencies Dependencies) Re
 							pretty,
 						)
 					}
-					if errors.Is(err, remote.ErrProtocolChanged) {
+					if errors.Is(err, auth.ErrRemoteProtocolChanged) {
 						return authenticationProtocolChangedFailure(definition.path, pretty)
 					}
-					if errors.Is(err, remote.ErrUnavailable) {
+					if errors.Is(err, auth.ErrRemoteUnavailable) {
 						return authenticationUnavailableFailure(definition.path, pretty)
 					}
 					if errors.Is(err, auth.ErrPersistence) {
@@ -572,7 +572,7 @@ func Execute(ctx context.Context, request Request, dependencies Dependencies) Re
 					remote.AuthClient{HTTP: dependencies.HTTP},
 				)
 				if err != nil {
-					if errors.Is(err, remote.ErrAuthExpired) {
+					if errors.Is(err, auth.ErrRemoteTokenExpired) {
 						return authenticationExpiredFailure(
 							definition.path,
 							"INVALID_REFRESH_TOKEN",
@@ -580,10 +580,10 @@ func Execute(ctx context.Context, request Request, dependencies Dependencies) Re
 							pretty,
 						)
 					}
-					if errors.Is(err, remote.ErrProtocolChanged) {
+					if errors.Is(err, auth.ErrRemoteProtocolChanged) {
 						return authenticationProtocolChangedFailure(definition.path, pretty)
 					}
-					if errors.Is(err, remote.ErrUnavailable) {
+					if errors.Is(err, auth.ErrRemoteUnavailable) {
 						return authenticationUnavailableFailure(definition.path, pretty)
 					}
 					if errors.Is(err, auth.ErrPersistence) {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -521,6 +521,8 @@ func Execute(ctx context.Context, request Request, dependencies Dependencies) Re
 					case errors.Is(err, auth.ErrPersistence),
 						errors.Is(err, auth.ErrUnavailable):
 						return credentialUnavailableFailure(definition.path, pretty)
+					case errors.Is(err, auth.ErrInvalid):
+						return credentialInvalidFailure(definition.path, pretty)
 					default:
 						return internalFailure(definition.path, pretty)
 					}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -15,7 +15,7 @@ import (
 const (
 	Version                 = "1.0.0"
 	ProductContractRevision = "2026-08-10.1"
-	RemoteContractRevision  = "2026-08-11.3"
+	RemoteContractRevision  = "2026-08-11.4"
 )
 
 type Request struct {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -55,15 +55,16 @@ const (
 )
 
 type commandDefinition struct {
-	path          string
-	invocation    []string
-	kind          commandKind
-	positionals   []positionalDefinition
-	flags         []flagDefinition
-	inputSchema   jsonSchema
-	successSchema jsonSchema
-	failureTypes  []string
-	safety        safetyDefinition
+	path            string
+	invocation      []string
+	kind            commandKind
+	positionals     []positionalDefinition
+	flags           []flagDefinition
+	inputSchema     jsonSchema
+	successSchema   jsonSchema
+	failureTypes    []string
+	safety          safetyDefinition
+	sessionRequired bool
 }
 
 var commandCatalog = []commandDefinition{
@@ -123,8 +124,13 @@ var commandCatalog = []commandDefinition{
 		flags:         []flagDefinition{},
 		inputSchema:   emptyInputSchema(),
 		successSchema: authStateSuccessSchema(),
-		failureTypes:  []string{"internal.failure"},
-		safety:        readOnlySafety(),
+		failureTypes: []string{
+			"auth.expired",
+			"remote.unavailable",
+			"contract.protocol_changed",
+			"internal.failure",
+		},
+		safety: readOnlySafety(),
 	},
 	{
 		path:          "auth.logout",
@@ -475,6 +481,51 @@ func Execute(ctx context.Context, request Request, dependencies Dependencies) Re
 	}
 	for _, definition := range commandCatalog {
 		if definition.matches(argv) {
+			if definition.sessionRequired {
+				if dependencies.CredentialsPathError != nil {
+					return configurationDirectoryFailure(definition.path, pretty)
+				}
+				now := time.Now()
+				if dependencies.Now != nil {
+					now = dependencies.Now()
+				}
+				_, err := auth.AcquireSession(
+					ctx,
+					dependencies.Files,
+					dependencies.CredentialsPath,
+					now,
+					remote.AuthClient{HTTP: dependencies.HTTP},
+				)
+				if err != nil {
+					switch {
+					case errors.Is(err, auth.ErrRequired):
+						return authenticationRequiredFailure(definition.path, pretty)
+					case errors.Is(err, auth.ErrSessionExpired):
+						return authenticationExpiredFailure(
+							definition.path,
+							"SESSION_EXPIRED",
+							"Stored authentication has expired. Log in again.",
+							pretty,
+						)
+					case errors.Is(err, remote.ErrAuthExpired):
+						return authenticationExpiredFailure(
+							definition.path,
+							"INVALID_REFRESH_TOKEN",
+							"Stored authentication has expired. Log in again.",
+							pretty,
+						)
+					case errors.Is(err, remote.ErrProtocolChanged):
+						return authenticationProtocolChangedFailure(definition.path, pretty)
+					case errors.Is(err, remote.ErrUnavailable):
+						return authenticationUnavailableFailure(definition.path, pretty)
+					case errors.Is(err, auth.ErrPersistence),
+						errors.Is(err, auth.ErrUnavailable):
+						return credentialUnavailableFailure(definition.path, pretty)
+					default:
+						return internalFailure(definition.path, pretty)
+					}
+				}
+			}
 			switch definition.kind {
 			case versionCommand:
 				return success(definition.path, versionData{
@@ -555,12 +606,31 @@ func Execute(ctx context.Context, request Request, dependencies Dependencies) Re
 				if dependencies.Now != nil {
 					now = dependencies.Now()
 				}
-				state, err := auth.Status(
+				state, err := auth.StatusWithRefresh(
+					ctx,
 					dependencies.Files,
 					dependencies.CredentialsPath,
 					now,
+					remote.AuthClient{HTTP: dependencies.HTTP},
 				)
 				if err != nil {
+					if errors.Is(err, remote.ErrAuthExpired) {
+						return authenticationExpiredFailure(
+							definition.path,
+							"INVALID_REFRESH_TOKEN",
+							"Stored authentication has expired. Log in again.",
+							pretty,
+						)
+					}
+					if errors.Is(err, remote.ErrProtocolChanged) {
+						return authenticationProtocolChangedFailure(definition.path, pretty)
+					}
+					if errors.Is(err, remote.ErrUnavailable) {
+						return authenticationUnavailableFailure(definition.path, pretty)
+					}
+					if errors.Is(err, auth.ErrPersistence) {
+						return credentialUnavailableFailure(definition.path, pretty)
+					}
 					if errors.Is(err, auth.ErrInvalid) {
 						return credentialInvalidFailure(definition.path, pretty)
 					}
@@ -947,6 +1017,18 @@ func privateTerminalRequiredFailure(command string, pretty bool) Result {
 		Details:   map[string]any{},
 	}, pretty)
 	result.Stderr = "partiful: private terminal required\n"
+	return result
+}
+
+func authenticationRequiredFailure(command string, pretty bool) Result {
+	result := failure(command, 3, errorBody{
+		Type:      "auth.required",
+		Code:      "AUTHENTICATION_REQUIRED",
+		Message:   "This command requires authentication. Log in first.",
+		Retryable: false,
+		Details:   map[string]any{},
+	}, pretty)
+	result.Stderr = "partiful: authentication required\n"
 	return result
 }
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -64,7 +64,6 @@ type commandDefinition struct {
 	successSchema   jsonSchema
 	failureTypes    []string
 	safety          safetyDefinition
-	sessionRequired bool
 }
 
 var commandCatalog = []commandDefinition{
@@ -481,53 +480,6 @@ func Execute(ctx context.Context, request Request, dependencies Dependencies) Re
 	}
 	for _, definition := range commandCatalog {
 		if definition.matches(argv) {
-			if definition.sessionRequired {
-				if dependencies.CredentialsPathError != nil {
-					return configurationDirectoryFailure(definition.path, pretty)
-				}
-				now := time.Now()
-				if dependencies.Now != nil {
-					now = dependencies.Now()
-				}
-				_, err := auth.AcquireSession(
-					ctx,
-					dependencies.Files,
-					dependencies.CredentialsPath,
-					now,
-					remote.AuthClient{HTTP: dependencies.HTTP},
-				)
-				if err != nil {
-					switch {
-					case errors.Is(err, auth.ErrRequired):
-						return authenticationRequiredFailure(definition.path, pretty)
-					case errors.Is(err, auth.ErrSessionExpired):
-						return authenticationExpiredFailure(
-							definition.path,
-							"SESSION_EXPIRED",
-							"Stored authentication has expired. Log in again.",
-							pretty,
-						)
-					case errors.Is(err, remote.ErrAuthExpired):
-						return authenticationExpiredFailure(
-							definition.path,
-							"INVALID_REFRESH_TOKEN",
-							"Stored authentication has expired. Log in again.",
-							pretty,
-						)
-					case errors.Is(err, remote.ErrProtocolChanged):
-						return authenticationProtocolChangedFailure(definition.path, pretty)
-					case errors.Is(err, remote.ErrUnavailable):
-						return authenticationUnavailableFailure(definition.path, pretty)
-					case errors.Is(err, auth.ErrPersistence),
-						errors.Is(err, auth.ErrUnavailable):
-						return credentialUnavailableFailure(definition.path, pretty)
-					case errors.Is(err, auth.ErrInvalid):
-						return credentialInvalidFailure(definition.path, pretty)
-					default:
-						return internalFailure(definition.path, pretty)
-					}
-				}
-			}
 			switch definition.kind {
 			case versionCommand:
 				return success(definition.path, versionData{
@@ -931,9 +883,19 @@ func projectSchema(definition commandDefinition) commandSchema {
 		Flags:         definition.flags,
 		InputSchema:   definition.inputSchema,
 		SuccessSchema: definition.successSchema,
-		FailureTypes:  definition.failureTypes,
+		FailureTypes:  declaredFailureTypes(definition),
 		Safety:        definition.safety,
 	}
+}
+
+func declaredFailureTypes(definition commandDefinition) []string {
+	failureTypes := []string{"usage.invalid", "input.invalid"}
+	for _, failureType := range definition.failureTypes {
+		if !slices.Contains(failureTypes, failureType) {
+			failureTypes = append(failureTypes, failureType)
+		}
+	}
+	return failureTypes
 }
 
 func commandName(argv []string) string {
@@ -1019,18 +981,6 @@ func privateTerminalRequiredFailure(command string, pretty bool) Result {
 		Details:   map[string]any{},
 	}, pretty)
 	result.Stderr = "partiful: private terminal required\n"
-	return result
-}
-
-func authenticationRequiredFailure(command string, pretty bool) Result {
-	result := failure(command, 3, errorBody{
-		Type:      "auth.required",
-		Code:      "AUTHENTICATION_REQUIRED",
-		Message:   "This command requires authentication. Log in first.",
-		Retryable: false,
-		Details:   map[string]any{},
-	}, pretty)
-	result.Stderr = "partiful: authentication required\n"
 	return result
 }
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -55,15 +55,15 @@ const (
 )
 
 type commandDefinition struct {
-	path            string
-	invocation      []string
-	kind            commandKind
-	positionals     []positionalDefinition
-	flags           []flagDefinition
-	inputSchema     jsonSchema
-	successSchema   jsonSchema
-	failureTypes    []string
-	safety          safetyDefinition
+	path          string
+	invocation    []string
+	kind          commandKind
+	positionals   []positionalDefinition
+	flags         []flagDefinition
+	inputSchema   jsonSchema
+	successSchema jsonSchema
+	failureTypes  []string
+	safety        safetyDefinition
 }
 
 var commandCatalog = []commandDefinition{
@@ -129,7 +129,11 @@ var commandCatalog = []commandDefinition{
 			"contract.protocol_changed",
 			"internal.failure",
 		},
-		safety: readOnlySafety(),
+		safety: safetyDefinition{
+			Kind:                 "local-mutation",
+			PlanRequired:         false,
+			ConfirmationRequired: false,
+		},
 	},
 	{
 		path:          "auth.logout",

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -513,16 +513,16 @@ func Execute(ctx context.Context, request Request, dependencies Dependencies) Re
 				if dependencies.CredentialsPathError != nil {
 					return configurationDirectoryFailure(definition.path, pretty)
 				}
-				now := time.Now()
+				clock := time.Now
 				if dependencies.Now != nil {
-					now = dependencies.Now()
+					clock = dependencies.Now
 				}
 				state, err := auth.Login(
 					ctx,
 					dependencies.Files,
 					dependencies.CredentialsPath,
 					dependencies.Terminal,
-					now,
+					clock,
 					dependencies.AuthRandom,
 					remote.AuthClient{HTTP: dependencies.HTTP},
 				)
@@ -560,15 +560,15 @@ func Execute(ctx context.Context, request Request, dependencies Dependencies) Re
 				if dependencies.CredentialsPathError != nil {
 					return configurationDirectoryFailure(definition.path, pretty)
 				}
-				now := time.Now()
+				clock := time.Now
 				if dependencies.Now != nil {
-					now = dependencies.Now()
+					clock = dependencies.Now
 				}
 				state, err := auth.StatusWithRefresh(
 					ctx,
 					dependencies.Files,
 					dependencies.CredentialsPath,
-					now,
+					clock,
 					remote.AuthClient{HTTP: dependencies.HTTP},
 				)
 				if err != nil {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -15,7 +15,7 @@ import (
 const (
 	Version                 = "1.0.0"
 	ProductContractRevision = "2026-08-10.1"
-	RemoteContractRevision  = "2026-08-11.1"
+	RemoteContractRevision  = "2026-08-11.2"
 )
 
 type Request struct {
@@ -37,6 +37,8 @@ type Dependencies struct {
 	HTTP                 remote.HTTPClient
 	CursorKeys           CursorKeyProvider
 	CursorRandom         io.Reader
+	AuthRandom           io.Reader
+	Terminal             auth.PrivateTerminal
 }
 
 type commandKind uint8
@@ -44,6 +46,7 @@ type commandKind uint8
 const (
 	versionCommand commandKind = iota
 	schemaCommand
+	authLoginCommand
 	authStatusCommand
 	authLogoutCommand
 	doctorCommand
@@ -89,6 +92,28 @@ var commandCatalog = []commandDefinition{
 		successSchema: schemaSuccessSchema(),
 		failureTypes:  []string{"usage.invalid"},
 		safety:        readOnlySafety(),
+	},
+	{
+		path:          "auth.login",
+		invocation:    []string{"auth", "login"},
+		kind:          authLoginCommand,
+		positionals:   []positionalDefinition{},
+		flags:         []flagDefinition{},
+		inputSchema:   emptyInputSchema(),
+		successSchema: authStateSuccessSchema(),
+		failureTypes: []string{
+			"input.invalid",
+			"auth.expired",
+			"auth.human_required",
+			"remote.unavailable",
+			"contract.protocol_changed",
+			"internal.failure",
+		},
+		safety: safetyDefinition{
+			Kind:                 "local-mutation",
+			PlanRequired:         false,
+			ConfirmationRequired: false,
+		},
 	},
 	{
 		path:          "auth.status",
@@ -471,6 +496,57 @@ func Execute(ctx context.Context, request Request, dependencies Dependencies) Re
 					Retryable: false,
 					Details:   map[string]any{},
 				}, pretty)
+			case authLoginCommand:
+				if slices.Contains(request.Argv, "--non-interactive") ||
+					dependencies.Terminal == nil {
+					return privateTerminalRequiredFailure(definition.path, pretty)
+				}
+				if dependencies.CredentialsPathError != nil {
+					return configurationDirectoryFailure(definition.path, pretty)
+				}
+				now := time.Now()
+				if dependencies.Now != nil {
+					now = dependencies.Now()
+				}
+				state, err := auth.Login(
+					ctx,
+					dependencies.Files,
+					dependencies.CredentialsPath,
+					dependencies.Terminal,
+					now,
+					dependencies.AuthRandom,
+					remote.AuthClient{HTTP: dependencies.HTTP},
+				)
+				if err != nil {
+					if errors.Is(err, auth.ErrHumanRequired) {
+						return privateTerminalRequiredFailure(definition.path, pretty)
+					}
+					if errors.Is(err, auth.ErrInputInvalid) {
+						return authenticationInputInvalidFailure(definition.path, pretty)
+					}
+					if errors.Is(err, remote.ErrAuthCodeRejected) {
+						return authCodeRejectedFailure(definition.path, pretty)
+					}
+					if errors.Is(err, remote.ErrAuthExpired) {
+						return authenticationExpiredFailure(
+							definition.path,
+							"INVALID_CUSTOM_TOKEN",
+							"Authentication expired during login. Start login again.",
+							pretty,
+						)
+					}
+					if errors.Is(err, remote.ErrProtocolChanged) {
+						return authenticationProtocolChangedFailure(definition.path, pretty)
+					}
+					if errors.Is(err, remote.ErrUnavailable) {
+						return authenticationUnavailableFailure(definition.path, pretty)
+					}
+					if errors.Is(err, auth.ErrPersistence) {
+						return credentialUnavailableFailure(definition.path, pretty)
+					}
+					return internalFailure(definition.path, pretty)
+				}
+				return success(definition.path, state, pretty)
 			case authStatusCommand:
 				if dependencies.CredentialsPathError != nil {
 					return configurationDirectoryFailure(definition.path, pretty)
@@ -859,6 +935,78 @@ func configurationDirectoryFailure(command string, pretty bool) Result {
 		Details:   map[string]any{},
 	}, pretty)
 	result.Stderr = "partiful: local operation failed\n"
+	return result
+}
+
+func privateTerminalRequiredFailure(command string, pretty bool) Result {
+	result := failure(command, 3, errorBody{
+		Type:      "auth.human_required",
+		Code:      "PRIVATE_TERMINAL_REQUIRED",
+		Message:   "Authentication login requires a private terminal.",
+		Retryable: false,
+		Details:   map[string]any{},
+	}, pretty)
+	result.Stderr = "partiful: private terminal required\n"
+	return result
+}
+
+func authenticationInputInvalidFailure(command string, pretty bool) Result {
+	result := failure(command, 2, errorBody{
+		Type:      "input.invalid",
+		Code:      "AUTH_INPUT_INVALID",
+		Message:   "Authentication input is invalid.",
+		Retryable: false,
+		Details:   map[string]any{},
+	}, pretty)
+	result.Stderr = "partiful: authentication input invalid\n"
+	return result
+}
+
+func authCodeRejectedFailure(command string, pretty bool) Result {
+	result := failure(command, 2, errorBody{
+		Type:      "input.invalid",
+		Code:      "AUTH_CODE_REJECTED",
+		Message:   "The verification code was rejected.",
+		Retryable: false,
+		Details:   map[string]any{},
+	}, pretty)
+	result.Stderr = "partiful: authentication code rejected\n"
+	return result
+}
+
+func authenticationExpiredFailure(command, code, message string, pretty bool) Result {
+	result := failure(command, 3, errorBody{
+		Type:      "auth.expired",
+		Code:      code,
+		Message:   message,
+		Retryable: false,
+		Details:   map[string]any{},
+	}, pretty)
+	result.Stderr = "partiful: authentication expired\n"
+	return result
+}
+
+func authenticationProtocolChangedFailure(command string, pretty bool) Result {
+	result := failure(command, 9, errorBody{
+		Type:      "contract.protocol_changed",
+		Code:      "AUTH_PROTOCOL_CHANGED",
+		Message:   "Authentication no longer matches the reviewed remote contract.",
+		Retryable: false,
+		Details:   map[string]any{},
+	}, pretty)
+	result.Stderr = "partiful: authentication protocol changed\n"
+	return result
+}
+
+func authenticationUnavailableFailure(command string, pretty bool) Result {
+	result := failure(command, 8, errorBody{
+		Type:      "remote.unavailable",
+		Code:      "AUTH_SERVICE_UNAVAILABLE",
+		Message:   "The authentication service is unavailable.",
+		Retryable: true,
+		Details:   map[string]any{},
+	}, pretty)
+	result.Stderr = "partiful: authentication service unavailable\n"
 	return result
 }
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -15,7 +15,7 @@ import (
 const (
 	Version                 = "1.0.0"
 	ProductContractRevision = "2026-08-10.1"
-	RemoteContractRevision  = "2026-08-11.2"
+	RemoteContractRevision  = "2026-08-11.3"
 )
 
 type Request struct {

--- a/internal/app/execute_test.go
+++ b/internal/app/execute_test.go
@@ -1119,7 +1119,7 @@ func TestExecuteSchemaProjectsExecutableDefinition(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":true,"data":{"command":"auth.status","positionals":[],"flags":[],"inputSchema":{"type":"object","additionalProperties":false},"successSchema":{"type":"object","additionalProperties":false,"required":["authenticated","tokenState","expiresAt"],"properties":{"authenticated":{"type":"boolean"},"expiresAt":{"type":["string","null"],"format":"date-time"},"tokenState":{"type":"string","enum":["healthy","expiring","expired","missing"]}}},"failureTypes":["internal.failure"],"safety":{"kind":"read-only","planRequired":false,"confirmationRequired":false}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"command":"auth.status","positionals":[],"flags":[],"inputSchema":{"type":"object","additionalProperties":false},"successSchema":{"type":"object","additionalProperties":false,"required":["authenticated","tokenState","expiresAt"],"properties":{"authenticated":{"type":"boolean"},"expiresAt":{"type":["string","null"],"format":"date-time"},"tokenState":{"type":"string","enum":["healthy","expiring","expired","missing"]}}},"failureTypes":["auth.expired","remote.unavailable","contract.protocol_changed","internal.failure"],"safety":{"kind":"read-only","planRequired":false,"confirmationRequired":false}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -1802,6 +1802,171 @@ func TestExecuteAuthStatusReportsExpiringToken(t *testing.T) {
 	}
 	if result.Stderr != "" {
 		t.Fatalf("stderr = %q, want empty", result.Stderr)
+	}
+}
+
+func TestExecuteAuthStatusDeterministicallyRefreshesExpiringSession(t *testing.T) {
+	const (
+		oldAccessValue  = "old-access-private-value"
+		oldRefreshValue = "refresh/private+value"
+		newAccessValue  = "new-id-private-value"
+		newRefreshValue = "new-refresh-private-value"
+	)
+	const credentialsPath = "/config/partiful/credentials.json"
+	files := &memoryFilesystem{files: map[string][]byte{
+		credentialsPath: []byte(
+			`{"accessToken":"` + oldAccessValue +
+				`","refreshToken":"` + oldRefreshValue +
+				`","expiresAt":"2026-08-11T00:04:00Z"}`,
+		),
+	}}
+	terminal := &scriptedPrivateTerminal{values: []string{"must-not-be-read"}}
+	httpCalls := 0
+	dependencies := app.Dependencies{
+		Files:           files,
+		CredentialsPath: credentialsPath,
+		Terminal:        terminal,
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+		HTTP: scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+			httpCalls++
+			body, err := io.ReadAll(request.Body)
+			if err != nil {
+				t.Fatalf("read refresh request: %v", err)
+			}
+			if request.Method != http.MethodPost ||
+				request.URL.Scheme != "https" ||
+				request.URL.Host != "securetoken.googleapis.com" ||
+				request.URL.Path != "/v1/token" ||
+				request.URL.Query().Get("key") == "" {
+				t.Fatalf("refresh request URL = %q, want reviewed endpoint", request.URL)
+			}
+			if request.Header.Get("Content-Type") != "application/x-www-form-urlencoded" ||
+				request.Header.Get("Origin") != "https://partiful.com" ||
+				request.Header.Get("Referer") != "https://partiful.com/" {
+				t.Fatalf("refresh headers = %#v, want reviewed browser origin", request.Header)
+			}
+			const wantBody = "grant_type=refresh_token&refresh_token=refresh%2Fprivate%2Bvalue"
+			if string(body) != wantBody {
+				t.Fatalf("refresh body = %q, want %q", body, wantBody)
+			}
+			return jsonResponse(
+				http.StatusOK,
+				`{"access_token":"private-access-alias","id_token":"`+newAccessValue+`","refresh_token":"`+newRefreshValue+`","expires_in":"3600","token_type":"Bearer","project_id":"private-project","user_id":"private-user"}`,
+			), nil
+		}},
+	}
+
+	first := app.Execute(context.Background(), app.Request{
+		Argv: []string{"auth", "status"},
+	}, dependencies)
+	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T01:00:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2","warnings":[]}}` + "\n"
+	if first.ExitCode != 0 || first.Stdout != want || first.Stderr != "" {
+		t.Fatalf("first status = %#v, want refreshed healthy session", first)
+	}
+	if httpCalls != 1 || files.atomicWrites != 1 {
+		t.Fatalf("refresh calls = %d, atomic writes = %d, want one each", httpCalls, files.atomicWrites)
+	}
+	if len(terminal.prompts) != 0 {
+		t.Fatalf("session refresh prompted: %#v", terminal.prompts)
+	}
+	for _, privateValue := range []string{
+		oldAccessValue,
+		oldRefreshValue,
+		newAccessValue,
+		newRefreshValue,
+		"private-access-alias",
+		"private-project",
+		"private-user",
+	} {
+		if strings.Contains(first.Stdout+first.Stderr, privateValue) {
+			t.Fatalf("refresh output contains private value %q", privateValue)
+		}
+	}
+
+	second := app.Execute(context.Background(), app.Request{
+		Argv: []string{"auth", "status"},
+	}, dependencies)
+	if second.ExitCode != 0 || second.Stdout != want {
+		t.Fatalf("second status = %#v, want persisted healthy session", second)
+	}
+	if httpCalls != 1 || files.atomicWrites != 1 {
+		t.Fatalf("second status repeated refresh: calls = %d, writes = %d", httpCalls, files.atomicWrites)
+	}
+}
+
+func TestExecuteAuthStatusMapsReviewedInvalidRefreshTokenToExpired(t *testing.T) {
+	const (
+		privateRefreshValue = "expired-private-refresh-value"
+		privateRemoteValue  = "private invalid refresh"
+	)
+	result := app.Execute(context.Background(), app.Request{
+		Argv: []string{"auth", "status"},
+	}, app.Dependencies{
+		Files: fakeFilesystem{
+			readFile: func(string) ([]byte, error) {
+				return []byte(
+					`{"accessToken":"expired-private-access","refreshToken":"` +
+						privateRefreshValue +
+						`","expiresAt":"2026-08-10T23:59:00Z"}`,
+				), nil
+			},
+		},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+		HTTP: scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
+			return jsonResponse(
+				http.StatusBadRequest,
+				`{"error":{"code":400,"message":"`+privateRemoteValue+`","status":"INVALID_ARGUMENT"}}`,
+			), nil
+		}},
+	})
+
+	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"INVALID_REFRESH_TOKEN","message":"Stored authentication has expired. Log in again.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
+	const wantStderr = "partiful: authentication expired\n"
+	if result.ExitCode != 3 || result.Stdout != wantStdout || result.Stderr != wantStderr {
+		t.Fatalf("result = %#v, want reviewed invalid-refresh failure", result)
+	}
+	for _, privateValue := range []string{privateRefreshValue, privateRemoteValue} {
+		if strings.Contains(result.Stdout+result.Stderr, privateValue) {
+			t.Fatalf("invalid-refresh output contains private value %q", privateValue)
+		}
+	}
+}
+
+func TestExecuteAuthStatusFailsClosedOnMalformedRefreshSuccess(t *testing.T) {
+	const privateValue = "private-refreshed-id-token"
+	result := app.Execute(context.Background(), app.Request{
+		Argv: []string{"auth", "status"},
+	}, app.Dependencies{
+		Files: fakeFilesystem{
+			readFile: func(string) ([]byte, error) {
+				return []byte(
+					`{"accessToken":"expired-private-access","refreshToken":"refresh-private-value","expiresAt":"2026-08-10T23:59:00Z"}`,
+				), nil
+			},
+		},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+		HTTP: scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
+			return jsonResponse(
+				http.StatusOK,
+				`{"access_token":"private-access","id_token":"`+privateValue+`","refresh_token":"private-refresh","expires_in":"3600"}`,
+			), nil
+		}},
+	})
+
+	if result.ExitCode != 9 ||
+		!strings.Contains(result.Stdout, `"code":"AUTH_PROTOCOL_CHANGED"`) {
+		t.Fatalf("result = %#v, want malformed refresh to fail closed", result)
+	}
+	if strings.Contains(result.Stdout+result.Stderr, privateValue) {
+		t.Fatal("malformed refresh failure exposed a credential value")
 	}
 }
 

--- a/internal/app/execute_test.go
+++ b/internal/app/execute_test.go
@@ -1323,6 +1323,7 @@ func TestExecuteAuthLoginPersistsReviewedSessionWithoutRevealingPrivateValues(t 
 	terminal := &scriptedPrivateTerminal{values: []string{phone, code}}
 	files := &memoryFilesystem{files: map[string][]byte{}}
 	call := 0
+	clockCalls := 0
 	result := app.Execute(context.Background(), app.Request{
 		Argv:  []string{"auth", "login"},
 		Stdin: strings.NewReader("ordinary-private-input"),
@@ -1330,6 +1331,10 @@ func TestExecuteAuthLoginPersistsReviewedSessionWithoutRevealingPrivateValues(t 
 		Files:           files,
 		CredentialsPath: "/config/partiful/credentials.json",
 		Now: func() time.Time {
+			clockCalls++
+			if clockCalls > 1 {
+				return time.Date(2026, time.August, 11, 0, 10, 0, 0, time.UTC)
+			}
 			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
 		},
 		AuthRandom: strings.NewReader("0123456789abcdef"),
@@ -1399,12 +1404,15 @@ func TestExecuteAuthLoginPersistsReviewedSessionWithoutRevealingPrivateValues(t 
 		}},
 	})
 
-	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T01:00:00Z"},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T01:10:00Z"},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want redacted login success", result)
 	}
 	if call != 3 {
 		t.Fatalf("HTTP calls = %d, want 3", call)
+	}
+	if clockCalls != 2 {
+		t.Fatalf("clock calls = %d, want request and completion timestamps", clockCalls)
 	}
 	if files.atomicWrites != 1 {
 		t.Fatalf("atomic writes = %d, want 1", files.atomicWrites)
@@ -1528,6 +1536,7 @@ func TestExecuteAuthLoginRejectsOversizedSendAcknowledgement(t *testing.T) {
 		HTTP: scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
 			return &http.Response{
 				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": {"application/json"}},
 				Body: io.NopCloser(
 					io.MultiReader(
 						strings.NewReader("{}"),
@@ -1621,7 +1630,7 @@ func TestExecuteAuthLoginRejectsInvalidOptionalFirebaseSuccessField(t *testing.T
 	}
 }
 
-func TestExecuteAuthLoginAllowsUndeclaredFirebaseErrorField(t *testing.T) {
+func TestExecuteAuthLoginAllowsUndeclaredFirebaseErrorStatus(t *testing.T) {
 	call := 0
 	result := app.Execute(context.Background(), app.Request{
 		Argv: []string{"auth", "login"},
@@ -2014,11 +2023,16 @@ func TestExecuteAuthStatusDeterministicallyRefreshesExpiringSession(t *testing.T
 	}}
 	terminal := &scriptedPrivateTerminal{values: []string{"must-not-be-read"}}
 	httpCalls := 0
+	clockCalls := 0
 	dependencies := app.Dependencies{
 		Files:           files,
 		CredentialsPath: credentialsPath,
 		Terminal:        terminal,
 		Now: func() time.Time {
+			clockCalls++
+			if clockCalls > 1 {
+				return time.Date(2026, time.August, 11, 0, 10, 0, 0, time.UTC)
+			}
 			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
 		},
 		HTTP: scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
@@ -2055,12 +2069,15 @@ func TestExecuteAuthStatusDeterministicallyRefreshesExpiringSession(t *testing.T
 	first := app.Execute(context.Background(), app.Request{
 		Argv: []string{"auth", "status"},
 	}, dependencies)
-	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T01:00:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T01:10:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[]}}` + "\n"
 	if first.ExitCode != 0 || first.Stdout != want || first.Stderr != "" {
 		t.Fatalf("first status = %#v, want refreshed healthy session", first)
 	}
 	if httpCalls != 1 || files.atomicWrites != 1 {
 		t.Fatalf("refresh calls = %d, atomic writes = %d, want one each", httpCalls, files.atomicWrites)
+	}
+	if clockCalls != 2 {
+		t.Fatalf("clock calls = %d, want state and refresh completion timestamps", clockCalls)
 	}
 	if len(terminal.prompts) != 0 {
 		t.Fatalf("session refresh prompted: %#v", terminal.prompts)

--- a/internal/app/execute_test.go
+++ b/internal/app/execute_test.go
@@ -1485,6 +1485,64 @@ func TestExecuteAuthLoginMapsReviewedWrongCodeWithoutEchoingIt(t *testing.T) {
 	}
 }
 
+func TestExecuteAuthLoginRejectsInvalidOptionalCallableErrorField(t *testing.T) {
+	call := 0
+	result := app.Execute(context.Background(), app.Request{
+		Argv: []string{"auth", "login"},
+	}, app.Dependencies{
+		Files:           &memoryFilesystem{files: map[string][]byte{}},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Terminal:        &scriptedPrivateTerminal{values: []string{"+15555550123", "123456"}},
+		AuthRandom:      strings.NewReader("0123456789abcdef"),
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+		HTTP: scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
+			call++
+			if call == 1 {
+				return jsonResponse(http.StatusOK, `{}`), nil
+			}
+			return jsonResponse(
+				http.StatusForbidden,
+				`{"error":{"message":"rejected","status":"PERMISSION_DENIED","details":{"authErrorCode":123}}}`,
+			), nil
+		}},
+	})
+	if result.ExitCode != 9 ||
+		!strings.Contains(result.Stdout, `"code":"AUTH_PROTOCOL_CHANGED"`) {
+		t.Fatalf("result = %#v, want invalid optional callable field to fail closed", result)
+	}
+}
+
+func TestExecuteAuthLoginRejectsOversizedSendAcknowledgement(t *testing.T) {
+	result := app.Execute(context.Background(), app.Request{
+		Argv: []string{"auth", "login"},
+	}, app.Dependencies{
+		Files:           &memoryFilesystem{files: map[string][]byte{}},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Terminal:        &scriptedPrivateTerminal{values: []string{"+15555550123"}},
+		AuthRandom:      strings.NewReader("0123456789abcdef"),
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+		HTTP: scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body: io.NopCloser(
+					io.MultiReader(
+						strings.NewReader("{}"),
+						strings.NewReader(strings.Repeat(" ", (64<<10)-1)),
+					),
+				),
+			}, nil
+		}},
+	})
+	if result.ExitCode != 9 ||
+		!strings.Contains(result.Stdout, `"code":"AUTH_PROTOCOL_CHANGED"`) {
+		t.Fatalf("result = %#v, want oversized send acknowledgement to fail closed", result)
+	}
+}
+
 func TestExecuteAuthLoginMapsRejectedCustomTokenToExpired(t *testing.T) {
 	terminal := &scriptedPrivateTerminal{values: []string{"+15555550123", "123456"}}
 	call := 0
@@ -1524,6 +1582,78 @@ func TestExecuteAuthLoginMapsRejectedCustomTokenToExpired(t *testing.T) {
 	}
 	if strings.Contains(result.Stdout+result.Stderr, "private") {
 		t.Fatal("custom-token failure exposed a remote response value")
+	}
+}
+
+func TestExecuteAuthLoginRejectsInvalidOptionalFirebaseSuccessField(t *testing.T) {
+	call := 0
+	result := app.Execute(context.Background(), app.Request{
+		Argv: []string{"auth", "login"},
+	}, app.Dependencies{
+		Files:           &memoryFilesystem{files: map[string][]byte{}},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Terminal:        &scriptedPrivateTerminal{values: []string{"+15555550123", "123456"}},
+		AuthRandom:      strings.NewReader("0123456789abcdef"),
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+		HTTP: scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
+			call++
+			switch call {
+			case 1:
+				return jsonResponse(http.StatusOK, `{}`), nil
+			case 2:
+				return jsonResponse(
+					http.StatusOK,
+					`{"result":{"data":{"token":"custom-private-token"}}}`,
+				), nil
+			default:
+				return jsonResponse(
+					http.StatusOK,
+					`{"idToken":"private-id-token","refreshToken":"private-refresh","expiresIn":"3600","kind":123}`,
+				), nil
+			}
+		}},
+	})
+	if result.ExitCode != 9 ||
+		!strings.Contains(result.Stdout, `"code":"AUTH_PROTOCOL_CHANGED"`) {
+		t.Fatalf("result = %#v, want invalid optional Firebase field to fail closed", result)
+	}
+}
+
+func TestExecuteAuthLoginRejectsInvalidOptionalFirebaseErrorField(t *testing.T) {
+	call := 0
+	result := app.Execute(context.Background(), app.Request{
+		Argv: []string{"auth", "login"},
+	}, app.Dependencies{
+		Files:           &memoryFilesystem{files: map[string][]byte{}},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Terminal:        &scriptedPrivateTerminal{values: []string{"+15555550123", "123456"}},
+		AuthRandom:      strings.NewReader("0123456789abcdef"),
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+		HTTP: scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
+			call++
+			switch call {
+			case 1:
+				return jsonResponse(http.StatusOK, `{}`), nil
+			case 2:
+				return jsonResponse(
+					http.StatusOK,
+					`{"result":{"data":{"token":"custom-private-token"}}}`,
+				), nil
+			default:
+				return jsonResponse(
+					http.StatusBadRequest,
+					`{"error":{"code":400,"message":"invalid token","status":123}}`,
+				), nil
+			}
+		}},
+	})
+	if result.ExitCode != 9 ||
+		!strings.Contains(result.Stdout, `"code":"AUTH_PROTOCOL_CHANGED"`) {
+		t.Fatalf("result = %#v, want invalid optional Firebase error field to fail closed", result)
 	}
 }
 
@@ -2065,10 +2195,39 @@ func TestExecuteAuthStatusMapsReviewedInvalidRefreshTokenToExpired(t *testing.T)
 	if result.ExitCode != 3 || result.Stdout != wantStdout || result.Stderr != wantStderr {
 		t.Fatalf("result = %#v, want reviewed invalid-refresh failure", result)
 	}
+
 	for _, privateValue := range []string{privateRefreshValue, privateRemoteValue} {
 		if strings.Contains(result.Stdout+result.Stderr, privateValue) {
 			t.Fatalf("invalid-refresh output contains private value %q", privateValue)
 		}
+	}
+}
+
+func TestExecuteAuthStatusRejectsInvalidOptionalRefreshField(t *testing.T) {
+	result := app.Execute(context.Background(), app.Request{
+		Argv: []string{"auth", "status"},
+	}, app.Dependencies{
+		Files: fakeFilesystem{
+			readFile: func(string) ([]byte, error) {
+				return []byte(
+					`{"accessToken":"private-access","refreshToken":"private-refresh","expiresAt":"2026-08-11T00:04:00Z"}`,
+				), nil
+			},
+		},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+		HTTP: scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
+			return jsonResponse(
+				http.StatusOK,
+				`{"access_token":"private-access","id_token":"private-id","refresh_token":"private-refresh","expires_in":"3600","token_type":"Bearer","user_id":123}`,
+			), nil
+		}},
+	})
+	if result.ExitCode != 9 ||
+		!strings.Contains(result.Stdout, `"code":"AUTH_PROTOCOL_CHANGED"`) {
+		t.Fatalf("result = %#v, want invalid optional refresh field to fail closed", result)
 	}
 }
 

--- a/internal/app/execute_test.go
+++ b/internal/app/execute_test.go
@@ -25,6 +25,18 @@ type scriptedHTTP struct {
 	do func(*http.Request) (*http.Response, error)
 }
 
+type failingReadCloser struct {
+	err error
+}
+
+func (reader failingReadCloser) Read([]byte) (int, error) {
+	return 0, reader.err
+}
+
+func (failingReadCloser) Close() error {
+	return nil
+}
+
 type scriptedRoundTripper struct {
 	roundTrip func(*http.Request) (*http.Response, error)
 }
@@ -1516,6 +1528,40 @@ func TestExecuteAuthLoginMapsReviewedWrongCodeWithoutEchoingIt(t *testing.T) {
 		if strings.Contains(result.Stdout+result.Stderr, privateValue) {
 			t.Fatalf("failure output contains private value %q", privateValue)
 		}
+	}
+}
+
+func TestExecuteAuthLoginPreservesErrorResponseReadFailure(t *testing.T) {
+	const privateReadError = "private response read failure"
+	call := 0
+	result := app.Execute(context.Background(), app.Request{
+		Argv: []string{"auth", "login"},
+	}, app.Dependencies{
+		Files:           &memoryFilesystem{files: map[string][]byte{}},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Terminal:        &scriptedPrivateTerminal{values: []string{"+15555550123", "123456"}},
+		AuthRandom:      strings.NewReader("0123456789abcdef"),
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+		HTTP: scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
+			call++
+			if call == 1 {
+				return jsonResponse(http.StatusOK, `{}`), nil
+			}
+			return &http.Response{
+				StatusCode: http.StatusForbidden,
+				Header:     http.Header{"Content-Type": {"application/json"}},
+				Body:       failingReadCloser{err: errors.New(privateReadError)},
+			}, nil
+		}},
+	})
+	if result.ExitCode != 8 ||
+		!strings.Contains(result.Stdout, `"code":"AUTH_SERVICE_UNAVAILABLE"`) {
+		t.Fatalf("result = %#v, want response read failure to stay unavailable", result)
+	}
+	if strings.Contains(result.Stdout+result.Stderr, privateReadError) {
+		t.Fatal("response read failure leaked private detail")
 	}
 }
 

--- a/internal/app/execute_test.go
+++ b/internal/app/execute_test.go
@@ -1312,6 +1312,32 @@ func (terminal *scriptedPrivateTerminal) ReadSecret(prompt string) (string, erro
 	return value, nil
 }
 
+type failingPrivateTerminal struct {
+	err error
+}
+
+func (terminal failingPrivateTerminal) ReadSecret(string) (string, error) {
+	return "", terminal.err
+}
+
+func TestExecuteAuthLoginPreservesPrivateTerminalValidationFailure(t *testing.T) {
+	result := app.Execute(context.Background(), app.Request{
+		Argv: []string{"auth", "login"},
+	}, app.Dependencies{
+		Files:           &memoryFilesystem{files: map[string][]byte{}},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Terminal:        failingPrivateTerminal{err: auth.ErrInputInvalid},
+		AuthRandom:      strings.NewReader("0123456789abcdef"),
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+	})
+	if result.ExitCode != 2 ||
+		!strings.Contains(result.Stdout, `"code":"AUTH_INPUT_INVALID"`) {
+		t.Fatalf("result = %#v, want private terminal validation failure", result)
+	}
+}
+
 func TestExecuteAuthLoginPersistsReviewedSessionWithoutRevealingPrivateValues(t *testing.T) {
 	const (
 		phone        = "+15555550123"

--- a/internal/app/execute_test.go
+++ b/internal/app/execute_test.go
@@ -1702,6 +1702,42 @@ func TestExecuteAuthLoginRejectsInvalidOptionalFirebaseSuccessField(t *testing.T
 	}
 }
 
+func TestExecuteAuthLoginRejectsTokenInsideRefreshWindow(t *testing.T) {
+	call := 0
+	result := app.Execute(context.Background(), app.Request{
+		Argv: []string{"auth", "login"},
+	}, app.Dependencies{
+		Files:           &memoryFilesystem{files: map[string][]byte{}},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Terminal:        &scriptedPrivateTerminal{values: []string{"+15555550123", "123456"}},
+		AuthRandom:      strings.NewReader("0123456789abcdef"),
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+		HTTP: scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
+			call++
+			switch call {
+			case 1:
+				return jsonResponse(http.StatusOK, `{}`), nil
+			case 2:
+				return jsonResponse(
+					http.StatusOK,
+					`{"result":{"data":{"token":"custom-private-token"}}}`,
+				), nil
+			default:
+				return jsonResponse(
+					http.StatusOK,
+					`{"idToken":"private-id-token","refreshToken":"private-refresh","expiresIn":"300"}`,
+				), nil
+			}
+		}},
+	})
+	if result.ExitCode != 9 ||
+		!strings.Contains(result.Stdout, `"code":"AUTH_PROTOCOL_CHANGED"`) {
+		t.Fatalf("result = %#v, want short token lifetime to fail closed", result)
+	}
+}
+
 func TestExecuteAuthLoginAllowsUndeclaredFirebaseErrorStatus(t *testing.T) {
 	call := 0
 	result := app.Execute(context.Background(), app.Request{
@@ -2353,6 +2389,34 @@ func TestExecuteAuthStatusRejectsInvalidOptionalRefreshField(t *testing.T) {
 	if result.ExitCode != 9 ||
 		!strings.Contains(result.Stdout, `"code":"AUTH_PROTOCOL_CHANGED"`) {
 		t.Fatalf("result = %#v, want invalid optional refresh field to fail closed", result)
+	}
+}
+
+func TestExecuteAuthStatusRejectsRefreshedTokenInsideRefreshWindow(t *testing.T) {
+	result := app.Execute(context.Background(), app.Request{
+		Argv: []string{"auth", "status"},
+	}, app.Dependencies{
+		Files: fakeFilesystem{
+			readFile: func(string) ([]byte, error) {
+				return []byte(
+					`{"accessToken":"private-access","refreshToken":"private-refresh","expiresAt":"2026-08-11T00:04:00Z"}`,
+				), nil
+			},
+		},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+		HTTP: scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
+			return jsonResponse(
+				http.StatusOK,
+				`{"access_token":"private-access","id_token":"private-id","refresh_token":"private-refresh","expires_in":"300","token_type":"Bearer"}`,
+			), nil
+		}},
+	})
+	if result.ExitCode != 9 ||
+		!strings.Contains(result.Stdout, `"code":"AUTH_PROTOCOL_CHANGED"`) {
+		t.Fatalf("result = %#v, want short refreshed lifetime to fail closed", result)
 	}
 }
 

--- a/internal/app/execute_test.go
+++ b/internal/app/execute_test.go
@@ -65,7 +65,7 @@ func TestExecutePostersListReturnsFirstLocalPage(t *testing.T) {
 		}},
 	}))
 
-	const want = `{"ok":true,"data":{"items":[{"posterId":"first","name":"First","url":"https://example.invalid/first.png","contentType":"image/png","width":1200,"height":630,"tags":["party"],"categories":["fun"]},{"posterId":"duplicate","name":"Duplicate","url":"https://example.invalid/duplicate.gif","contentType":"image/gif","width":null,"height":null,"tags":["dance"],"categories":[]},{"posterId":"duplicate","name":"Duplicate Again","url":"https://example.invalid/duplicate-2.gif","contentType":"image/gif","width":640,"height":480,"tags":[],"categories":["night"]}]},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
+	const want = `{"ok":true,"data":{"items":[{"posterId":"first","name":"First","url":"https://example.invalid/first.png","contentType":"image/png","width":1200,"height":630,"tags":["party"],"categories":["fun"]},{"posterId":"duplicate","name":"Duplicate","url":"https://example.invalid/duplicate.gif","contentType":"image/gif","width":null,"height":null,"tags":["dance"],"categories":[]},{"posterId":"duplicate","name":"Duplicate Again","url":"https://example.invalid/duplicate-2.gif","contentType":"image/gif","width":640,"height":480,"tags":[],"categories":["night"]}]},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -471,7 +471,7 @@ func TestExecutePostersListRejectsCursorWhenPayloadChanges(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, dependencies)
 
-	const want = `{"ok":false,"error":{"type":"state.conflict","code":"CURSOR_SNAPSHOT_CHANGED","message":"The poster catalog changed after this cursor was issued.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"state.conflict","code":"CURSOR_SNAPSHOT_CHANGED","message":"The poster catalog changed after this cursor was issued.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
 	if result.ExitCode != 6 {
 		t.Fatalf("exit code = %d, want 6", result.ExitCode)
 	}
@@ -613,7 +613,7 @@ func TestExecutePostersListRejectsUnexpectedSuccessContentType(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
 	const wantStderr = "partiful: poster catalog protocol changed\n"
 	if result.ExitCode != 9 {
 		t.Fatalf("exit code = %d, want 9", result.ExitCode)
@@ -639,7 +639,7 @@ func TestExecutePostersListRejectsMalformedCursorBeforeRemoteFailure(t *testing.
 		}},
 	}))
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_INVALID","message":"The cursor is malformed.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_INVALID","message":"The cursor is malformed.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -694,7 +694,7 @@ func TestExecutePostersSearchRejectsCursorWithDifferentNormalizedFilter(t *testi
 		Stdin: strings.NewReader(""),
 	}, dependencies)
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_FILTER_MISMATCH","message":"The cursor does not match this command and filters.","retryable":false,"details":{}},"meta":{"command":"posters.search","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_FILTER_MISMATCH","message":"The cursor does not match this command and filters.","retryable":false,"details":{}},"meta":{"command":"posters.search","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -717,7 +717,7 @@ func TestExecutePostersListMapsNetworkFailureToRemoteUnavailable(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"remote.unavailable","code":"POSTER_CATALOG_UNAVAILABLE","message":"The poster catalog is unavailable.","retryable":true,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"remote.unavailable","code":"POSTER_CATALOG_UNAVAILABLE","message":"The poster catalog is unavailable.","retryable":true,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
 	const wantStderr = "partiful: poster catalog unavailable\n"
 	if result.ExitCode != 8 {
 		t.Fatalf("exit code = %d, want 8", result.ExitCode)
@@ -747,7 +747,7 @@ func TestExecutePostersListFailsClosedOnReceivedNon200(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
 	const wantStderr = "partiful: poster catalog protocol changed\n"
 	if result.ExitCode != 9 {
 		t.Fatalf("exit code = %d, want 9", result.ExitCode)
@@ -825,7 +825,7 @@ func TestExecutePostersListFailsClosedOnMalformed200Body(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
 	if result.ExitCode != 9 {
 		t.Fatalf("exit code = %d, want 9", result.ExitCode)
 	}
@@ -890,7 +890,7 @@ func TestExecutePostersListRequiresMaxItemsWithAll(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"MAX_ITEMS_REQUIRED","message":"--all requires --max-items.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"MAX_ITEMS_REQUIRED","message":"--all requires --max-items.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -912,7 +912,7 @@ func TestExecutePostersListRejectsLimitWithAll(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"LIMIT_WITH_ALL","message":"--limit cannot be combined with --all.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"LIMIT_WITH_ALL","message":"--limit cannot be combined with --all.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -930,7 +930,7 @@ func TestExecutePostersListRejectsLimitAboveMaximum(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"LIMIT_INVALID","message":"Limit must be an integer from 1 to 100.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"LIMIT_INVALID","message":"Limit must be an integer from 1 to 100.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -945,7 +945,7 @@ func TestExecutePostersListRejectsEmptyCursor(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_INVALID","message":"The cursor is malformed.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_INVALID","message":"The cursor is malformed.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -963,7 +963,7 @@ func TestExecutePostersSearchRequiresNonEmptyQuery(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"QUERY_REQUIRED","message":"Search query must not be empty.","retryable":false,"details":{}},"meta":{"command":"posters.search","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"QUERY_REQUIRED","message":"Search query must not be empty.","retryable":false,"details":{}},"meta":{"command":"posters.search","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -978,7 +978,7 @@ func TestExecuteVersion(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":true,"data":{"version":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"},"meta":{"command":"version","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"version":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"},"meta":{"command":"version","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -996,7 +996,7 @@ func TestExecuteRejectsUnknownCommand(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_NOT_FOUND","message":"Unknown command.","retryable":false,"details":{}},"meta":{"command":"unknown","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_NOT_FOUND","message":"Unknown command.","retryable":false,"details":{}},"meta":{"command":"unknown","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -1019,13 +1019,13 @@ func TestExecutePrettyPrintsOneCompleteEnvelope(t *testing.T) {
   "data": {
     "version": "1.0.0",
     "productContractRevision": "2026-08-10.1",
-    "remoteContractRevision": "2026-08-11.3"
+    "remoteContractRevision": "2026-08-11.4"
   },
   "meta": {
     "command": "version",
     "cliVersion": "1.0.0",
     "productContractRevision": "2026-08-10.1",
-    "remoteContractRevision": "2026-08-11.3",
+    "remoteContractRevision": "2026-08-11.4",
     "warnings": []
   }
 }
@@ -1047,7 +1047,7 @@ func TestExecuteAcceptsNonInteractiveGlobalFlag(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":true,"data":{"version":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"},"meta":{"command":"version","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"version":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"},"meta":{"command":"version","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -1080,7 +1080,7 @@ func TestExecuteRejectsRepeatedScalarFlag(t *testing.T) {
     "command": "version",
     "cliVersion": "1.0.0",
     "productContractRevision": "2026-08-10.1",
-    "remoteContractRevision": "2026-08-11.3"
+    "remoteContractRevision": "2026-08-11.4"
   }
 }
 `
@@ -1101,7 +1101,7 @@ func TestExecuteSchemaListsOnlyCompletedCatalog(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":true,"data":{"commands":["auth.login","auth.logout","auth.status","doctor","posters.list","posters.search","schema","version"]},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"commands":["auth.login","auth.logout","auth.status","doctor","posters.list","posters.search","schema","version"]},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -1119,7 +1119,7 @@ func TestExecuteSchemaProjectsExecutableDefinition(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":true,"data":{"command":"auth.status","positionals":[],"flags":[],"inputSchema":{"type":"object","additionalProperties":false},"successSchema":{"type":"object","additionalProperties":false,"required":["authenticated","tokenState","expiresAt"],"properties":{"authenticated":{"type":"boolean"},"expiresAt":{"type":["string","null"],"format":"date-time"},"tokenState":{"type":"string","enum":["healthy","expiring","expired","missing"]}}},"failureTypes":["auth.expired","remote.unavailable","contract.protocol_changed","internal.failure"],"safety":{"kind":"read-only","planRequired":false,"confirmationRequired":false}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"command":"auth.status","positionals":[],"flags":[],"inputSchema":{"type":"object","additionalProperties":false},"successSchema":{"type":"object","additionalProperties":false,"required":["authenticated","tokenState","expiresAt"],"properties":{"authenticated":{"type":"boolean"},"expiresAt":{"type":["string","null"],"format":"date-time"},"tokenState":{"type":"string","enum":["healthy","expiring","expired","missing"]}}},"failureTypes":["auth.expired","remote.unavailable","contract.protocol_changed","internal.failure"],"safety":{"kind":"read-only","planRequired":false,"confirmationRequired":false}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -1176,7 +1176,7 @@ func TestExecuteRejectsUnknownSchemaPathWithoutEchoingInput(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_SCHEMA_NOT_FOUND","message":"No completed command has that schema path.","retryable":false,"details":{}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_SCHEMA_NOT_FOUND","message":"No completed command has that schema path.","retryable":false,"details":{}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -1207,7 +1207,7 @@ func TestExecuteAuthStatusWhenCredentialsAreMissing(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"missing","expiresAt":null},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"missing","expiresAt":null},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -1225,7 +1225,7 @@ func TestExecuteAuthLoginRequiresPrivateTerminal(t *testing.T) {
 		Stdin: strings.NewReader("private-stdin-value"),
 	}, app.Dependencies{})
 
-	const wantStdout = `{"ok":false,"error":{"type":"auth.human_required","code":"PRIVATE_TERMINAL_REQUIRED","message":"Authentication login requires a private terminal.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"auth.human_required","code":"PRIVATE_TERMINAL_REQUIRED","message":"Authentication login requires a private terminal.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
 	const wantStderr = "partiful: private terminal required\n"
 	if result.ExitCode != 3 {
 		t.Fatalf("exit code = %d, want 3", result.ExitCode)
@@ -1284,7 +1284,7 @@ func TestExecuteAuthLoginRejectsEmptyPrivateInputBeforeHTTP(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"input.invalid","code":"AUTH_INPUT_INVALID","message":"Authentication input is invalid.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"input.invalid","code":"AUTH_INPUT_INVALID","message":"Authentication input is invalid.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
 	if result.ExitCode != 2 || result.Stdout != wantStdout {
 		t.Fatalf("result = %#v, want invalid private input failure", result)
 	}
@@ -1341,10 +1341,11 @@ func TestExecuteAuthLoginPersistsReviewedSessionWithoutRevealingPrivateValues(t 
 			}
 			switch call {
 			case 1:
-				if request.Header.Get("Content-Type") != "application/json" ||
-					request.Header.Get("Origin") != "https://partiful.com" ||
-					request.Header.Get("Referer") != "https://partiful.com/" {
-					t.Fatalf("callable headers = %#v, want Origin+Referer", request.Header)
+				if request.Header.Get("Content-Type") != "application/json" {
+					t.Fatalf("callable Content-Type = %q, want application/json", request.Header.Get("Content-Type"))
+				}
+				if request.Header.Get("Origin") != "" || request.Header.Get("Referer") != "" {
+					t.Fatalf("callable headers = %#v, want no uncontracted Origin or Referer", request.Header)
 				}
 				if request.URL.String() != "https://api.partiful.com/sendAuthCodeTrusted" {
 					t.Fatalf("send URL = %q", request.URL)
@@ -1355,10 +1356,11 @@ func TestExecuteAuthLoginPersistsReviewedSessionWithoutRevealingPrivateValues(t 
 				}
 				return jsonResponse(http.StatusOK, `{}`), nil
 			case 2:
-				if request.Header.Get("Content-Type") != "application/json" ||
-					request.Header.Get("Origin") != "https://partiful.com" ||
-					request.Header.Get("Referer") != "https://partiful.com/" {
-					t.Fatalf("callable headers = %#v, want Origin+Referer", request.Header)
+				if request.Header.Get("Content-Type") != "application/json" {
+					t.Fatalf("callable Content-Type = %q, want application/json", request.Header.Get("Content-Type"))
+				}
+				if request.Header.Get("Origin") != "" || request.Header.Get("Referer") != "" {
+					t.Fatalf("callable headers = %#v, want no uncontracted Origin or Referer", request.Header)
 				}
 				if request.URL.String() != "https://api.partiful.com/getLoginToken" {
 					t.Fatalf("login token URL = %q", request.URL)
@@ -1393,7 +1395,7 @@ func TestExecuteAuthLoginPersistsReviewedSessionWithoutRevealingPrivateValues(t 
 		}},
 	})
 
-	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T01:00:00Z"},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T01:00:00Z"},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want redacted login success", result)
 	}
@@ -1463,7 +1465,7 @@ func TestExecuteAuthLoginMapsReviewedWrongCodeWithoutEchoingIt(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"input.invalid","code":"AUTH_CODE_REJECTED","message":"The verification code was rejected.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"input.invalid","code":"AUTH_CODE_REJECTED","message":"The verification code was rejected.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
 	const wantStderr = "partiful: authentication code rejected\n"
 	if result.ExitCode != 2 || result.Stdout != wantStdout || result.Stderr != wantStderr {
 		t.Fatalf("result = %#v, want reviewed wrong-code failure", result)
@@ -1511,7 +1513,7 @@ func TestExecuteAuthLoginMapsRejectedCustomTokenToExpired(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"INVALID_CUSTOM_TOKEN","message":"Authentication expired during login. Start login again.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"INVALID_CUSTOM_TOKEN","message":"Authentication expired during login. Start login again.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
 	const wantStderr = "partiful: authentication expired\n"
 	if result.ExitCode != 3 || result.Stdout != wantStdout || result.Stderr != wantStderr {
 		t.Fatalf("result = %#v, want reviewed custom-token failure", result)
@@ -1554,7 +1556,7 @@ func TestExecuteAuthLoginFailsClosedOnMalformedReviewedSuccess(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"AUTH_PROTOCOL_CHANGED","message":"Authentication no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"AUTH_PROTOCOL_CHANGED","message":"Authentication no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
 	const wantStderr = "partiful: authentication protocol changed\n"
 	if result.ExitCode != 9 || result.Stdout != wantStdout || result.Stderr != wantStderr {
 		t.Fatalf("result = %#v, want protocol drift failure", result)
@@ -1651,7 +1653,7 @@ func TestExecuteAuthLoginMapsNoResponseWithoutLeakingTransportError(t *testing.T
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"remote.unavailable","code":"AUTH_SERVICE_UNAVAILABLE","message":"The authentication service is unavailable.","retryable":true,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"remote.unavailable","code":"AUTH_SERVICE_UNAVAILABLE","message":"The authentication service is unavailable.","retryable":true,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
 	const wantStderr = "partiful: authentication service unavailable\n"
 	if result.ExitCode != 8 || result.Stdout != wantStdout || result.Stderr != wantStderr {
 		t.Fatalf("result = %#v, want auth unavailable failure", result)
@@ -1705,7 +1707,7 @@ func TestExecuteAuthLoginAtomicPersistenceFailurePreservesExistingCredentials(t 
 		Argv: []string{"auth", "login"},
 	}, dependencies)
 
-	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIAL_STORE_UNAVAILABLE","message":"Local credential storage is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIAL_STORE_UNAVAILABLE","message":"Local credential storage is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
 	if result.ExitCode != 10 || result.Stdout != wantStdout {
 		t.Fatalf("result = %#v, want atomic persistence failure", result)
 	}
@@ -1770,7 +1772,7 @@ func TestExecuteAuthStatusRedactsHealthyCredentials(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T02:00:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T02:00:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -1804,7 +1806,7 @@ func TestExecuteAuthStatusReportsExpiringToken(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"expiring","expiresAt":"2026-08-11T00:04:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"expiring","expiresAt":"2026-08-11T00:04:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -1874,7 +1876,7 @@ func TestExecuteAuthStatusDeterministicallyRefreshesExpiringSession(t *testing.T
 	first := app.Execute(context.Background(), app.Request{
 		Argv: []string{"auth", "status"},
 	}, dependencies)
-	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T01:00:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T01:00:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[]}}` + "\n"
 	if first.ExitCode != 0 || first.Stdout != want || first.Stderr != "" {
 		t.Fatalf("first status = %#v, want refreshed healthy session", first)
 	}
@@ -1938,7 +1940,7 @@ func TestExecuteAuthStatusMapsReviewedInvalidRefreshTokenToExpired(t *testing.T)
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"INVALID_REFRESH_TOKEN","message":"Stored authentication has expired. Log in again.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"INVALID_REFRESH_TOKEN","message":"Stored authentication has expired. Log in again.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
 	const wantStderr = "partiful: authentication expired\n"
 	if result.ExitCode != 3 || result.Stdout != wantStdout || result.Stderr != wantStderr {
 		t.Fatalf("result = %#v, want reviewed invalid-refresh failure", result)
@@ -2000,7 +2002,7 @@ func TestExecuteAuthStatusReportsExpiredToken(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"expired","expiresAt":"2026-08-10T23:59:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"expired","expiresAt":"2026-08-10T23:59:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -2029,7 +2031,7 @@ func TestExecuteAuthStatusFailureDoesNotRevealCredentialContents(t *testing.T) {
 		},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIALS_INVALID","message":"Local credentials are invalid.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIALS_INVALID","message":"Local credentials are invalid.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
 	const wantStderr = "partiful: local operation failed\n"
 	if result.ExitCode != 10 {
 		t.Fatalf("exit code = %d, want 10", result.ExitCode)
@@ -2065,7 +2067,7 @@ func TestExecuteAuthLogoutAtomicallyRemovesCredentials(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, dependencies)
 
-	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"missing","expiresAt":null},"meta":{"command":"auth.logout","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"missing","expiresAt":null},"meta":{"command":"auth.logout","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -2136,7 +2138,7 @@ func TestExecuteAuthLogoutFailureLeavesCredentialsAvailableAndRedactsError(t *te
 		Stdin: strings.NewReader(""),
 	}, dependencies)
 
-	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIAL_STORE_UNAVAILABLE","message":"Local credential storage is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.logout","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIAL_STORE_UNAVAILABLE","message":"Local credential storage is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.logout","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
 	if result.ExitCode != 10 {
 		t.Fatalf("exit code = %d, want 10", result.ExitCode)
 	}
@@ -2173,7 +2175,7 @@ func TestExecuteDoctorReportsHealthyCredentialsWithoutPrivateData(t *testing.T) 
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":true,"checks":[{"name":"credentials","status":"pass","message":"Authentication credentials are available.","remediation":null}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":true,"checks":[{"name":"credentials","status":"pass","message":"Authentication credentials are available.","remediation":null}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -2206,7 +2208,7 @@ func TestExecuteDoctorReportsMissingCredentialsAsARedactedCheck(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials are missing.","remediation":"Establish authentication before using commands that require it."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials are missing.","remediation":"Establish authentication before using commands that require it."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -2235,7 +2237,7 @@ func TestExecuteDoctorWarnsWhenCredentialsExpireSoon(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":true,"checks":[{"name":"credentials","status":"warn","message":"Authentication credentials expire soon.","remediation":"Refresh authentication before the credentials expire."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":true,"checks":[{"name":"credentials","status":"warn","message":"Authentication credentials expire soon.","remediation":"Refresh authentication before the credentials expire."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -2264,7 +2266,7 @@ func TestExecuteDoctorFailsExpiredCredentialsCheck(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials have expired.","remediation":"Re-establish authentication."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials have expired.","remediation":"Re-establish authentication."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -2293,7 +2295,7 @@ func TestExecuteDoctorRedactsInvalidCredentialFile(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials are invalid.","remediation":"Remove the invalid credentials and re-establish authentication."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials are invalid.","remediation":"Remove the invalid credentials and re-establish authentication."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -2325,7 +2327,7 @@ func TestExecuteDoctorRedactsCredentialStorageFailure(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Credential storage is unavailable.","remediation":"Check local credential file permissions."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Credential storage is unavailable.","remediation":"Check local credential file permissions."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -2433,7 +2435,7 @@ func TestExecuteUsesDefinitionForFlagFailureCommandMetadata(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"FLAG_REPEATED","message":"A scalar flag cannot be repeated.","retryable":false,"details":{"flag":"--non-interactive"}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"FLAG_REPEATED","message":"A scalar flag cannot be repeated.","retryable":false,"details":{"flag":"--non-interactive"}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -2477,7 +2479,7 @@ func TestExecuteUsesKnownCommandMetadataForInvalidArity(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_NOT_FOUND","message":"Unknown command.","retryable":false,"details":{}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_NOT_FOUND","message":"Unknown command.","retryable":false,"details":{}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -2502,7 +2504,7 @@ func TestExecuteAuthStatusReportsConfigurationDirectoryFailure(t *testing.T) {
 		},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CONFIG_DIRECTORY_UNAVAILABLE","message":"Local configuration directory is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CONFIG_DIRECTORY_UNAVAILABLE","message":"Local configuration directory is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
 	if result.ExitCode != 10 {
 		t.Fatalf("exit code = %d, want 10", result.ExitCode)
 	}
@@ -2527,7 +2529,7 @@ func TestExecuteDoctorDiagnosesConfigurationDirectoryFailure(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Configuration directory is unavailable.","remediation":"Set a usable user configuration directory."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Configuration directory is unavailable.","remediation":"Set a usable user configuration directory."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}

--- a/internal/app/execute_test.go
+++ b/internal/app/execute_test.go
@@ -1621,7 +1621,7 @@ func TestExecuteAuthLoginRejectsInvalidOptionalFirebaseSuccessField(t *testing.T
 	}
 }
 
-func TestExecuteAuthLoginRejectsInvalidOptionalFirebaseErrorField(t *testing.T) {
+func TestExecuteAuthLoginAllowsUndeclaredFirebaseErrorField(t *testing.T) {
 	call := 0
 	result := app.Execute(context.Background(), app.Request{
 		Argv: []string{"auth", "login"},
@@ -1651,9 +1651,45 @@ func TestExecuteAuthLoginRejectsInvalidOptionalFirebaseErrorField(t *testing.T) 
 			}
 		}},
 	})
+	if result.ExitCode != 3 ||
+		!strings.Contains(result.Stdout, `"code":"INVALID_CUSTOM_TOKEN"`) {
+		t.Fatalf("result = %#v, want undeclared Firebase error field to remain allowed", result)
+	}
+}
+
+func TestExecuteAuthLoginRejectsInvalidOptionalFirebaseValidationErrors(t *testing.T) {
+	call := 0
+	result := app.Execute(context.Background(), app.Request{
+		Argv: []string{"auth", "login"},
+	}, app.Dependencies{
+		Files:           &memoryFilesystem{files: map[string][]byte{}},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Terminal:        &scriptedPrivateTerminal{values: []string{"+15555550123", "123456"}},
+		AuthRandom:      strings.NewReader("0123456789abcdef"),
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+		HTTP: scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
+			call++
+			switch call {
+			case 1:
+				return jsonResponse(http.StatusOK, `{}`), nil
+			case 2:
+				return jsonResponse(
+					http.StatusOK,
+					`{"result":{"data":{"token":"custom-private-token"}}}`,
+				), nil
+			default:
+				return jsonResponse(
+					http.StatusBadRequest,
+					`{"error":{"code":400,"message":"invalid token","errors":"invalid"}}`,
+				), nil
+			}
+		}},
+	})
 	if result.ExitCode != 9 ||
 		!strings.Contains(result.Stdout, `"code":"AUTH_PROTOCOL_CHANGED"`) {
-		t.Fatalf("result = %#v, want invalid optional Firebase error field to fail closed", result)
+		t.Fatalf("result = %#v, want invalid declared Firebase errors field to fail closed", result)
 	}
 }
 

--- a/internal/app/execute_test.go
+++ b/internal/app/execute_test.go
@@ -1122,7 +1122,7 @@ func TestExecuteSchemaProjectsExecutableDefinition(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":true,"data":{"command":"auth.status","positionals":[],"flags":[],"inputSchema":{"type":"object","additionalProperties":false},"successSchema":{"type":"object","additionalProperties":false,"required":["authenticated","tokenState","expiresAt"],"properties":{"authenticated":{"type":"boolean"},"expiresAt":{"type":["string","null"],"format":"date-time"},"tokenState":{"type":"string","enum":["healthy","expiring","expired","missing"]}}},"failureTypes":["usage.invalid","input.invalid","auth.expired","remote.unavailable","contract.protocol_changed","internal.failure"],"safety":{"kind":"read-only","planRequired":false,"confirmationRequired":false}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"command":"auth.status","positionals":[],"flags":[],"inputSchema":{"type":"object","additionalProperties":false},"successSchema":{"type":"object","additionalProperties":false,"required":["authenticated","tokenState","expiresAt"],"properties":{"authenticated":{"type":"boolean"},"expiresAt":{"type":["string","null"],"format":"date-time"},"tokenState":{"type":"string","enum":["healthy","expiring","expired","missing"]}}},"failureTypes":["usage.invalid","input.invalid","auth.expired","remote.unavailable","contract.protocol_changed","internal.failure"],"safety":{"kind":"local-mutation","planRequired":false,"confirmationRequired":false}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -1317,7 +1317,7 @@ func TestExecuteAuthLoginPersistsReviewedSessionWithoutRevealingPrivateValues(t 
 		phone        = "+15555550123"
 		code         = "123456"
 		customValue  = "custom-private-token"
-		accessValue  = "eyJhbGciOiJub25lIn0.eyJzdWIiOiJwcml2YXRlLXVzZXIifQ.signature"
+		accessValue  = "access-private-token"
 		refreshValue = "refresh-private-token"
 	)
 	terminal := &scriptedPrivateTerminal{values: []string{phone, code}}
@@ -1408,17 +1408,6 @@ func TestExecuteAuthLoginPersistsReviewedSessionWithoutRevealingPrivateValues(t 
 	}
 	if files.atomicWrites != 1 {
 		t.Fatalf("atomic writes = %d, want 1", files.atomicWrites)
-	}
-	storedCredentials := string(files.files["/config/partiful/credentials.json"])
-	if !strings.Contains(
-		storedCredentials,
-		`"accountFingerprint":"30d4c6416f97f2f3a466d7c093aa6927edcf2177516b3da1012f85f1c9aad1b4"`,
-	) {
-		t.Fatalf("stored credentials lack the stable private account fingerprint")
-	}
-	if strings.Contains(storedCredentials, "private-user") ||
-		strings.Contains(storedCredentials, `"userId"`) {
-		t.Fatal("stored credentials exposed a private account identifier")
 	}
 	if !reflect.DeepEqual(
 		terminal.prompts,

--- a/internal/app/execute_test.go
+++ b/internal/app/execute_test.go
@@ -65,7 +65,7 @@ func TestExecutePostersListReturnsFirstLocalPage(t *testing.T) {
 		}},
 	}))
 
-	const want = `{"ok":true,"data":{"items":[{"posterId":"first","name":"First","url":"https://example.invalid/first.png","contentType":"image/png","width":1200,"height":630,"tags":["party"],"categories":["fun"]},{"posterId":"duplicate","name":"Duplicate","url":"https://example.invalid/duplicate.gif","contentType":"image/gif","width":null,"height":null,"tags":["dance"],"categories":[]},{"posterId":"duplicate","name":"Duplicate Again","url":"https://example.invalid/duplicate-2.gif","contentType":"image/gif","width":640,"height":480,"tags":[],"categories":["night"]}]},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
+	const want = `{"ok":true,"data":{"items":[{"posterId":"first","name":"First","url":"https://example.invalid/first.png","contentType":"image/png","width":1200,"height":630,"tags":["party"],"categories":["fun"]},{"posterId":"duplicate","name":"Duplicate","url":"https://example.invalid/duplicate.gif","contentType":"image/gif","width":null,"height":null,"tags":["dance"],"categories":[]},{"posterId":"duplicate","name":"Duplicate Again","url":"https://example.invalid/duplicate-2.gif","contentType":"image/gif","width":640,"height":480,"tags":[],"categories":["night"]}]},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -471,7 +471,7 @@ func TestExecutePostersListRejectsCursorWhenPayloadChanges(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, dependencies)
 
-	const want = `{"ok":false,"error":{"type":"state.conflict","code":"CURSOR_SNAPSHOT_CHANGED","message":"The poster catalog changed after this cursor was issued.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"state.conflict","code":"CURSOR_SNAPSHOT_CHANGED","message":"The poster catalog changed after this cursor was issued.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
 	if result.ExitCode != 6 {
 		t.Fatalf("exit code = %d, want 6", result.ExitCode)
 	}
@@ -613,7 +613,7 @@ func TestExecutePostersListRejectsUnexpectedSuccessContentType(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
 	const wantStderr = "partiful: poster catalog protocol changed\n"
 	if result.ExitCode != 9 {
 		t.Fatalf("exit code = %d, want 9", result.ExitCode)
@@ -639,7 +639,7 @@ func TestExecutePostersListRejectsMalformedCursorBeforeRemoteFailure(t *testing.
 		}},
 	}))
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_INVALID","message":"The cursor is malformed.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_INVALID","message":"The cursor is malformed.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -694,7 +694,7 @@ func TestExecutePostersSearchRejectsCursorWithDifferentNormalizedFilter(t *testi
 		Stdin: strings.NewReader(""),
 	}, dependencies)
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_FILTER_MISMATCH","message":"The cursor does not match this command and filters.","retryable":false,"details":{}},"meta":{"command":"posters.search","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_FILTER_MISMATCH","message":"The cursor does not match this command and filters.","retryable":false,"details":{}},"meta":{"command":"posters.search","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -717,7 +717,7 @@ func TestExecutePostersListMapsNetworkFailureToRemoteUnavailable(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"remote.unavailable","code":"POSTER_CATALOG_UNAVAILABLE","message":"The poster catalog is unavailable.","retryable":true,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"remote.unavailable","code":"POSTER_CATALOG_UNAVAILABLE","message":"The poster catalog is unavailable.","retryable":true,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
 	const wantStderr = "partiful: poster catalog unavailable\n"
 	if result.ExitCode != 8 {
 		t.Fatalf("exit code = %d, want 8", result.ExitCode)
@@ -747,7 +747,7 @@ func TestExecutePostersListFailsClosedOnReceivedNon200(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
 	const wantStderr = "partiful: poster catalog protocol changed\n"
 	if result.ExitCode != 9 {
 		t.Fatalf("exit code = %d, want 9", result.ExitCode)
@@ -825,7 +825,7 @@ func TestExecutePostersListFailsClosedOnMalformed200Body(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
 	if result.ExitCode != 9 {
 		t.Fatalf("exit code = %d, want 9", result.ExitCode)
 	}
@@ -890,7 +890,7 @@ func TestExecutePostersListRequiresMaxItemsWithAll(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"MAX_ITEMS_REQUIRED","message":"--all requires --max-items.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"MAX_ITEMS_REQUIRED","message":"--all requires --max-items.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -912,7 +912,7 @@ func TestExecutePostersListRejectsLimitWithAll(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"LIMIT_WITH_ALL","message":"--limit cannot be combined with --all.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"LIMIT_WITH_ALL","message":"--limit cannot be combined with --all.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -930,7 +930,7 @@ func TestExecutePostersListRejectsLimitAboveMaximum(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"LIMIT_INVALID","message":"Limit must be an integer from 1 to 100.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"LIMIT_INVALID","message":"Limit must be an integer from 1 to 100.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -945,7 +945,7 @@ func TestExecutePostersListRejectsEmptyCursor(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_INVALID","message":"The cursor is malformed.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_INVALID","message":"The cursor is malformed.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -963,7 +963,7 @@ func TestExecutePostersSearchRequiresNonEmptyQuery(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"QUERY_REQUIRED","message":"Search query must not be empty.","retryable":false,"details":{}},"meta":{"command":"posters.search","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"QUERY_REQUIRED","message":"Search query must not be empty.","retryable":false,"details":{}},"meta":{"command":"posters.search","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -978,7 +978,7 @@ func TestExecuteVersion(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":true,"data":{"version":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"},"meta":{"command":"version","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"version":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"},"meta":{"command":"version","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -996,7 +996,7 @@ func TestExecuteRejectsUnknownCommand(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_NOT_FOUND","message":"Unknown command.","retryable":false,"details":{}},"meta":{"command":"unknown","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_NOT_FOUND","message":"Unknown command.","retryable":false,"details":{}},"meta":{"command":"unknown","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -1019,13 +1019,13 @@ func TestExecutePrettyPrintsOneCompleteEnvelope(t *testing.T) {
   "data": {
     "version": "1.0.0",
     "productContractRevision": "2026-08-10.1",
-    "remoteContractRevision": "2026-08-11.2"
+    "remoteContractRevision": "2026-08-11.3"
   },
   "meta": {
     "command": "version",
     "cliVersion": "1.0.0",
     "productContractRevision": "2026-08-10.1",
-    "remoteContractRevision": "2026-08-11.2",
+    "remoteContractRevision": "2026-08-11.3",
     "warnings": []
   }
 }
@@ -1047,7 +1047,7 @@ func TestExecuteAcceptsNonInteractiveGlobalFlag(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":true,"data":{"version":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"},"meta":{"command":"version","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"version":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"},"meta":{"command":"version","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -1080,7 +1080,7 @@ func TestExecuteRejectsRepeatedScalarFlag(t *testing.T) {
     "command": "version",
     "cliVersion": "1.0.0",
     "productContractRevision": "2026-08-10.1",
-    "remoteContractRevision": "2026-08-11.2"
+    "remoteContractRevision": "2026-08-11.3"
   }
 }
 `
@@ -1101,7 +1101,7 @@ func TestExecuteSchemaListsOnlyCompletedCatalog(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":true,"data":{"commands":["auth.login","auth.logout","auth.status","doctor","posters.list","posters.search","schema","version"]},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"commands":["auth.login","auth.logout","auth.status","doctor","posters.list","posters.search","schema","version"]},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -1119,7 +1119,7 @@ func TestExecuteSchemaProjectsExecutableDefinition(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":true,"data":{"command":"auth.status","positionals":[],"flags":[],"inputSchema":{"type":"object","additionalProperties":false},"successSchema":{"type":"object","additionalProperties":false,"required":["authenticated","tokenState","expiresAt"],"properties":{"authenticated":{"type":"boolean"},"expiresAt":{"type":["string","null"],"format":"date-time"},"tokenState":{"type":"string","enum":["healthy","expiring","expired","missing"]}}},"failureTypes":["auth.expired","remote.unavailable","contract.protocol_changed","internal.failure"],"safety":{"kind":"read-only","planRequired":false,"confirmationRequired":false}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"command":"auth.status","positionals":[],"flags":[],"inputSchema":{"type":"object","additionalProperties":false},"successSchema":{"type":"object","additionalProperties":false,"required":["authenticated","tokenState","expiresAt"],"properties":{"authenticated":{"type":"boolean"},"expiresAt":{"type":["string","null"],"format":"date-time"},"tokenState":{"type":"string","enum":["healthy","expiring","expired","missing"]}}},"failureTypes":["auth.expired","remote.unavailable","contract.protocol_changed","internal.failure"],"safety":{"kind":"read-only","planRequired":false,"confirmationRequired":false}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -1176,7 +1176,7 @@ func TestExecuteRejectsUnknownSchemaPathWithoutEchoingInput(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_SCHEMA_NOT_FOUND","message":"No completed command has that schema path.","retryable":false,"details":{}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_SCHEMA_NOT_FOUND","message":"No completed command has that schema path.","retryable":false,"details":{}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -1207,7 +1207,7 @@ func TestExecuteAuthStatusWhenCredentialsAreMissing(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"missing","expiresAt":null},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"missing","expiresAt":null},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -1225,7 +1225,7 @@ func TestExecuteAuthLoginRequiresPrivateTerminal(t *testing.T) {
 		Stdin: strings.NewReader("private-stdin-value"),
 	}, app.Dependencies{})
 
-	const wantStdout = `{"ok":false,"error":{"type":"auth.human_required","code":"PRIVATE_TERMINAL_REQUIRED","message":"Authentication login requires a private terminal.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"auth.human_required","code":"PRIVATE_TERMINAL_REQUIRED","message":"Authentication login requires a private terminal.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
 	const wantStderr = "partiful: private terminal required\n"
 	if result.ExitCode != 3 {
 		t.Fatalf("exit code = %d, want 3", result.ExitCode)
@@ -1284,7 +1284,7 @@ func TestExecuteAuthLoginRejectsEmptyPrivateInputBeforeHTTP(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"input.invalid","code":"AUTH_INPUT_INVALID","message":"Authentication input is invalid.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"input.invalid","code":"AUTH_INPUT_INVALID","message":"Authentication input is invalid.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
 	if result.ExitCode != 2 || result.Stdout != wantStdout {
 		t.Fatalf("result = %#v, want invalid private input failure", result)
 	}
@@ -1339,13 +1339,13 @@ func TestExecuteAuthLoginPersistsReviewedSessionWithoutRevealingPrivateValues(t 
 			if request.Method != http.MethodPost {
 				t.Fatalf("request method = %q, want POST", request.Method)
 			}
-			if request.Header.Get("Content-Type") != "application/json" ||
-				request.Header.Get("Origin") != "https://partiful.com" ||
-				request.Header.Get("Referer") != "https://partiful.com/" {
-				t.Fatalf("request headers = %#v, want reviewed browser origin", request.Header)
-			}
 			switch call {
 			case 1:
+				if request.Header.Get("Content-Type") != "application/json" ||
+					request.Header.Get("Origin") != "https://partiful.com" ||
+					request.Header.Get("Referer") != "https://partiful.com/" {
+					t.Fatalf("callable headers = %#v, want Origin+Referer", request.Header)
+				}
 				if request.URL.String() != "https://api.partiful.com/sendAuthCodeTrusted" {
 					t.Fatalf("send URL = %q", request.URL)
 				}
@@ -1355,6 +1355,11 @@ func TestExecuteAuthLoginPersistsReviewedSessionWithoutRevealingPrivateValues(t 
 				}
 				return jsonResponse(http.StatusOK, `{}`), nil
 			case 2:
+				if request.Header.Get("Content-Type") != "application/json" ||
+					request.Header.Get("Origin") != "https://partiful.com" ||
+					request.Header.Get("Referer") != "https://partiful.com/" {
+					t.Fatalf("callable headers = %#v, want Origin+Referer", request.Header)
+				}
 				if request.URL.String() != "https://api.partiful.com/getLoginToken" {
 					t.Fatalf("login token URL = %q", request.URL)
 				}
@@ -1370,6 +1375,12 @@ func TestExecuteAuthLoginPersistsReviewedSessionWithoutRevealingPrivateValues(t 
 					request.URL.Query().Get("key") == "" {
 					t.Fatalf("custom-token URL = %q, want reviewed Firebase endpoint", request.URL)
 				}
+				if request.Header.Get("Referer") != "https://partiful.com/" {
+					t.Fatalf("custom-token Referer = %q, want contracted value", request.Header.Get("Referer"))
+				}
+				if request.Header.Get("Origin") != "" {
+					t.Fatalf("custom-token Origin = %q, want absent (not contracted)", request.Header.Get("Origin"))
+				}
 				const want = `{"token":"custom-private-token","returnSecureToken":true}`
 				if string(body) != want {
 					t.Fatalf("custom-token body = %s, want %s", body, want)
@@ -1382,7 +1393,7 @@ func TestExecuteAuthLoginPersistsReviewedSessionWithoutRevealingPrivateValues(t 
 		}},
 	})
 
-	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T01:00:00Z"},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T01:00:00Z"},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want redacted login success", result)
 	}
@@ -1452,7 +1463,7 @@ func TestExecuteAuthLoginMapsReviewedWrongCodeWithoutEchoingIt(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"input.invalid","code":"AUTH_CODE_REJECTED","message":"The verification code was rejected.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"input.invalid","code":"AUTH_CODE_REJECTED","message":"The verification code was rejected.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
 	const wantStderr = "partiful: authentication code rejected\n"
 	if result.ExitCode != 2 || result.Stdout != wantStdout || result.Stderr != wantStderr {
 		t.Fatalf("result = %#v, want reviewed wrong-code failure", result)
@@ -1500,7 +1511,7 @@ func TestExecuteAuthLoginMapsRejectedCustomTokenToExpired(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"INVALID_CUSTOM_TOKEN","message":"Authentication expired during login. Start login again.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"INVALID_CUSTOM_TOKEN","message":"Authentication expired during login. Start login again.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
 	const wantStderr = "partiful: authentication expired\n"
 	if result.ExitCode != 3 || result.Stdout != wantStdout || result.Stderr != wantStderr {
 		t.Fatalf("result = %#v, want reviewed custom-token failure", result)
@@ -1543,7 +1554,7 @@ func TestExecuteAuthLoginFailsClosedOnMalformedReviewedSuccess(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"AUTH_PROTOCOL_CHANGED","message":"Authentication no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"AUTH_PROTOCOL_CHANGED","message":"Authentication no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
 	const wantStderr = "partiful: authentication protocol changed\n"
 	if result.ExitCode != 9 || result.Stdout != wantStdout || result.Stderr != wantStderr {
 		t.Fatalf("result = %#v, want protocol drift failure", result)
@@ -1640,7 +1651,7 @@ func TestExecuteAuthLoginMapsNoResponseWithoutLeakingTransportError(t *testing.T
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"remote.unavailable","code":"AUTH_SERVICE_UNAVAILABLE","message":"The authentication service is unavailable.","retryable":true,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"remote.unavailable","code":"AUTH_SERVICE_UNAVAILABLE","message":"The authentication service is unavailable.","retryable":true,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
 	const wantStderr = "partiful: authentication service unavailable\n"
 	if result.ExitCode != 8 || result.Stdout != wantStdout || result.Stderr != wantStderr {
 		t.Fatalf("result = %#v, want auth unavailable failure", result)
@@ -1694,7 +1705,7 @@ func TestExecuteAuthLoginAtomicPersistenceFailurePreservesExistingCredentials(t 
 		Argv: []string{"auth", "login"},
 	}, dependencies)
 
-	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIAL_STORE_UNAVAILABLE","message":"Local credential storage is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIAL_STORE_UNAVAILABLE","message":"Local credential storage is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
 	if result.ExitCode != 10 || result.Stdout != wantStdout {
 		t.Fatalf("result = %#v, want atomic persistence failure", result)
 	}
@@ -1759,7 +1770,7 @@ func TestExecuteAuthStatusRedactsHealthyCredentials(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T02:00:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T02:00:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -1793,7 +1804,7 @@ func TestExecuteAuthStatusReportsExpiringToken(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"expiring","expiresAt":"2026-08-11T00:04:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"expiring","expiresAt":"2026-08-11T00:04:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -1843,9 +1854,11 @@ func TestExecuteAuthStatusDeterministicallyRefreshesExpiringSession(t *testing.T
 				t.Fatalf("refresh request URL = %q, want reviewed endpoint", request.URL)
 			}
 			if request.Header.Get("Content-Type") != "application/x-www-form-urlencoded" ||
-				request.Header.Get("Origin") != "https://partiful.com" ||
 				request.Header.Get("Referer") != "https://partiful.com/" {
-				t.Fatalf("refresh headers = %#v, want reviewed browser origin", request.Header)
+				t.Fatalf("refresh headers = %#v, want contracted Referer", request.Header)
+			}
+			if request.Header.Get("Origin") != "" {
+				t.Fatalf("refresh Origin = %q, want absent (not contracted)", request.Header.Get("Origin"))
 			}
 			const wantBody = "grant_type=refresh_token&refresh_token=refresh%2Fprivate%2Bvalue"
 			if string(body) != wantBody {
@@ -1861,7 +1874,7 @@ func TestExecuteAuthStatusDeterministicallyRefreshesExpiringSession(t *testing.T
 	first := app.Execute(context.Background(), app.Request{
 		Argv: []string{"auth", "status"},
 	}, dependencies)
-	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T01:00:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T01:00:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3","warnings":[]}}` + "\n"
 	if first.ExitCode != 0 || first.Stdout != want || first.Stderr != "" {
 		t.Fatalf("first status = %#v, want refreshed healthy session", first)
 	}
@@ -1925,7 +1938,7 @@ func TestExecuteAuthStatusMapsReviewedInvalidRefreshTokenToExpired(t *testing.T)
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"INVALID_REFRESH_TOKEN","message":"Stored authentication has expired. Log in again.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"INVALID_REFRESH_TOKEN","message":"Stored authentication has expired. Log in again.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
 	const wantStderr = "partiful: authentication expired\n"
 	if result.ExitCode != 3 || result.Stdout != wantStdout || result.Stderr != wantStderr {
 		t.Fatalf("result = %#v, want reviewed invalid-refresh failure", result)
@@ -1987,7 +2000,7 @@ func TestExecuteAuthStatusReportsExpiredToken(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"expired","expiresAt":"2026-08-10T23:59:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"expired","expiresAt":"2026-08-10T23:59:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -2016,7 +2029,7 @@ func TestExecuteAuthStatusFailureDoesNotRevealCredentialContents(t *testing.T) {
 		},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIALS_INVALID","message":"Local credentials are invalid.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIALS_INVALID","message":"Local credentials are invalid.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
 	const wantStderr = "partiful: local operation failed\n"
 	if result.ExitCode != 10 {
 		t.Fatalf("exit code = %d, want 10", result.ExitCode)
@@ -2052,7 +2065,7 @@ func TestExecuteAuthLogoutAtomicallyRemovesCredentials(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, dependencies)
 
-	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"missing","expiresAt":null},"meta":{"command":"auth.logout","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"missing","expiresAt":null},"meta":{"command":"auth.logout","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -2123,7 +2136,7 @@ func TestExecuteAuthLogoutFailureLeavesCredentialsAvailableAndRedactsError(t *te
 		Stdin: strings.NewReader(""),
 	}, dependencies)
 
-	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIAL_STORE_UNAVAILABLE","message":"Local credential storage is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.logout","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIAL_STORE_UNAVAILABLE","message":"Local credential storage is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.logout","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
 	if result.ExitCode != 10 {
 		t.Fatalf("exit code = %d, want 10", result.ExitCode)
 	}
@@ -2160,7 +2173,7 @@ func TestExecuteDoctorReportsHealthyCredentialsWithoutPrivateData(t *testing.T) 
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":true,"checks":[{"name":"credentials","status":"pass","message":"Authentication credentials are available.","remediation":null}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":true,"checks":[{"name":"credentials","status":"pass","message":"Authentication credentials are available.","remediation":null}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -2193,7 +2206,7 @@ func TestExecuteDoctorReportsMissingCredentialsAsARedactedCheck(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials are missing.","remediation":"Establish authentication before using commands that require it."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials are missing.","remediation":"Establish authentication before using commands that require it."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -2222,7 +2235,7 @@ func TestExecuteDoctorWarnsWhenCredentialsExpireSoon(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":true,"checks":[{"name":"credentials","status":"warn","message":"Authentication credentials expire soon.","remediation":"Refresh authentication before the credentials expire."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":true,"checks":[{"name":"credentials","status":"warn","message":"Authentication credentials expire soon.","remediation":"Refresh authentication before the credentials expire."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -2251,7 +2264,7 @@ func TestExecuteDoctorFailsExpiredCredentialsCheck(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials have expired.","remediation":"Re-establish authentication."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials have expired.","remediation":"Re-establish authentication."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -2280,7 +2293,7 @@ func TestExecuteDoctorRedactsInvalidCredentialFile(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials are invalid.","remediation":"Remove the invalid credentials and re-establish authentication."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials are invalid.","remediation":"Remove the invalid credentials and re-establish authentication."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -2312,7 +2325,7 @@ func TestExecuteDoctorRedactsCredentialStorageFailure(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Credential storage is unavailable.","remediation":"Check local credential file permissions."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Credential storage is unavailable.","remediation":"Check local credential file permissions."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -2420,7 +2433,7 @@ func TestExecuteUsesDefinitionForFlagFailureCommandMetadata(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"FLAG_REPEATED","message":"A scalar flag cannot be repeated.","retryable":false,"details":{"flag":"--non-interactive"}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"FLAG_REPEATED","message":"A scalar flag cannot be repeated.","retryable":false,"details":{"flag":"--non-interactive"}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -2464,7 +2477,7 @@ func TestExecuteUsesKnownCommandMetadataForInvalidArity(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_NOT_FOUND","message":"Unknown command.","retryable":false,"details":{}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_NOT_FOUND","message":"Unknown command.","retryable":false,"details":{}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -2489,7 +2502,7 @@ func TestExecuteAuthStatusReportsConfigurationDirectoryFailure(t *testing.T) {
 		},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CONFIG_DIRECTORY_UNAVAILABLE","message":"Local configuration directory is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CONFIG_DIRECTORY_UNAVAILABLE","message":"Local configuration directory is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3"}}` + "\n"
 	if result.ExitCode != 10 {
 		t.Fatalf("exit code = %d, want 10", result.ExitCode)
 	}
@@ -2514,7 +2527,7 @@ func TestExecuteDoctorDiagnosesConfigurationDirectoryFailure(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Configuration directory is unavailable.","remediation":"Set a usable user configuration directory."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Configuration directory is unavailable.","remediation":"Set a usable user configuration directory."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.3","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}

--- a/internal/app/execute_test.go
+++ b/internal/app/execute_test.go
@@ -9,12 +9,15 @@ import (
 	"io"
 	"io/fs"
 	"net/http"
+	"os"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/KalebCole/partiful-cli/internal/app"
+	"github.com/KalebCole/partiful-cli/internal/auth"
 	"github.com/KalebCole/partiful-cli/internal/remote"
 )
 
@@ -587,7 +590,7 @@ func TestExecuteSchemaProjectsPosterSearchDefinition(t *testing.T) {
 	if got := envelope.Data.SuccessSchema.Properties["items"].Items.Required; !reflect.DeepEqual(got, wantPosterFields) {
 		t.Fatalf("poster fields = %v, want %v", got, wantPosterFields)
 	}
-	wantFailures := []string{"input.invalid", "state.conflict", "remote.unavailable", "contract.protocol_changed", "internal.failure"}
+	wantFailures := []string{"usage.invalid", "input.invalid", "state.conflict", "remote.unavailable", "contract.protocol_changed", "internal.failure"}
 	if !reflect.DeepEqual(envelope.Data.FailureTypes, wantFailures) {
 		t.Fatalf("failure types = %v, want %v", envelope.Data.FailureTypes, wantFailures)
 	}
@@ -1119,7 +1122,7 @@ func TestExecuteSchemaProjectsExecutableDefinition(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":true,"data":{"command":"auth.status","positionals":[],"flags":[],"inputSchema":{"type":"object","additionalProperties":false},"successSchema":{"type":"object","additionalProperties":false,"required":["authenticated","tokenState","expiresAt"],"properties":{"authenticated":{"type":"boolean"},"expiresAt":{"type":["string","null"],"format":"date-time"},"tokenState":{"type":"string","enum":["healthy","expiring","expired","missing"]}}},"failureTypes":["auth.expired","remote.unavailable","contract.protocol_changed","internal.failure"],"safety":{"kind":"read-only","planRequired":false,"confirmationRequired":false}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"command":"auth.status","positionals":[],"flags":[],"inputSchema":{"type":"object","additionalProperties":false},"successSchema":{"type":"object","additionalProperties":false,"required":["authenticated","tokenState","expiresAt"],"properties":{"authenticated":{"type":"boolean"},"expiresAt":{"type":["string","null"],"format":"date-time"},"tokenState":{"type":"string","enum":["healthy","expiring","expired","missing"]}}},"failureTypes":["usage.invalid","input.invalid","auth.expired","remote.unavailable","contract.protocol_changed","internal.failure"],"safety":{"kind":"read-only","planRequired":false,"confirmationRequired":false}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -1151,6 +1154,7 @@ func TestExecuteSchemaProjectsCompleteAuthLoginDefinition(t *testing.T) {
 		t.Fatalf("decode schema: %v", err)
 	}
 	wantFailures := []string{
+		"usage.invalid",
 		"input.invalid",
 		"auth.expired",
 		"auth.human_required",
@@ -1313,7 +1317,7 @@ func TestExecuteAuthLoginPersistsReviewedSessionWithoutRevealingPrivateValues(t 
 		phone        = "+15555550123"
 		code         = "123456"
 		customValue  = "custom-private-token"
-		accessValue  = "access-private-token"
+		accessValue  = "eyJhbGciOiJub25lIn0.eyJzdWIiOiJwcml2YXRlLXVzZXIifQ.signature"
 		refreshValue = "refresh-private-token"
 	)
 	terminal := &scriptedPrivateTerminal{values: []string{phone, code}}
@@ -1404,6 +1408,17 @@ func TestExecuteAuthLoginPersistsReviewedSessionWithoutRevealingPrivateValues(t 
 	}
 	if files.atomicWrites != 1 {
 		t.Fatalf("atomic writes = %d, want 1", files.atomicWrites)
+	}
+	storedCredentials := string(files.files["/config/partiful/credentials.json"])
+	if !strings.Contains(
+		storedCredentials,
+		`"accountFingerprint":"30d4c6416f97f2f3a466d7c093aa6927edcf2177516b3da1012f85f1c9aad1b4"`,
+	) {
+		t.Fatalf("stored credentials lack the stable private account fingerprint")
+	}
+	if strings.Contains(storedCredentials, "private-user") ||
+		strings.Contains(storedCredentials, `"userId"`) {
+		t.Fatal("stored credentials exposed a private account identifier")
 	}
 	if !reflect.DeepEqual(
 		terminal.prompts,
@@ -1735,6 +1750,7 @@ type fakeFilesystem struct {
 	readFile        func(string) ([]byte, error)
 	remove          func(string) error
 	writeFileAtomic func(string, []byte) error
+	withLock        func(string, func()) error
 }
 
 func (filesystem fakeFilesystem) ReadFile(path string) ([]byte, error) {
@@ -1752,6 +1768,14 @@ func (filesystem fakeFilesystem) WriteFileAtomic(path string, document []byte) e
 	if filesystem.writeFileAtomic != nil {
 		return filesystem.writeFileAtomic(path, document)
 	}
+	return nil
+}
+
+func (filesystem fakeFilesystem) WithLock(path string, operation func()) error {
+	if filesystem.withLock != nil {
+		return filesystem.withLock(path, operation)
+	}
+	operation()
 	return nil
 }
 
@@ -1908,6 +1932,113 @@ func TestExecuteAuthStatusDeterministicallyRefreshesExpiringSession(t *testing.T
 	}
 	if httpCalls != 1 || files.atomicWrites != 1 {
 		t.Fatalf("second status repeated refresh: calls = %d, writes = %d", httpCalls, files.atomicWrites)
+	}
+}
+
+func TestExecuteAuthLogoutCannotBeUndoneByConcurrentRefresh(t *testing.T) {
+	const credentialsPath = "/config/partiful/credentials.json"
+	files := &memoryFilesystem{files: map[string][]byte{
+		credentialsPath: []byte(
+			`{"accessToken":"old-private-token","refreshToken":"old-private-refresh","expiresAt":"2026-08-11T00:04:00Z"}`,
+		),
+	}}
+	refreshStarted := make(chan struct{})
+	allowRefresh := make(chan struct{})
+	dependencies := app.Dependencies{
+		Files:           files,
+		CredentialsPath: credentialsPath,
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+		HTTP: scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
+			close(refreshStarted)
+			<-allowRefresh
+			return jsonResponse(
+				http.StatusOK,
+				`{"access_token":"private-access","id_token":"new-private-token","refresh_token":"new-private-refresh","expires_in":"3600","token_type":"Bearer","user_id":"private-user"}`,
+			), nil
+		}},
+	}
+
+	statusResult := make(chan app.Result, 1)
+	go func() {
+		statusResult <- app.Execute(context.Background(), app.Request{
+			Argv: []string{"auth", "status"},
+		}, dependencies)
+	}()
+	<-refreshStarted
+
+	logoutResult := make(chan app.Result, 1)
+	go func() {
+		logoutResult <- app.Execute(context.Background(), app.Request{
+			Argv: []string{"auth", "logout"},
+		}, dependencies)
+	}()
+
+	select {
+	case result := <-logoutResult:
+		t.Fatalf("logout completed before in-flight refresh committed: %#v", result)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	close(allowRefresh)
+	if result := <-statusResult; result.ExitCode != 0 {
+		t.Fatalf("refreshing status = %#v, want success", result)
+	}
+	if result := <-logoutResult; result.ExitCode != 0 {
+		t.Fatalf("serialized logout = %#v, want success", result)
+	}
+	final := app.Execute(context.Background(), app.Request{
+		Argv: []string{"auth", "status"},
+	}, dependencies)
+	if final.ExitCode != 0 ||
+		!strings.Contains(final.Stdout, `"authenticated":false,"tokenState":"missing"`) {
+		t.Fatalf("final status = %#v, want logout to remain authoritative", final)
+	}
+}
+
+func TestExecuteAuthStatusAtomicallyReplacesProductionCredentials(t *testing.T) {
+	credentialsPath := t.TempDir() + "/credentials.json"
+	if err := os.WriteFile(
+		credentialsPath,
+		[]byte(`{"accessToken":"old-private-token","refreshToken":"old-private-refresh","expiresAt":"2026-08-11T00:04:00Z"}`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write initial credentials: %v", err)
+	}
+
+	result := app.Execute(context.Background(), app.Request{
+		Argv: []string{"auth", "status"},
+	}, app.Dependencies{
+		Files:           auth.OSFileSystem{},
+		CredentialsPath: credentialsPath,
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+		HTTP: scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
+			return jsonResponse(
+				http.StatusOK,
+				`{"access_token":"private-access","id_token":"new-private-token","refresh_token":"new-private-refresh","expires_in":"3600","token_type":"Bearer","user_id":"private-user"}`,
+			), nil
+		}},
+	})
+	if result.ExitCode != 0 {
+		t.Fatalf("status = %#v, want successful production credential replacement", result)
+	}
+	document, err := os.ReadFile(credentialsPath)
+	if err != nil {
+		t.Fatalf("read replaced credentials: %v", err)
+	}
+	if strings.Contains(string(document), "old-private") ||
+		!strings.Contains(string(document), "new-private-token") {
+		t.Fatalf("replaced credentials do not contain one coherent refreshed record")
+	}
+	info, err := os.Stat(credentialsPath)
+	if err != nil {
+		t.Fatalf("stat replaced credentials: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("credential mode = %o, want 600", info.Mode().Perm())
 	}
 }
 
@@ -2090,6 +2221,7 @@ func TestExecuteAuthLogoutAtomicallyRemovesCredentials(t *testing.T) {
 type memoryFilesystem struct {
 	files        map[string][]byte
 	atomicWrites int
+	mutex        sync.Mutex
 }
 
 func (filesystem *memoryFilesystem) ReadFile(path string) ([]byte, error) {
@@ -2111,6 +2243,13 @@ func (filesystem *memoryFilesystem) Remove(path string) error {
 func (filesystem *memoryFilesystem) WriteFileAtomic(path string, document []byte) error {
 	filesystem.atomicWrites++
 	filesystem.files[path] = append([]byte(nil), document...)
+	return nil
+}
+
+func (filesystem *memoryFilesystem) WithLock(_ string, operation func()) error {
+	filesystem.mutex.Lock()
+	defer filesystem.mutex.Unlock()
+	operation()
 	return nil
 }
 

--- a/internal/app/execute_test.go
+++ b/internal/app/execute_test.go
@@ -65,7 +65,7 @@ func TestExecutePostersListReturnsFirstLocalPage(t *testing.T) {
 		}},
 	}))
 
-	const want = `{"ok":true,"data":{"items":[{"posterId":"first","name":"First","url":"https://example.invalid/first.png","contentType":"image/png","width":1200,"height":630,"tags":["party"],"categories":["fun"]},{"posterId":"duplicate","name":"Duplicate","url":"https://example.invalid/duplicate.gif","contentType":"image/gif","width":null,"height":null,"tags":["dance"],"categories":[]},{"posterId":"duplicate","name":"Duplicate Again","url":"https://example.invalid/duplicate-2.gif","contentType":"image/gif","width":640,"height":480,"tags":[],"categories":["night"]}]},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.1","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
+	const want = `{"ok":true,"data":{"items":[{"posterId":"first","name":"First","url":"https://example.invalid/first.png","contentType":"image/png","width":1200,"height":630,"tags":["party"],"categories":["fun"]},{"posterId":"duplicate","name":"Duplicate","url":"https://example.invalid/duplicate.gif","contentType":"image/gif","width":null,"height":null,"tags":["dance"],"categories":[]},{"posterId":"duplicate","name":"Duplicate Again","url":"https://example.invalid/duplicate-2.gif","contentType":"image/gif","width":640,"height":480,"tags":[],"categories":["night"]}]},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -471,7 +471,7 @@ func TestExecutePostersListRejectsCursorWhenPayloadChanges(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, dependencies)
 
-	const want = `{"ok":false,"error":{"type":"state.conflict","code":"CURSOR_SNAPSHOT_CHANGED","message":"The poster catalog changed after this cursor was issued.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.1"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"state.conflict","code":"CURSOR_SNAPSHOT_CHANGED","message":"The poster catalog changed after this cursor was issued.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
 	if result.ExitCode != 6 {
 		t.Fatalf("exit code = %d, want 6", result.ExitCode)
 	}
@@ -613,7 +613,7 @@ func TestExecutePostersListRejectsUnexpectedSuccessContentType(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.1"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
 	const wantStderr = "partiful: poster catalog protocol changed\n"
 	if result.ExitCode != 9 {
 		t.Fatalf("exit code = %d, want 9", result.ExitCode)
@@ -639,7 +639,7 @@ func TestExecutePostersListRejectsMalformedCursorBeforeRemoteFailure(t *testing.
 		}},
 	}))
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_INVALID","message":"The cursor is malformed.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.1"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_INVALID","message":"The cursor is malformed.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -694,7 +694,7 @@ func TestExecutePostersSearchRejectsCursorWithDifferentNormalizedFilter(t *testi
 		Stdin: strings.NewReader(""),
 	}, dependencies)
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_FILTER_MISMATCH","message":"The cursor does not match this command and filters.","retryable":false,"details":{}},"meta":{"command":"posters.search","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.1"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_FILTER_MISMATCH","message":"The cursor does not match this command and filters.","retryable":false,"details":{}},"meta":{"command":"posters.search","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -717,7 +717,7 @@ func TestExecutePostersListMapsNetworkFailureToRemoteUnavailable(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"remote.unavailable","code":"POSTER_CATALOG_UNAVAILABLE","message":"The poster catalog is unavailable.","retryable":true,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.1"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"remote.unavailable","code":"POSTER_CATALOG_UNAVAILABLE","message":"The poster catalog is unavailable.","retryable":true,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
 	const wantStderr = "partiful: poster catalog unavailable\n"
 	if result.ExitCode != 8 {
 		t.Fatalf("exit code = %d, want 8", result.ExitCode)
@@ -747,7 +747,7 @@ func TestExecutePostersListFailsClosedOnReceivedNon200(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.1"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
 	const wantStderr = "partiful: poster catalog protocol changed\n"
 	if result.ExitCode != 9 {
 		t.Fatalf("exit code = %d, want 9", result.ExitCode)
@@ -825,7 +825,7 @@ func TestExecutePostersListFailsClosedOnMalformed200Body(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.1"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
 	if result.ExitCode != 9 {
 		t.Fatalf("exit code = %d, want 9", result.ExitCode)
 	}
@@ -890,7 +890,7 @@ func TestExecutePostersListRequiresMaxItemsWithAll(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"MAX_ITEMS_REQUIRED","message":"--all requires --max-items.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.1"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"MAX_ITEMS_REQUIRED","message":"--all requires --max-items.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -912,7 +912,7 @@ func TestExecutePostersListRejectsLimitWithAll(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"LIMIT_WITH_ALL","message":"--limit cannot be combined with --all.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.1"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"LIMIT_WITH_ALL","message":"--limit cannot be combined with --all.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -930,7 +930,7 @@ func TestExecutePostersListRejectsLimitAboveMaximum(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"LIMIT_INVALID","message":"Limit must be an integer from 1 to 100.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.1"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"LIMIT_INVALID","message":"Limit must be an integer from 1 to 100.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -945,7 +945,7 @@ func TestExecutePostersListRejectsEmptyCursor(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_INVALID","message":"The cursor is malformed.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.1"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_INVALID","message":"The cursor is malformed.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -963,7 +963,7 @@ func TestExecutePostersSearchRequiresNonEmptyQuery(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"QUERY_REQUIRED","message":"Search query must not be empty.","retryable":false,"details":{}},"meta":{"command":"posters.search","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.1"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"QUERY_REQUIRED","message":"Search query must not be empty.","retryable":false,"details":{}},"meta":{"command":"posters.search","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -978,7 +978,7 @@ func TestExecuteVersion(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":true,"data":{"version":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.1"},"meta":{"command":"version","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.1","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"version":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"},"meta":{"command":"version","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -996,7 +996,7 @@ func TestExecuteRejectsUnknownCommand(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_NOT_FOUND","message":"Unknown command.","retryable":false,"details":{}},"meta":{"command":"unknown","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.1"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_NOT_FOUND","message":"Unknown command.","retryable":false,"details":{}},"meta":{"command":"unknown","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -1019,13 +1019,13 @@ func TestExecutePrettyPrintsOneCompleteEnvelope(t *testing.T) {
   "data": {
     "version": "1.0.0",
     "productContractRevision": "2026-08-10.1",
-    "remoteContractRevision": "2026-08-11.1"
+    "remoteContractRevision": "2026-08-11.2"
   },
   "meta": {
     "command": "version",
     "cliVersion": "1.0.0",
     "productContractRevision": "2026-08-10.1",
-    "remoteContractRevision": "2026-08-11.1",
+    "remoteContractRevision": "2026-08-11.2",
     "warnings": []
   }
 }
@@ -1047,7 +1047,7 @@ func TestExecuteAcceptsNonInteractiveGlobalFlag(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":true,"data":{"version":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.1"},"meta":{"command":"version","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.1","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"version":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"},"meta":{"command":"version","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -1080,7 +1080,7 @@ func TestExecuteRejectsRepeatedScalarFlag(t *testing.T) {
     "command": "version",
     "cliVersion": "1.0.0",
     "productContractRevision": "2026-08-10.1",
-    "remoteContractRevision": "2026-08-11.1"
+    "remoteContractRevision": "2026-08-11.2"
   }
 }
 `
@@ -1101,7 +1101,7 @@ func TestExecuteSchemaListsOnlyCompletedCatalog(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":true,"data":{"commands":["auth.logout","auth.status","doctor","posters.list","posters.search","schema","version"]},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.1","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"commands":["auth.login","auth.logout","auth.status","doctor","posters.list","posters.search","schema","version"]},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -1119,7 +1119,7 @@ func TestExecuteSchemaProjectsExecutableDefinition(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":true,"data":{"command":"auth.status","positionals":[],"flags":[],"inputSchema":{"type":"object","additionalProperties":false},"successSchema":{"type":"object","additionalProperties":false,"required":["authenticated","tokenState","expiresAt"],"properties":{"authenticated":{"type":"boolean"},"expiresAt":{"type":["string","null"],"format":"date-time"},"tokenState":{"type":"string","enum":["healthy","expiring","expired","missing"]}}},"failureTypes":["internal.failure"],"safety":{"kind":"read-only","planRequired":false,"confirmationRequired":false}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.1","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"command":"auth.status","positionals":[],"flags":[],"inputSchema":{"type":"object","additionalProperties":false},"successSchema":{"type":"object","additionalProperties":false,"required":["authenticated","tokenState","expiresAt"],"properties":{"authenticated":{"type":"boolean"},"expiresAt":{"type":["string","null"],"format":"date-time"},"tokenState":{"type":"string","enum":["healthy","expiring","expired","missing"]}}},"failureTypes":["internal.failure"],"safety":{"kind":"read-only","planRequired":false,"confirmationRequired":false}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -1131,13 +1131,52 @@ func TestExecuteSchemaProjectsExecutableDefinition(t *testing.T) {
 	}
 }
 
+func TestExecuteSchemaProjectsCompleteAuthLoginDefinition(t *testing.T) {
+	result := app.Execute(context.Background(), app.Request{
+		Argv: []string{"schema", "auth.login"},
+	}, app.Dependencies{})
+
+	var envelope struct {
+		Data struct {
+			Command      string   `json:"command"`
+			FailureTypes []string `json:"failureTypes"`
+			Safety       struct {
+				Kind                 string `json:"kind"`
+				PlanRequired         bool   `json:"planRequired"`
+				ConfirmationRequired bool   `json:"confirmationRequired"`
+			} `json:"safety"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(result.Stdout), &envelope); err != nil {
+		t.Fatalf("decode schema: %v", err)
+	}
+	wantFailures := []string{
+		"input.invalid",
+		"auth.expired",
+		"auth.human_required",
+		"remote.unavailable",
+		"contract.protocol_changed",
+		"internal.failure",
+	}
+	if result.ExitCode != 0 ||
+		envelope.Data.Command != "auth.login" ||
+		!reflect.DeepEqual(envelope.Data.FailureTypes, wantFailures) {
+		t.Fatalf("schema = %#v, want complete auth login definition", envelope.Data)
+	}
+	if envelope.Data.Safety.Kind != "local-mutation" ||
+		envelope.Data.Safety.PlanRequired ||
+		envelope.Data.Safety.ConfirmationRequired {
+		t.Fatalf("safety = %#v, want local credential mutation", envelope.Data.Safety)
+	}
+}
+
 func TestExecuteRejectsUnknownSchemaPathWithoutEchoingInput(t *testing.T) {
 	result := app.Execute(context.Background(), app.Request{
 		Argv:  []string{"schema", "secret-private-value"},
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_SCHEMA_NOT_FOUND","message":"No completed command has that schema path.","retryable":false,"details":{}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.1"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_SCHEMA_NOT_FOUND","message":"No completed command has that schema path.","retryable":false,"details":{}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -1168,7 +1207,7 @@ func TestExecuteAuthStatusWhenCredentialsAreMissing(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"missing","expiresAt":null},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.1","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"missing","expiresAt":null},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -1180,9 +1219,509 @@ func TestExecuteAuthStatusWhenCredentialsAreMissing(t *testing.T) {
 	}
 }
 
+func TestExecuteAuthLoginRequiresPrivateTerminal(t *testing.T) {
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"auth", "login"},
+		Stdin: strings.NewReader("private-stdin-value"),
+	}, app.Dependencies{})
+
+	const wantStdout = `{"ok":false,"error":{"type":"auth.human_required","code":"PRIVATE_TERMINAL_REQUIRED","message":"Authentication login requires a private terminal.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
+	const wantStderr = "partiful: private terminal required\n"
+	if result.ExitCode != 3 {
+		t.Fatalf("exit code = %d, want 3", result.ExitCode)
+	}
+	if result.Stdout != wantStdout {
+		t.Fatalf("stdout = %q, want %q", result.Stdout, wantStdout)
+	}
+	if result.Stderr != wantStderr {
+		t.Fatalf("stderr = %q, want %q", result.Stderr, wantStderr)
+	}
+	if strings.Contains(result.Stdout+result.Stderr, "private-stdin-value") {
+		t.Fatal("login read ordinary stdin")
+	}
+}
+
+func TestExecuteAuthLoginNonInteractiveNeverReadsPrivateTerminal(t *testing.T) {
+	terminal := &scriptedPrivateTerminal{values: []string{"+15555550123"}}
+	httpCalled := false
+	result := app.Execute(context.Background(), app.Request{
+		Argv: []string{"auth", "login", "--non-interactive"},
+	}, app.Dependencies{
+		Terminal: terminal,
+		HTTP: scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
+			httpCalled = true
+			return nil, errors.New("unexpected request")
+		}},
+	})
+
+	if result.ExitCode != 3 ||
+		!strings.Contains(result.Stdout, `"type":"auth.human_required"`) {
+		t.Fatalf("result = %#v, want human-required failure", result)
+	}
+	if len(terminal.prompts) != 0 {
+		t.Fatalf("private terminal prompts = %#v, want none", terminal.prompts)
+	}
+	if httpCalled {
+		t.Fatal("non-interactive login reached HTTP")
+	}
+}
+
+func TestExecuteAuthLoginRejectsEmptyPrivateInputBeforeHTTP(t *testing.T) {
+	httpCalled := false
+	result := app.Execute(context.Background(), app.Request{
+		Argv: []string{"auth", "login"},
+	}, app.Dependencies{
+		Files:           &memoryFilesystem{files: map[string][]byte{}},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Terminal:        &scriptedPrivateTerminal{values: []string{"   "}},
+		AuthRandom:      strings.NewReader("0123456789abcdef"),
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+		HTTP: scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
+			httpCalled = true
+			return nil, errors.New("unexpected request")
+		}},
+	})
+
+	const wantStdout = `{"ok":false,"error":{"type":"input.invalid","code":"AUTH_INPUT_INVALID","message":"Authentication input is invalid.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
+	if result.ExitCode != 2 || result.Stdout != wantStdout {
+		t.Fatalf("result = %#v, want invalid private input failure", result)
+	}
+	if httpCalled {
+		t.Fatal("invalid private input reached HTTP")
+	}
+}
+
+type scriptedPrivateTerminal struct {
+	values  []string
+	prompts []string
+}
+
+func (terminal *scriptedPrivateTerminal) ReadSecret(prompt string) (string, error) {
+	terminal.prompts = append(terminal.prompts, prompt)
+	if len(terminal.values) == 0 {
+		return "", errors.New("no scripted terminal value")
+	}
+	value := terminal.values[0]
+	terminal.values = terminal.values[1:]
+	return value, nil
+}
+
+func TestExecuteAuthLoginPersistsReviewedSessionWithoutRevealingPrivateValues(t *testing.T) {
+	const (
+		phone        = "+15555550123"
+		code         = "123456"
+		customValue  = "custom-private-token"
+		accessValue  = "access-private-token"
+		refreshValue = "refresh-private-token"
+	)
+	terminal := &scriptedPrivateTerminal{values: []string{phone, code}}
+	files := &memoryFilesystem{files: map[string][]byte{}}
+	call := 0
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"auth", "login"},
+		Stdin: strings.NewReader("ordinary-private-input"),
+	}, app.Dependencies{
+		Files:           files,
+		CredentialsPath: "/config/partiful/credentials.json",
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+		AuthRandom: strings.NewReader("0123456789abcdef"),
+		Terminal:   terminal,
+		HTTP: scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+			call++
+			body, err := io.ReadAll(request.Body)
+			if err != nil {
+				t.Fatalf("read request body: %v", err)
+			}
+			if request.Method != http.MethodPost {
+				t.Fatalf("request method = %q, want POST", request.Method)
+			}
+			if request.Header.Get("Content-Type") != "application/json" ||
+				request.Header.Get("Origin") != "https://partiful.com" ||
+				request.Header.Get("Referer") != "https://partiful.com/" {
+				t.Fatalf("request headers = %#v, want reviewed browser origin", request.Header)
+			}
+			switch call {
+			case 1:
+				if request.URL.String() != "https://api.partiful.com/sendAuthCodeTrusted" {
+					t.Fatalf("send URL = %q", request.URL)
+				}
+				const want = `{"data":{"params":{"displayName":"","phoneNumber":"+15555550123","silent":false,"channelPreference":"sms","captchaToken":null,"useAppleBusinessUpdates":false},"amplitudeDeviceId":"MDEyMzQ1Njc4OWFiY2RlZg","amplitudeSessionId":1786406400000}}`
+				if string(body) != want {
+					t.Fatalf("send body = %s, want %s", body, want)
+				}
+				return jsonResponse(http.StatusOK, `{}`), nil
+			case 2:
+				if request.URL.String() != "https://api.partiful.com/getLoginToken" {
+					t.Fatalf("login token URL = %q", request.URL)
+				}
+				const want = `{"data":{"params":{"phoneNumber":"+15555550123","authCode":"123456","affiliateId":null,"utms":{}},"amplitudeDeviceId":"MDEyMzQ1Njc4OWFiY2RlZg","amplitudeSessionId":1786406400000}}`
+				if string(body) != want {
+					t.Fatalf("login token body = %s, want %s", body, want)
+				}
+				return jsonResponse(http.StatusOK, `{"result":{"data":{"token":"`+customValue+`"}}}`), nil
+			case 3:
+				if request.URL.Scheme != "https" ||
+					request.URL.Host != "identitytoolkit.googleapis.com" ||
+					request.URL.Path != "/v1/accounts:signInWithCustomToken" ||
+					request.URL.Query().Get("key") == "" {
+					t.Fatalf("custom-token URL = %q, want reviewed Firebase endpoint", request.URL)
+				}
+				const want = `{"token":"custom-private-token","returnSecureToken":true}`
+				if string(body) != want {
+					t.Fatalf("custom-token body = %s, want %s", body, want)
+				}
+				return jsonResponse(http.StatusOK, `{"idToken":"`+accessValue+`","refreshToken":"`+refreshValue+`","expiresIn":"3600","kind":"identitytoolkit#VerifyCustomTokenResponse"}`), nil
+			default:
+				t.Fatalf("unexpected HTTP call %d", call)
+				return nil, nil
+			}
+		}},
+	})
+
+	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T01:00:00Z"},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2","warnings":[]}}` + "\n"
+	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
+		t.Fatalf("result = %#v, want redacted login success", result)
+	}
+	if call != 3 {
+		t.Fatalf("HTTP calls = %d, want 3", call)
+	}
+	if files.atomicWrites != 1 {
+		t.Fatalf("atomic writes = %d, want 1", files.atomicWrites)
+	}
+	if !reflect.DeepEqual(
+		terminal.prompts,
+		[]string{"Phone number: ", "Verification code: "},
+	) {
+		t.Fatalf("private prompts = %#v, want safe prompts", terminal.prompts)
+	}
+	for _, privateValue := range []string{
+		phone,
+		code,
+		customValue,
+		accessValue,
+		refreshValue,
+		"ordinary-private-input",
+	} {
+		if strings.Contains(result.Stdout+result.Stderr, privateValue) {
+			t.Fatalf("output contains private value %q", privateValue)
+		}
+	}
+
+	status := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"auth", "status"},
+		Stdin: strings.NewReader(""),
+	}, app.Dependencies{
+		Files:           files,
+		CredentialsPath: "/config/partiful/credentials.json",
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 1, 0, 0, time.UTC)
+		},
+	})
+	if !strings.Contains(status.Stdout, `"authenticated":true,"tokenState":"healthy"`) {
+		t.Fatalf("status after login = %q, want persisted healthy credentials", status.Stdout)
+	}
+}
+
+func TestExecuteAuthLoginMapsReviewedWrongCodeWithoutEchoingIt(t *testing.T) {
+	const privateCode = "654321"
+	terminal := &scriptedPrivateTerminal{values: []string{"+15555550123", privateCode}}
+	call := 0
+	result := app.Execute(context.Background(), app.Request{
+		Argv: []string{"auth", "login"},
+	}, app.Dependencies{
+		Files:           &memoryFilesystem{files: map[string][]byte{}},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Terminal:        terminal,
+		AuthRandom:      strings.NewReader("0123456789abcdef"),
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+		HTTP: scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
+			call++
+			if call == 1 {
+				return jsonResponse(http.StatusOK, `{}`), nil
+			}
+			return jsonResponse(
+				http.StatusForbidden,
+				`{"error":{"message":"private remote rejection","status":"PERMISSION_DENIED","details":{"authErrorCode":"PRIVATE_REMOTE_CODE"}}}`,
+			), nil
+		}},
+	})
+
+	const wantStdout = `{"ok":false,"error":{"type":"input.invalid","code":"AUTH_CODE_REJECTED","message":"The verification code was rejected.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
+	const wantStderr = "partiful: authentication code rejected\n"
+	if result.ExitCode != 2 || result.Stdout != wantStdout || result.Stderr != wantStderr {
+		t.Fatalf("result = %#v, want reviewed wrong-code failure", result)
+	}
+	for _, privateValue := range []string{
+		privateCode,
+		"private remote rejection",
+		"PRIVATE_REMOTE_CODE",
+	} {
+		if strings.Contains(result.Stdout+result.Stderr, privateValue) {
+			t.Fatalf("failure output contains private value %q", privateValue)
+		}
+	}
+}
+
+func TestExecuteAuthLoginMapsRejectedCustomTokenToExpired(t *testing.T) {
+	terminal := &scriptedPrivateTerminal{values: []string{"+15555550123", "123456"}}
+	call := 0
+	result := app.Execute(context.Background(), app.Request{
+		Argv: []string{"auth", "login"},
+	}, app.Dependencies{
+		Files:           &memoryFilesystem{files: map[string][]byte{}},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Terminal:        terminal,
+		AuthRandom:      strings.NewReader("0123456789abcdef"),
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+		HTTP: scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
+			call++
+			switch call {
+			case 1:
+				return jsonResponse(http.StatusOK, `{}`), nil
+			case 2:
+				return jsonResponse(
+					http.StatusOK,
+					`{"result":{"data":{"token":"custom-private-token"}}}`,
+				), nil
+			default:
+				return jsonResponse(
+					http.StatusBadRequest,
+					`{"error":{"code":400,"message":"private invalid token","errors":[{"domain":"private","message":"private","reason":"private"}]}}`,
+				), nil
+			}
+		}},
+	})
+
+	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"INVALID_CUSTOM_TOKEN","message":"Authentication expired during login. Start login again.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
+	const wantStderr = "partiful: authentication expired\n"
+	if result.ExitCode != 3 || result.Stdout != wantStdout || result.Stderr != wantStderr {
+		t.Fatalf("result = %#v, want reviewed custom-token failure", result)
+	}
+	if strings.Contains(result.Stdout+result.Stderr, "private") {
+		t.Fatal("custom-token failure exposed a remote response value")
+	}
+}
+
+func TestExecuteAuthLoginFailsClosedOnMalformedReviewedSuccess(t *testing.T) {
+	const privateBodyValue = "private-access-token"
+	terminal := &scriptedPrivateTerminal{values: []string{"+15555550123", "123456"}}
+	call := 0
+	result := app.Execute(context.Background(), app.Request{
+		Argv: []string{"auth", "login"},
+	}, app.Dependencies{
+		Files:           &memoryFilesystem{files: map[string][]byte{}},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Terminal:        terminal,
+		AuthRandom:      strings.NewReader("0123456789abcdef"),
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+		HTTP: scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
+			call++
+			switch call {
+			case 1:
+				return jsonResponse(http.StatusOK, `{}`), nil
+			case 2:
+				return jsonResponse(
+					http.StatusOK,
+					`{"result":{"data":{"token":"custom-private-token"}}}`,
+				), nil
+			default:
+				return jsonResponse(
+					http.StatusOK,
+					`{"idToken":"`+privateBodyValue+`","expiresIn":"3600"}`,
+				), nil
+			}
+		}},
+	})
+
+	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"AUTH_PROTOCOL_CHANGED","message":"Authentication no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
+	const wantStderr = "partiful: authentication protocol changed\n"
+	if result.ExitCode != 9 || result.Stdout != wantStdout || result.Stderr != wantStderr {
+		t.Fatalf("result = %#v, want protocol drift failure", result)
+	}
+	if strings.Contains(result.Stdout+result.Stderr, privateBodyValue) {
+		t.Fatal("protocol drift failure exposed a response value")
+	}
+}
+
+func TestExecuteAuthLoginRejectsMissingFirebaseResponse(t *testing.T) {
+	terminal := &scriptedPrivateTerminal{values: []string{"+15555550123", "123456"}}
+	call := 0
+	result := app.Execute(context.Background(), app.Request{
+		Argv: []string{"auth", "login"},
+	}, app.Dependencies{
+		Files:           &memoryFilesystem{files: map[string][]byte{}},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Terminal:        terminal,
+		AuthRandom:      strings.NewReader("0123456789abcdef"),
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+		HTTP: scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
+			call++
+			switch call {
+			case 1:
+				return jsonResponse(http.StatusOK, `{}`), nil
+			case 2:
+				return jsonResponse(
+					http.StatusOK,
+					`{"result":{"data":{"token":"custom-private-token"}}}`,
+				), nil
+			default:
+				return nil, nil
+			}
+		}},
+	})
+
+	if result.ExitCode != 9 ||
+		!strings.Contains(result.Stdout, `"code":"AUTH_PROTOCOL_CHANGED"`) {
+		t.Fatalf("result = %#v, want missing response to fail closed", result)
+	}
+}
+
+func TestExecuteAuthLoginRejectsMalformedWrongCodeMapping(t *testing.T) {
+	terminal := &scriptedPrivateTerminal{values: []string{"+15555550123", "123456"}}
+	call := 0
+	result := app.Execute(context.Background(), app.Request{
+		Argv: []string{"auth", "login"},
+	}, app.Dependencies{
+		Files:           &memoryFilesystem{files: map[string][]byte{}},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Terminal:        terminal,
+		AuthRandom:      strings.NewReader("0123456789abcdef"),
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+		HTTP: scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
+			call++
+			if call == 1 {
+				return jsonResponse(http.StatusOK, `{}`), nil
+			}
+			return jsonResponse(
+				http.StatusForbidden,
+				`{"error":{"message":"private malformed error"}}`,
+			), nil
+		}},
+	})
+
+	if result.ExitCode != 9 ||
+		!strings.Contains(result.Stdout, `"type":"contract.protocol_changed"`) ||
+		!strings.Contains(result.Stdout, `"code":"AUTH_PROTOCOL_CHANGED"`) {
+		t.Fatalf("result = %#v, want malformed error to fail closed", result)
+	}
+	if strings.Contains(result.Stdout+result.Stderr, "private malformed error") {
+		t.Fatal("malformed error failure exposed a response value")
+	}
+}
+
+func TestExecuteAuthLoginMapsNoResponseWithoutLeakingTransportError(t *testing.T) {
+	const privateTransportValue = "private transport detail"
+	result := app.Execute(context.Background(), app.Request{
+		Argv: []string{"auth", "login"},
+	}, app.Dependencies{
+		Files:           &memoryFilesystem{files: map[string][]byte{}},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Terminal:        &scriptedPrivateTerminal{values: []string{"+15555550123"}},
+		AuthRandom:      strings.NewReader("0123456789abcdef"),
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+		HTTP: scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
+			return nil, errors.New(privateTransportValue)
+		}},
+	})
+
+	const wantStdout = `{"ok":false,"error":{"type":"remote.unavailable","code":"AUTH_SERVICE_UNAVAILABLE","message":"The authentication service is unavailable.","retryable":true,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
+	const wantStderr = "partiful: authentication service unavailable\n"
+	if result.ExitCode != 8 || result.Stdout != wantStdout || result.Stderr != wantStderr {
+		t.Fatalf("result = %#v, want auth unavailable failure", result)
+	}
+	if strings.Contains(result.Stdout+result.Stderr, privateTransportValue) {
+		t.Fatal("transport failure exposed a private error value")
+	}
+}
+
+func TestExecuteAuthLoginAtomicPersistenceFailurePreservesExistingCredentials(t *testing.T) {
+	const (
+		oldCredentials = `{"accessToken":"old-private-token","refreshToken":"old-private-refresh","expiresAt":"2026-08-11T02:00:00Z"}`
+		privateError   = "private atomic storage detail"
+	)
+	files := fakeFilesystem{
+		readFile: func(string) ([]byte, error) {
+			return []byte(oldCredentials), nil
+		},
+		writeFileAtomic: func(string, []byte) error {
+			return errors.New(privateError)
+		},
+	}
+	call := 0
+	dependencies := app.Dependencies{
+		Files:           files,
+		CredentialsPath: "/config/partiful/credentials.json",
+		Terminal:        &scriptedPrivateTerminal{values: []string{"+15555550123", "123456"}},
+		AuthRandom:      strings.NewReader("0123456789abcdef"),
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+		HTTP: scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
+			call++
+			switch call {
+			case 1:
+				return jsonResponse(http.StatusOK, `{}`), nil
+			case 2:
+				return jsonResponse(
+					http.StatusOK,
+					`{"result":{"data":{"token":"custom-private-token"}}}`,
+				), nil
+			default:
+				return jsonResponse(
+					http.StatusOK,
+					`{"idToken":"new-private-token","refreshToken":"new-private-refresh","expiresIn":"3600"}`,
+				), nil
+			}
+		}},
+	}
+	result := app.Execute(context.Background(), app.Request{
+		Argv: []string{"auth", "login"},
+	}, dependencies)
+
+	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIAL_STORE_UNAVAILABLE","message":"Local credential storage is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
+	if result.ExitCode != 10 || result.Stdout != wantStdout {
+		t.Fatalf("result = %#v, want atomic persistence failure", result)
+	}
+	if strings.Contains(result.Stdout+result.Stderr, privateError) {
+		t.Fatal("persistence failure exposed a private filesystem value")
+	}
+
+	status := app.Execute(context.Background(), app.Request{
+		Argv: []string{"auth", "status"},
+	}, dependencies)
+	if !strings.Contains(status.Stdout, `"authenticated":true,"tokenState":"healthy"`) {
+		t.Fatalf("status after failed persistence = %q, want old credentials intact", status.Stdout)
+	}
+}
+
+func jsonResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Header:     http.Header{"Content-Type": {"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
 type fakeFilesystem struct {
-	readFile func(string) ([]byte, error)
-	remove   func(string) error
+	readFile        func(string) ([]byte, error)
+	remove          func(string) error
+	writeFileAtomic func(string, []byte) error
 }
 
 func (filesystem fakeFilesystem) ReadFile(path string) ([]byte, error) {
@@ -1192,6 +1731,13 @@ func (filesystem fakeFilesystem) ReadFile(path string) ([]byte, error) {
 func (filesystem fakeFilesystem) Remove(path string) error {
 	if filesystem.remove != nil {
 		return filesystem.remove(path)
+	}
+	return nil
+}
+
+func (filesystem fakeFilesystem) WriteFileAtomic(path string, document []byte) error {
+	if filesystem.writeFileAtomic != nil {
+		return filesystem.writeFileAtomic(path, document)
 	}
 	return nil
 }
@@ -1213,7 +1759,7 @@ func TestExecuteAuthStatusRedactsHealthyCredentials(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T02:00:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.1","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T02:00:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -1247,7 +1793,7 @@ func TestExecuteAuthStatusReportsExpiringToken(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"expiring","expiresAt":"2026-08-11T00:04:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.1","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"expiring","expiresAt":"2026-08-11T00:04:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -1276,7 +1822,7 @@ func TestExecuteAuthStatusReportsExpiredToken(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"expired","expiresAt":"2026-08-10T23:59:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.1","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"expired","expiresAt":"2026-08-10T23:59:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -1305,7 +1851,7 @@ func TestExecuteAuthStatusFailureDoesNotRevealCredentialContents(t *testing.T) {
 		},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIALS_INVALID","message":"Local credentials are invalid.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.1"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIALS_INVALID","message":"Local credentials are invalid.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
 	const wantStderr = "partiful: local operation failed\n"
 	if result.ExitCode != 10 {
 		t.Fatalf("exit code = %d, want 10", result.ExitCode)
@@ -1341,7 +1887,7 @@ func TestExecuteAuthLogoutAtomicallyRemovesCredentials(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, dependencies)
 
-	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"missing","expiresAt":null},"meta":{"command":"auth.logout","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.1","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"missing","expiresAt":null},"meta":{"command":"auth.logout","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -1362,7 +1908,8 @@ func TestExecuteAuthLogoutAtomicallyRemovesCredentials(t *testing.T) {
 }
 
 type memoryFilesystem struct {
-	files map[string][]byte
+	files        map[string][]byte
+	atomicWrites int
 }
 
 func (filesystem *memoryFilesystem) ReadFile(path string) ([]byte, error) {
@@ -1378,6 +1925,12 @@ func (filesystem *memoryFilesystem) Remove(path string) error {
 		return fs.ErrNotExist
 	}
 	delete(filesystem.files, path)
+	return nil
+}
+
+func (filesystem *memoryFilesystem) WriteFileAtomic(path string, document []byte) error {
+	filesystem.atomicWrites++
+	filesystem.files[path] = append([]byte(nil), document...)
 	return nil
 }
 
@@ -1405,7 +1958,7 @@ func TestExecuteAuthLogoutFailureLeavesCredentialsAvailableAndRedactsError(t *te
 		Stdin: strings.NewReader(""),
 	}, dependencies)
 
-	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIAL_STORE_UNAVAILABLE","message":"Local credential storage is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.logout","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.1"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIAL_STORE_UNAVAILABLE","message":"Local credential storage is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.logout","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
 	if result.ExitCode != 10 {
 		t.Fatalf("exit code = %d, want 10", result.ExitCode)
 	}
@@ -1442,7 +1995,7 @@ func TestExecuteDoctorReportsHealthyCredentialsWithoutPrivateData(t *testing.T) 
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":true,"checks":[{"name":"credentials","status":"pass","message":"Authentication credentials are available.","remediation":null}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.1","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":true,"checks":[{"name":"credentials","status":"pass","message":"Authentication credentials are available.","remediation":null}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -1475,7 +2028,7 @@ func TestExecuteDoctorReportsMissingCredentialsAsARedactedCheck(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials are missing.","remediation":"Establish authentication before using commands that require it."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.1","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials are missing.","remediation":"Establish authentication before using commands that require it."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -1504,7 +2057,7 @@ func TestExecuteDoctorWarnsWhenCredentialsExpireSoon(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":true,"checks":[{"name":"credentials","status":"warn","message":"Authentication credentials expire soon.","remediation":"Refresh authentication before the credentials expire."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.1","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":true,"checks":[{"name":"credentials","status":"warn","message":"Authentication credentials expire soon.","remediation":"Refresh authentication before the credentials expire."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -1533,7 +2086,7 @@ func TestExecuteDoctorFailsExpiredCredentialsCheck(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials have expired.","remediation":"Re-establish authentication."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.1","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials have expired.","remediation":"Re-establish authentication."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -1562,7 +2115,7 @@ func TestExecuteDoctorRedactsInvalidCredentialFile(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials are invalid.","remediation":"Remove the invalid credentials and re-establish authentication."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.1","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials are invalid.","remediation":"Remove the invalid credentials and re-establish authentication."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -1594,7 +2147,7 @@ func TestExecuteDoctorRedactsCredentialStorageFailure(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Credential storage is unavailable.","remediation":"Check local credential file permissions."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.1","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Credential storage is unavailable.","remediation":"Check local credential file permissions."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -1702,7 +2255,7 @@ func TestExecuteUsesDefinitionForFlagFailureCommandMetadata(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"FLAG_REPEATED","message":"A scalar flag cannot be repeated.","retryable":false,"details":{"flag":"--non-interactive"}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.1"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"FLAG_REPEATED","message":"A scalar flag cannot be repeated.","retryable":false,"details":{"flag":"--non-interactive"}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -1746,7 +2299,7 @@ func TestExecuteUsesKnownCommandMetadataForInvalidArity(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_NOT_FOUND","message":"Unknown command.","retryable":false,"details":{}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.1"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_NOT_FOUND","message":"Unknown command.","retryable":false,"details":{}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -1771,7 +2324,7 @@ func TestExecuteAuthStatusReportsConfigurationDirectoryFailure(t *testing.T) {
 		},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CONFIG_DIRECTORY_UNAVAILABLE","message":"Local configuration directory is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.1"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CONFIG_DIRECTORY_UNAVAILABLE","message":"Local configuration directory is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2"}}` + "\n"
 	if result.ExitCode != 10 {
 		t.Fatalf("exit code = %d, want 10", result.ExitCode)
 	}
@@ -1796,7 +2349,7 @@ func TestExecuteDoctorDiagnosesConfigurationDirectoryFailure(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Configuration directory is unavailable.","remediation":"Set a usable user configuration directory."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.1","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Configuration directory is unavailable.","remediation":"Set a usable user configuration directory."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.2","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -2,7 +2,9 @@ package auth
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"io"
@@ -28,6 +30,7 @@ type FileSystem interface {
 	ReadFile(string) ([]byte, error)
 	Remove(string) error
 	WriteFileAtomic(string, []byte) error
+	WithLock(string, func()) error
 }
 
 type PrivateTerminal interface {
@@ -41,14 +44,16 @@ type State struct {
 }
 
 type Session struct {
-	AccessToken string
-	ExpiresAt   time.Time
+	AccessToken        string
+	ExpiresAt          time.Time
+	AccountFingerprint string
 }
 
 type credentialRecord struct {
-	AccessToken  string    `json:"accessToken"`
-	RefreshToken string    `json:"refreshToken"`
-	ExpiresAt    time.Time `json:"expiresAt"`
+	AccessToken        string    `json:"accessToken"`
+	RefreshToken       string    `json:"refreshToken"`
+	AccountFingerprint string    `json:"accountFingerprint,omitempty"`
+	ExpiresAt          time.Time `json:"expiresAt"`
 }
 
 func Login(
@@ -118,9 +123,10 @@ func Login(
 	}
 	expiresAt := now.Add(session.ExpiresIn).UTC()
 	err = SaveCredentials(files, path, Credentials{
-		AccessToken:  session.IDToken,
-		RefreshToken: session.RefreshToken,
-		ExpiresAt:    expiresAt,
+		AccessToken:        session.IDToken,
+		RefreshToken:       session.RefreshToken,
+		AccountFingerprint: accountFingerprint(session.IDToken),
+		ExpiresAt:          expiresAt,
 	})
 	if err != nil {
 		return State{}, ErrPersistence
@@ -136,47 +142,14 @@ func Status(files FileSystem, path string, now time.Time) (State, error) {
 	if files == nil || path == "" {
 		return State{}, ErrNotConfigured
 	}
-	document, err := files.ReadFile(path)
+	credentials, err := loadCredentials(files, path)
 	if errors.Is(err, fs.ErrNotExist) {
-		return State{
-			Authenticated: false,
-			TokenState:    "missing",
-			ExpiresAt:     nil,
-		}, nil
+		return missingState(), nil
 	}
 	if err != nil {
-		return State{}, ErrUnavailable
+		return State{}, err
 	}
-
-	var credentials credentialRecord
-	if err := json.Unmarshal(document, &credentials); err != nil ||
-		credentials.AccessToken == "" ||
-		credentials.ExpiresAt.IsZero() {
-		return State{}, ErrInvalid
-	}
-	if credentials.ExpiresAt.After(now.Add(5 * time.Minute)) {
-		expiresAt := credentials.ExpiresAt.UTC()
-		return State{
-			Authenticated: true,
-			TokenState:    "healthy",
-			ExpiresAt:     &expiresAt,
-		}, nil
-	}
-
-	if credentials.ExpiresAt.After(now) {
-		expiresAt := credentials.ExpiresAt.UTC()
-		return State{
-			Authenticated: true,
-			TokenState:    "expiring",
-			ExpiresAt:     &expiresAt,
-		}, nil
-	}
-	expiresAt := credentials.ExpiresAt.UTC()
-	return State{
-		Authenticated: false,
-		TokenState:    "expired",
-		ExpiresAt:     &expiresAt,
-	}, nil
+	return stateFromCredentials(credentials, now), nil
 }
 
 func StatusWithRefresh(
@@ -186,40 +159,8 @@ func StatusWithRefresh(
 	now time.Time,
 	client remote.AuthClient,
 ) (State, error) {
-	state, err := Status(files, path, now)
-	if err != nil ||
-		state.TokenState == "healthy" ||
-		state.TokenState == "missing" {
-		return state, err
-	}
-	document, err := files.ReadFile(path)
-	if err != nil {
-		return State{}, ErrUnavailable
-	}
-	var credentials credentialRecord
-	if json.Unmarshal(document, &credentials) != nil {
-		return State{}, ErrInvalid
-	}
-	if credentials.RefreshToken == "" {
-		return state, nil
-	}
-	refreshed, err := client.RefreshToken(ctx, credentials.RefreshToken)
-	if err != nil {
-		return State{}, err
-	}
-	expiresAt := now.Add(refreshed.ExpiresIn).UTC()
-	if err := SaveCredentials(files, path, Credentials{
-		AccessToken:  refreshed.IDToken,
-		RefreshToken: refreshed.RefreshToken,
-		ExpiresAt:    expiresAt,
-	}); err != nil {
-		return State{}, ErrPersistence
-	}
-	return State{
-		Authenticated: true,
-		TokenState:    "healthy",
-		ExpiresAt:     &expiresAt,
-	}, nil
+	_, state, err := refreshCredentials(ctx, files, path, now, client)
+	return state, err
 }
 
 func AcquireSession(
@@ -229,7 +170,7 @@ func AcquireSession(
 	now time.Time,
 	client remote.AuthClient,
 ) (Session, error) {
-	state, err := StatusWithRefresh(ctx, files, path, now, client)
+	credentials, state, err := refreshCredentials(ctx, files, path, now, client)
 	if err != nil {
 		return Session{}, err
 	}
@@ -239,17 +180,10 @@ func AcquireSession(
 	if state.TokenState == "expired" || !state.Authenticated || state.ExpiresAt == nil {
 		return Session{}, ErrSessionExpired
 	}
-	document, err := files.ReadFile(path)
-	if err != nil {
-		return Session{}, ErrUnavailable
-	}
-	var credentials credentialRecord
-	if json.Unmarshal(document, &credentials) != nil || credentials.AccessToken == "" {
-		return Session{}, ErrInvalid
-	}
 	return Session{
-		AccessToken: credentials.AccessToken,
-		ExpiresAt:   state.ExpiresAt.UTC(),
+		AccessToken:        credentials.AccessToken,
+		ExpiresAt:          state.ExpiresAt.UTC(),
+		AccountFingerprint: credentials.AccountFingerprint,
 	}, nil
 }
 
@@ -257,13 +191,165 @@ func Logout(files FileSystem, path string) (State, error) {
 	if files == nil || path == "" {
 		return State{}, ErrNotConfigured
 	}
-	err := files.Remove(path)
-	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+	var removeError error
+	if err := files.WithLock(path, func() {
+		removeError = files.Remove(path)
+	}); err != nil {
 		return State{}, ErrUnavailable
 	}
-	return State{
-		Authenticated: false,
-		TokenState:    "missing",
-		ExpiresAt:     nil,
-	}, nil
+	if removeError != nil && !errors.Is(removeError, fs.ErrNotExist) {
+		return State{}, ErrUnavailable
+	}
+	return missingState(), nil
+}
+
+func refreshCredentials(
+	ctx context.Context,
+	files FileSystem,
+	path string,
+	now time.Time,
+	client remote.AuthClient,
+) (credentialRecord, State, error) {
+	if files == nil || path == "" {
+		return credentialRecord{}, State{}, ErrNotConfigured
+	}
+	var (
+		credentials  credentialRecord
+		state        State
+		operationErr error
+	)
+	if err := files.WithLock(path, func() {
+		credentials, operationErr = loadCredentials(files, path)
+		if errors.Is(operationErr, fs.ErrNotExist) {
+			operationErr = nil
+			state = missingState()
+			return
+		}
+		if operationErr != nil {
+			return
+		}
+		state = stateFromCredentials(credentials, now)
+		if state.TokenState == "healthy" || credentials.RefreshToken == "" {
+			return
+		}
+		var refreshed remote.RefreshTokenResponse
+		refreshed, operationErr = client.RefreshToken(ctx, credentials.RefreshToken)
+		if operationErr != nil {
+			return
+		}
+		expiresAt := now.Add(refreshed.ExpiresIn).UTC()
+		credentials = credentialRecord{
+			AccessToken:  refreshed.IDToken,
+			RefreshToken: refreshed.RefreshToken,
+			AccountFingerprint: refreshedFingerprint(
+				credentials.AccountFingerprint,
+				refreshed.IDToken,
+			),
+			ExpiresAt: expiresAt,
+		}
+		operationErr = saveCredentialsUnlocked(files, path, Credentials{
+			AccessToken:        credentials.AccessToken,
+			RefreshToken:       credentials.RefreshToken,
+			AccountFingerprint: credentials.AccountFingerprint,
+			ExpiresAt:          credentials.ExpiresAt,
+		})
+		if operationErr != nil {
+			operationErr = ErrPersistence
+			return
+		}
+		state = stateFromCredentials(credentials, now)
+	}); err != nil {
+		return credentialRecord{}, State{}, ErrUnavailable
+	}
+	if operationErr != nil {
+		return credentialRecord{}, State{}, operationErr
+	}
+	return credentials, state, nil
+}
+
+func loadCredentials(files FileSystem, path string) (credentialRecord, error) {
+	document, err := files.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return credentialRecord{}, fs.ErrNotExist
+		}
+		return credentialRecord{}, ErrUnavailable
+	}
+	var credentials credentialRecord
+	if json.Unmarshal(document, &credentials) != nil ||
+		credentials.AccessToken == "" ||
+		credentials.ExpiresAt.IsZero() {
+		return credentialRecord{}, ErrInvalid
+	}
+	if credentials.AccountFingerprint == "" {
+		credentials.AccountFingerprint = accountFingerprint(credentials.AccessToken)
+	}
+	return credentials, nil
+}
+
+func stateFromCredentials(credentials credentialRecord, now time.Time) State {
+	expiresAt := credentials.ExpiresAt.UTC()
+	if credentials.ExpiresAt.After(now.Add(5 * time.Minute)) {
+		return State{Authenticated: true, TokenState: "healthy", ExpiresAt: &expiresAt}
+	}
+	if credentials.ExpiresAt.After(now) {
+		return State{Authenticated: true, TokenState: "expiring", ExpiresAt: &expiresAt}
+	}
+	return State{Authenticated: false, TokenState: "expired", ExpiresAt: &expiresAt}
+}
+
+func missingState() State {
+	return State{Authenticated: false, TokenState: "missing", ExpiresAt: nil}
+}
+
+func refreshedFingerprint(current, idToken string) string {
+	if fingerprint, ok := accountIdentityFingerprint(idToken); ok {
+		return fingerprint
+	}
+	if current != "" {
+		return current
+	}
+	return opaqueTokenFingerprint(idToken)
+}
+
+func accountFingerprint(idToken string) string {
+	if fingerprint, ok := accountIdentityFingerprint(idToken); ok {
+		return fingerprint
+	}
+	return opaqueTokenFingerprint(idToken)
+}
+
+func accountIdentityFingerprint(idToken string) (string, bool) {
+	segments := strings.Split(idToken, ".")
+	if len(segments) != 3 {
+		return "", false
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(segments[1])
+	if err != nil {
+		return "", false
+	}
+	var claims struct {
+		Subject string `json:"sub"`
+		UserID  string `json:"user_id"`
+	}
+	if json.Unmarshal(payload, &claims) != nil {
+		return "", false
+	}
+	identity := claims.UserID
+	if identity == "" {
+		identity = claims.Subject
+	}
+	if identity == "" {
+		return "", false
+	}
+	return fingerprint("partiful-account:v1:", identity), true
+}
+
+func opaqueTokenFingerprint(idToken string) string {
+	return fingerprint("partiful-session:v1:", idToken)
+}
+
+func fingerprint(domain, value string) string {
+	hash := sha256.Sum256([]byte(domain + value))
+	return hex.EncodeToString(hash[:])
 }

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -1,21 +1,35 @@
 package auth
 
 import (
+	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"io"
 	"io/fs"
+	"strings"
 	"time"
+
+	"github.com/KalebCole/partiful-cli/internal/remote"
 )
 
 var (
 	ErrNotConfigured = errors.New("credential storage is not configured")
 	ErrUnavailable   = errors.New("credential storage is unavailable")
 	ErrInvalid       = errors.New("credential record is invalid")
+	ErrHumanRequired = errors.New("a private terminal is required")
+	ErrInputInvalid  = errors.New("authentication input is invalid")
+	ErrPersistence   = errors.New("credential persistence failed")
 )
 
 type FileSystem interface {
 	ReadFile(string) ([]byte, error)
 	Remove(string) error
+	WriteFileAtomic(string, []byte) error
+}
+
+type PrivateTerminal interface {
+	ReadSecret(string) (string, error)
 }
 
 type State struct {
@@ -25,8 +39,90 @@ type State struct {
 }
 
 type credentialRecord struct {
-	AccessToken string    `json:"accessToken"`
-	ExpiresAt   time.Time `json:"expiresAt"`
+	AccessToken  string    `json:"accessToken"`
+	RefreshToken string    `json:"refreshToken"`
+	ExpiresAt    time.Time `json:"expiresAt"`
+}
+
+func Login(
+	ctx context.Context,
+	files FileSystem,
+	path string,
+	terminal PrivateTerminal,
+	now time.Time,
+	random io.Reader,
+	client remote.AuthClient,
+) (State, error) {
+	if files == nil || path == "" || random == nil {
+		return State{}, ErrNotConfigured
+	}
+	if terminal == nil {
+		return State{}, ErrHumanRequired
+	}
+	phoneNumber, err := terminal.ReadSecret("Phone number: ")
+	if errors.Is(err, ErrHumanRequired) {
+		return State{}, ErrHumanRequired
+	}
+	if err != nil {
+		return State{}, ErrUnavailable
+	}
+	phoneNumber = strings.TrimSpace(phoneNumber)
+	if phoneNumber == "" {
+		return State{}, ErrInputInvalid
+	}
+
+	deviceBytes := make([]byte, 16)
+	if _, err := io.ReadFull(random, deviceBytes); err != nil {
+		return State{}, ErrUnavailable
+	}
+	deviceID := base64.RawURLEncoding.EncodeToString(deviceBytes)
+	sessionID := now.UnixMilli()
+	if err := client.SendAuthCode(ctx, remote.SendAuthCodeRequest{
+		PhoneNumber:        phoneNumber,
+		AmplitudeDeviceID:  deviceID,
+		AmplitudeSessionID: sessionID,
+	}); err != nil {
+		return State{}, err
+	}
+
+	code, err := terminal.ReadSecret("Verification code: ")
+	if errors.Is(err, ErrHumanRequired) {
+		return State{}, ErrHumanRequired
+	}
+	if err != nil {
+		return State{}, ErrUnavailable
+	}
+	code = strings.TrimSpace(code)
+	if code == "" {
+		return State{}, ErrInputInvalid
+	}
+	customToken, err := client.GetLoginToken(ctx, remote.GetLoginTokenRequest{
+		PhoneNumber:        phoneNumber,
+		AuthCode:           code,
+		AmplitudeDeviceID:  deviceID,
+		AmplitudeSessionID: sessionID,
+	})
+	if err != nil {
+		return State{}, err
+	}
+	session, err := client.SignInWithCustomToken(ctx, customToken.Token)
+	if err != nil {
+		return State{}, err
+	}
+	expiresAt := now.Add(time.Duration(session.ExpiresIn) * time.Second).UTC()
+	err = SaveCredentials(files, path, Credentials{
+		AccessToken:  session.IDToken,
+		RefreshToken: session.RefreshToken,
+		ExpiresAt:    expiresAt,
+	})
+	if err != nil {
+		return State{}, ErrPersistence
+	}
+	return State{
+		Authenticated: true,
+		TokenState:    "healthy",
+		ExpiresAt:     &expiresAt,
+	}, nil
 }
 
 func Status(files FileSystem, path string, now time.Time) (State, error) {

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -52,11 +52,11 @@ func Login(
 	files FileSystem,
 	path string,
 	terminal PrivateTerminal,
-	now time.Time,
+	now func() time.Time,
 	random io.Reader,
 	client RemoteAuth,
 ) (State, error) {
-	if files == nil || path == "" || random == nil {
+	if files == nil || path == "" || now == nil || random == nil {
 		return State{}, ErrNotConfigured
 	}
 	if terminal == nil {
@@ -79,7 +79,7 @@ func Login(
 		return State{}, ErrUnavailable
 	}
 	deviceID := base64.RawURLEncoding.EncodeToString(deviceBytes)
-	sessionID := now.UnixMilli()
+	sessionID := now().UnixMilli()
 	if err := client.SendAuthCode(ctx, SendAuthCodeRequest{
 		PhoneNumber:        phoneNumber,
 		AmplitudeDeviceID:  deviceID,
@@ -112,7 +112,7 @@ func Login(
 	if err != nil {
 		return State{}, err
 	}
-	expiresAt := now.Add(session.ExpiresIn).UTC()
+	expiresAt := now().Add(session.ExpiresIn).UTC()
 	err = saveCredentials(files, path, credentialRecord{
 		AccessToken:  session.IDToken,
 		RefreshToken: session.RefreshToken,
@@ -146,7 +146,7 @@ func StatusWithRefresh(
 	ctx context.Context,
 	files FileSystem,
 	path string,
-	now time.Time,
+	now func() time.Time,
 	client RemoteAuth,
 ) (State, error) {
 	state, err := refreshCredentials(ctx, files, path, now, client)
@@ -173,10 +173,10 @@ func refreshCredentials(
 	ctx context.Context,
 	files FileSystem,
 	path string,
-	now time.Time,
+	now func() time.Time,
 	client RemoteAuth,
 ) (State, error) {
-	if files == nil || path == "" {
+	if files == nil || path == "" || now == nil {
 		return State{}, ErrNotConfigured
 	}
 	var (
@@ -194,7 +194,7 @@ func refreshCredentials(
 		if operationErr != nil {
 			return
 		}
-		state = stateFromCredentials(credentials, now)
+		state = stateFromCredentials(credentials, now())
 		if state.TokenState == "healthy" || credentials.RefreshToken == "" {
 			return
 		}
@@ -203,22 +203,19 @@ func refreshCredentials(
 		if operationErr != nil {
 			return
 		}
-		expiresAt := now.Add(refreshed.ExpiresIn).UTC()
+		completedAt := now()
+		expiresAt := completedAt.Add(refreshed.ExpiresIn).UTC()
 		credentials = credentialRecord{
 			AccessToken:  refreshed.IDToken,
 			RefreshToken: refreshed.RefreshToken,
 			ExpiresAt:    expiresAt,
 		}
-		operationErr = saveCredentialsUnlocked(files, path, credentialRecord{
-			AccessToken:  credentials.AccessToken,
-			RefreshToken: credentials.RefreshToken,
-			ExpiresAt:    credentials.ExpiresAt,
-		})
+		operationErr = saveCredentialsUnlocked(files, path, credentials)
 		if operationErr != nil {
 			operationErr = ErrPersistence
 			return
 		}
-		state = stateFromCredentials(credentials, now)
+		state = stateFromCredentials(credentials, completedAt)
 	}); err != nil {
 		return State{}, ErrUnavailable
 	}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -9,17 +9,19 @@ import (
 	"io/fs"
 	"strings"
 	"time"
-
-	"github.com/KalebCole/partiful-cli/internal/remote"
 )
 
 var (
-	ErrNotConfigured = errors.New("credential storage is not configured")
-	ErrUnavailable   = errors.New("credential storage is unavailable")
-	ErrInvalid       = errors.New("credential record is invalid")
-	ErrHumanRequired = errors.New("a private terminal is required")
-	ErrInputInvalid  = errors.New("authentication input is invalid")
-	ErrPersistence   = errors.New("credential persistence failed")
+	ErrNotConfigured         = errors.New("credential storage is not configured")
+	ErrUnavailable           = errors.New("credential storage is unavailable")
+	ErrInvalid               = errors.New("credential record is invalid")
+	ErrHumanRequired         = errors.New("a private terminal is required")
+	ErrInputInvalid          = errors.New("authentication input is invalid")
+	ErrPersistence           = errors.New("credential persistence failed")
+	ErrAuthCodeRejected      = errors.New("authentication code rejected")
+	ErrRemoteTokenExpired    = errors.New("remote authentication token expired")
+	ErrRemoteProtocolChanged = errors.New("remote authentication protocol changed")
+	ErrRemoteUnavailable     = errors.New("remote authentication service unavailable")
 )
 
 type FileSystem interface {
@@ -52,7 +54,7 @@ func Login(
 	terminal PrivateTerminal,
 	now time.Time,
 	random io.Reader,
-	client remote.AuthClient,
+	client RemoteAuth,
 ) (State, error) {
 	if files == nil || path == "" || random == nil {
 		return State{}, ErrNotConfigured
@@ -78,7 +80,7 @@ func Login(
 	}
 	deviceID := base64.RawURLEncoding.EncodeToString(deviceBytes)
 	sessionID := now.UnixMilli()
-	if err := client.SendAuthCode(ctx, remote.SendAuthCodeRequest{
+	if err := client.SendAuthCode(ctx, SendAuthCodeRequest{
 		PhoneNumber:        phoneNumber,
 		AmplitudeDeviceID:  deviceID,
 		AmplitudeSessionID: sessionID,
@@ -97,7 +99,7 @@ func Login(
 	if code == "" {
 		return State{}, ErrInputInvalid
 	}
-	customToken, err := client.GetLoginToken(ctx, remote.GetLoginTokenRequest{
+	customToken, err := client.GetLoginToken(ctx, GetLoginTokenRequest{
 		PhoneNumber:        phoneNumber,
 		AuthCode:           code,
 		AmplitudeDeviceID:  deviceID,
@@ -145,7 +147,7 @@ func StatusWithRefresh(
 	files FileSystem,
 	path string,
 	now time.Time,
-	client remote.AuthClient,
+	client RemoteAuth,
 ) (State, error) {
 	state, err := refreshCredentials(ctx, files, path, now, client)
 	return state, err
@@ -172,7 +174,7 @@ func refreshCredentials(
 	files FileSystem,
 	path string,
 	now time.Time,
-	client remote.AuthClient,
+	client RemoteAuth,
 ) (State, error) {
 	if files == nil || path == "" {
 		return State{}, ErrNotConfigured
@@ -196,7 +198,7 @@ func refreshCredentials(
 		if state.TokenState == "healthy" || credentials.RefreshToken == "" {
 			return
 		}
-		var refreshed remote.RefreshTokenResponse
+		var refreshed RefreshResponse
 		refreshed, operationErr = client.RefreshToken(ctx, credentials.RefreshToken)
 		if operationErr != nil {
 			return

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -14,12 +14,14 @@ import (
 )
 
 var (
-	ErrNotConfigured = errors.New("credential storage is not configured")
-	ErrUnavailable   = errors.New("credential storage is unavailable")
-	ErrInvalid       = errors.New("credential record is invalid")
-	ErrHumanRequired = errors.New("a private terminal is required")
-	ErrInputInvalid  = errors.New("authentication input is invalid")
-	ErrPersistence   = errors.New("credential persistence failed")
+	ErrNotConfigured  = errors.New("credential storage is not configured")
+	ErrUnavailable    = errors.New("credential storage is unavailable")
+	ErrInvalid        = errors.New("credential record is invalid")
+	ErrHumanRequired  = errors.New("a private terminal is required")
+	ErrInputInvalid   = errors.New("authentication input is invalid")
+	ErrPersistence    = errors.New("credential persistence failed")
+	ErrRequired       = errors.New("authentication is required")
+	ErrSessionExpired = errors.New("authentication session is expired")
 )
 
 type FileSystem interface {
@@ -36,6 +38,11 @@ type State struct {
 	Authenticated bool       `json:"authenticated"`
 	TokenState    string     `json:"tokenState"`
 	ExpiresAt     *time.Time `json:"expiresAt"`
+}
+
+type Session struct {
+	AccessToken string
+	ExpiresAt   time.Time
 }
 
 type credentialRecord struct {
@@ -169,6 +176,80 @@ func Status(files FileSystem, path string, now time.Time) (State, error) {
 		Authenticated: false,
 		TokenState:    "expired",
 		ExpiresAt:     &expiresAt,
+	}, nil
+}
+
+func StatusWithRefresh(
+	ctx context.Context,
+	files FileSystem,
+	path string,
+	now time.Time,
+	client remote.AuthClient,
+) (State, error) {
+	state, err := Status(files, path, now)
+	if err != nil ||
+		state.TokenState == "healthy" ||
+		state.TokenState == "missing" {
+		return state, err
+	}
+	document, err := files.ReadFile(path)
+	if err != nil {
+		return State{}, ErrUnavailable
+	}
+	var credentials credentialRecord
+	if json.Unmarshal(document, &credentials) != nil {
+		return State{}, ErrInvalid
+	}
+	if credentials.RefreshToken == "" {
+		return state, nil
+	}
+	refreshed, err := client.RefreshToken(ctx, credentials.RefreshToken)
+	if err != nil {
+		return State{}, err
+	}
+	expiresAt := now.Add(time.Duration(refreshed.ExpiresIn) * time.Second).UTC()
+	if err := SaveCredentials(files, path, Credentials{
+		AccessToken:  refreshed.IDToken,
+		RefreshToken: refreshed.RefreshToken,
+		ExpiresAt:    expiresAt,
+	}); err != nil {
+		return State{}, ErrPersistence
+	}
+	return State{
+		Authenticated: true,
+		TokenState:    "healthy",
+		ExpiresAt:     &expiresAt,
+	}, nil
+}
+
+func AcquireSession(
+	ctx context.Context,
+	files FileSystem,
+	path string,
+	now time.Time,
+	client remote.AuthClient,
+) (Session, error) {
+	state, err := StatusWithRefresh(ctx, files, path, now, client)
+	if err != nil {
+		return Session{}, err
+	}
+	if state.TokenState == "missing" {
+		return Session{}, ErrRequired
+	}
+	if state.TokenState == "expired" || !state.Authenticated || state.ExpiresAt == nil {
+		return Session{}, ErrSessionExpired
+	}
+	document, err := files.ReadFile(path)
+	if err != nil {
+		return Session{}, ErrUnavailable
+	}
+	var credentials credentialRecord
+	if json.Unmarshal(document, &credentials) != nil || credentials.AccessToken == "" {
+		return Session{}, ErrInvalid
+	}
+	return Session{
+		AccessToken: credentials.AccessToken,
+		ExpiresAt:   state.ExpiresAt.UTC(),
 	}, nil
 }
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -111,7 +111,7 @@ func Login(
 		return State{}, err
 	}
 	expiresAt := now.Add(session.ExpiresIn).UTC()
-	err = SaveCredentials(files, path, Credentials{
+	err = saveCredentials(files, path, credentialRecord{
 		AccessToken:  session.IDToken,
 		RefreshToken: session.RefreshToken,
 		ExpiresAt:    expiresAt,
@@ -147,7 +147,7 @@ func StatusWithRefresh(
 	now time.Time,
 	client remote.AuthClient,
 ) (State, error) {
-	_, state, err := refreshCredentials(ctx, files, path, now, client)
+	state, err := refreshCredentials(ctx, files, path, now, client)
 	return state, err
 }
 
@@ -173,9 +173,9 @@ func refreshCredentials(
 	path string,
 	now time.Time,
 	client remote.AuthClient,
-) (credentialRecord, State, error) {
+) (State, error) {
 	if files == nil || path == "" {
-		return credentialRecord{}, State{}, ErrNotConfigured
+		return State{}, ErrNotConfigured
 	}
 	var (
 		credentials  credentialRecord
@@ -207,7 +207,7 @@ func refreshCredentials(
 			RefreshToken: refreshed.RefreshToken,
 			ExpiresAt:    expiresAt,
 		}
-		operationErr = saveCredentialsUnlocked(files, path, Credentials{
+		operationErr = saveCredentialsUnlocked(files, path, credentialRecord{
 			AccessToken:  credentials.AccessToken,
 			RefreshToken: credentials.RefreshToken,
 			ExpiresAt:    credentials.ExpiresAt,
@@ -218,12 +218,12 @@ func refreshCredentials(
 		}
 		state = stateFromCredentials(credentials, now)
 	}); err != nil {
-		return credentialRecord{}, State{}, ErrUnavailable
+		return State{}, ErrUnavailable
 	}
 	if operationErr != nil {
-		return credentialRecord{}, State{}, operationErr
+		return State{}, operationErr
 	}
-	return credentials, state, nil
+	return state, nil
 }
 
 func loadCredentials(files FileSystem, path string) (credentialRecord, error) {

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -116,7 +116,7 @@ func Login(
 	if err != nil {
 		return State{}, err
 	}
-	expiresAt := now.Add(time.Duration(session.ExpiresIn) * time.Second).UTC()
+	expiresAt := now.Add(session.ExpiresIn).UTC()
 	err = SaveCredentials(files, path, Credentials{
 		AccessToken:  session.IDToken,
 		RefreshToken: session.RefreshToken,
@@ -207,7 +207,7 @@ func StatusWithRefresh(
 	if err != nil {
 		return State{}, err
 	}
-	expiresAt := now.Add(time.Duration(refreshed.ExpiresIn) * time.Second).UTC()
+	expiresAt := now.Add(refreshed.ExpiresIn).UTC()
 	if err := SaveCredentials(files, path, Credentials{
 		AccessToken:  refreshed.IDToken,
 		RefreshToken: refreshed.RefreshToken,

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -66,6 +66,9 @@ func Login(
 	if errors.Is(err, ErrHumanRequired) {
 		return State{}, ErrHumanRequired
 	}
+	if errors.Is(err, ErrInputInvalid) {
+		return State{}, ErrInputInvalid
+	}
 	if err != nil {
 		return State{}, ErrUnavailable
 	}
@@ -91,6 +94,9 @@ func Login(
 	code, err := terminal.ReadSecret("Verification code: ")
 	if errors.Is(err, ErrHumanRequired) {
 		return State{}, ErrHumanRequired
+	}
+	if errors.Is(err, ErrInputInvalid) {
+		return State{}, ErrInputInvalid
 	}
 	if err != nil {
 		return State{}, ErrUnavailable

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -2,9 +2,7 @@ package auth
 
 import (
 	"context"
-	"crypto/sha256"
 	"encoding/base64"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"io"
@@ -16,14 +14,12 @@ import (
 )
 
 var (
-	ErrNotConfigured  = errors.New("credential storage is not configured")
-	ErrUnavailable    = errors.New("credential storage is unavailable")
-	ErrInvalid        = errors.New("credential record is invalid")
-	ErrHumanRequired  = errors.New("a private terminal is required")
-	ErrInputInvalid   = errors.New("authentication input is invalid")
-	ErrPersistence    = errors.New("credential persistence failed")
-	ErrRequired       = errors.New("authentication is required")
-	ErrSessionExpired = errors.New("authentication session is expired")
+	ErrNotConfigured = errors.New("credential storage is not configured")
+	ErrUnavailable   = errors.New("credential storage is unavailable")
+	ErrInvalid       = errors.New("credential record is invalid")
+	ErrHumanRequired = errors.New("a private terminal is required")
+	ErrInputInvalid  = errors.New("authentication input is invalid")
+	ErrPersistence   = errors.New("credential persistence failed")
 )
 
 type FileSystem interface {
@@ -43,17 +39,10 @@ type State struct {
 	ExpiresAt     *time.Time `json:"expiresAt"`
 }
 
-type Session struct {
-	AccessToken        string
-	ExpiresAt          time.Time
-	AccountFingerprint string
-}
-
 type credentialRecord struct {
-	AccessToken        string    `json:"accessToken"`
-	RefreshToken       string    `json:"refreshToken"`
-	AccountFingerprint string    `json:"accountFingerprint,omitempty"`
-	ExpiresAt          time.Time `json:"expiresAt"`
+	AccessToken  string    `json:"accessToken"`
+	RefreshToken string    `json:"refreshToken"`
+	ExpiresAt    time.Time `json:"expiresAt"`
 }
 
 func Login(
@@ -123,10 +112,9 @@ func Login(
 	}
 	expiresAt := now.Add(session.ExpiresIn).UTC()
 	err = SaveCredentials(files, path, Credentials{
-		AccessToken:        session.IDToken,
-		RefreshToken:       session.RefreshToken,
-		AccountFingerprint: accountFingerprint(session.IDToken),
-		ExpiresAt:          expiresAt,
+		AccessToken:  session.IDToken,
+		RefreshToken: session.RefreshToken,
+		ExpiresAt:    expiresAt,
 	})
 	if err != nil {
 		return State{}, ErrPersistence
@@ -161,30 +149,6 @@ func StatusWithRefresh(
 ) (State, error) {
 	_, state, err := refreshCredentials(ctx, files, path, now, client)
 	return state, err
-}
-
-func AcquireSession(
-	ctx context.Context,
-	files FileSystem,
-	path string,
-	now time.Time,
-	client remote.AuthClient,
-) (Session, error) {
-	credentials, state, err := refreshCredentials(ctx, files, path, now, client)
-	if err != nil {
-		return Session{}, err
-	}
-	if state.TokenState == "missing" {
-		return Session{}, ErrRequired
-	}
-	if state.TokenState == "expired" || !state.Authenticated || state.ExpiresAt == nil {
-		return Session{}, ErrSessionExpired
-	}
-	return Session{
-		AccessToken:        credentials.AccessToken,
-		ExpiresAt:          state.ExpiresAt.UTC(),
-		AccountFingerprint: credentials.AccountFingerprint,
-	}, nil
 }
 
 func Logout(files FileSystem, path string) (State, error) {
@@ -241,17 +205,12 @@ func refreshCredentials(
 		credentials = credentialRecord{
 			AccessToken:  refreshed.IDToken,
 			RefreshToken: refreshed.RefreshToken,
-			AccountFingerprint: refreshedFingerprint(
-				credentials.AccountFingerprint,
-				refreshed.IDToken,
-			),
-			ExpiresAt: expiresAt,
+			ExpiresAt:    expiresAt,
 		}
 		operationErr = saveCredentialsUnlocked(files, path, Credentials{
-			AccessToken:        credentials.AccessToken,
-			RefreshToken:       credentials.RefreshToken,
-			AccountFingerprint: credentials.AccountFingerprint,
-			ExpiresAt:          credentials.ExpiresAt,
+			AccessToken:  credentials.AccessToken,
+			RefreshToken: credentials.RefreshToken,
+			ExpiresAt:    credentials.ExpiresAt,
 		})
 		if operationErr != nil {
 			operationErr = ErrPersistence
@@ -281,9 +240,6 @@ func loadCredentials(files FileSystem, path string) (credentialRecord, error) {
 		credentials.ExpiresAt.IsZero() {
 		return credentialRecord{}, ErrInvalid
 	}
-	if credentials.AccountFingerprint == "" {
-		credentials.AccountFingerprint = accountFingerprint(credentials.AccessToken)
-	}
 	return credentials, nil
 }
 
@@ -300,56 +256,4 @@ func stateFromCredentials(credentials credentialRecord, now time.Time) State {
 
 func missingState() State {
 	return State{Authenticated: false, TokenState: "missing", ExpiresAt: nil}
-}
-
-func refreshedFingerprint(current, idToken string) string {
-	if fingerprint, ok := accountIdentityFingerprint(idToken); ok {
-		return fingerprint
-	}
-	if current != "" {
-		return current
-	}
-	return opaqueTokenFingerprint(idToken)
-}
-
-func accountFingerprint(idToken string) string {
-	if fingerprint, ok := accountIdentityFingerprint(idToken); ok {
-		return fingerprint
-	}
-	return opaqueTokenFingerprint(idToken)
-}
-
-func accountIdentityFingerprint(idToken string) (string, bool) {
-	segments := strings.Split(idToken, ".")
-	if len(segments) != 3 {
-		return "", false
-	}
-	payload, err := base64.RawURLEncoding.DecodeString(segments[1])
-	if err != nil {
-		return "", false
-	}
-	var claims struct {
-		Subject string `json:"sub"`
-		UserID  string `json:"user_id"`
-	}
-	if json.Unmarshal(payload, &claims) != nil {
-		return "", false
-	}
-	identity := claims.UserID
-	if identity == "" {
-		identity = claims.Subject
-	}
-	if identity == "" {
-		return "", false
-	}
-	return fingerprint("partiful-account:v1:", identity), true
-}
-
-func opaqueTokenFingerprint(idToken string) string {
-	return fingerprint("partiful-session:v1:", idToken)
-}
-
-func fingerprint(domain, value string) string {
-	hash := sha256.Sum256([]byte(domain + value))
-	return hex.EncodeToString(hash[:])
 }

--- a/internal/auth/os_files.go
+++ b/internal/auth/os_files.go
@@ -1,8 +1,6 @@
 package auth
 
 import (
-	"errors"
-	"io/fs"
 	"os"
 	"path/filepath"
 )
@@ -15,6 +13,28 @@ func (OSFileSystem) ReadFile(path string) ([]byte, error) {
 
 func (OSFileSystem) Remove(path string) error {
 	return os.Remove(path)
+}
+
+func (OSFileSystem) WithLock(path string, operation func()) error {
+	directory := filepath.Dir(path)
+	if err := os.MkdirAll(directory, 0o700); err != nil {
+		return err
+	}
+	lock, err := os.OpenFile(path+".lock", os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return err
+	}
+	defer lock.Close()
+	if err := lock.Chmod(0o600); err != nil {
+		return err
+	}
+	release, err := acquireFileLock(lock)
+	if err != nil {
+		return err
+	}
+	defer release()
+	operation()
+	return nil
 }
 
 func (OSFileSystem) WriteFileAtomic(path string, document []byte) (resultError error) {
@@ -45,18 +65,10 @@ func (OSFileSystem) WriteFileAtomic(path string, document []byte) (resultError e
 	if err := temporary.Close(); err != nil {
 		return err
 	}
-	if err := os.Rename(temporaryPath, path); err != nil {
+	if err := replaceFile(temporaryPath, path); err != nil {
 		return err
 	}
-	directoryHandle, err := os.Open(directory)
-	if err != nil {
-		return err
-	}
-	defer directoryHandle.Close()
-	if err := directoryHandle.Sync(); err != nil &&
-		!errors.Is(err, fs.ErrInvalid) {
-		return err
-	}
+	syncDirectory(directory)
 	return nil
 }
 

--- a/internal/auth/os_files.go
+++ b/internal/auth/os_files.go
@@ -20,12 +20,20 @@ func (OSFileSystem) WithLock(path string, operation func()) error {
 	if err := os.MkdirAll(directory, 0o700); err != nil {
 		return err
 	}
+	if err := secureDirectory(directory); err != nil {
+		return err
+	}
 	lock, err := os.OpenFile(path+".lock", os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
 		return err
 	}
-	defer lock.Close()
+	defer func() {
+		_ = lock.Close()
+	}()
 	if err := lock.Chmod(0o600); err != nil {
+		return err
+	}
+	if err := secureFile(lock.Name()); err != nil {
 		return err
 	}
 	release, err := acquireFileLock(lock)
@@ -42,6 +50,9 @@ func (OSFileSystem) WriteFileAtomic(path string, document []byte) (resultError e
 	if err := os.MkdirAll(directory, 0o700); err != nil {
 		return err
 	}
+	if err := secureDirectory(directory); err != nil {
+		return err
+	}
 	temporary, err := os.CreateTemp(directory, ".credentials-*")
 	if err != nil {
 		return err
@@ -54,6 +65,9 @@ func (OSFileSystem) WriteFileAtomic(path string, document []byte) (resultError e
 		}
 	}()
 	if err := temporary.Chmod(0o600); err != nil {
+		return err
+	}
+	if err := secureFile(temporaryPath); err != nil {
 		return err
 	}
 	if _, err := temporary.Write(document); err != nil {

--- a/internal/auth/os_files.go
+++ b/internal/auth/os_files.go
@@ -1,6 +1,8 @@
 package auth
 
 import (
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 )
@@ -13,6 +15,49 @@ func (OSFileSystem) ReadFile(path string) ([]byte, error) {
 
 func (OSFileSystem) Remove(path string) error {
 	return os.Remove(path)
+}
+
+func (OSFileSystem) WriteFileAtomic(path string, document []byte) (resultError error) {
+	directory := filepath.Dir(path)
+	if err := os.MkdirAll(directory, 0o700); err != nil {
+		return err
+	}
+	temporary, err := os.CreateTemp(directory, ".credentials-*")
+	if err != nil {
+		return err
+	}
+	temporaryPath := temporary.Name()
+	defer func() {
+		if resultError != nil {
+			_ = temporary.Close()
+			_ = os.Remove(temporaryPath)
+		}
+	}()
+	if err := temporary.Chmod(0o600); err != nil {
+		return err
+	}
+	if _, err := temporary.Write(document); err != nil {
+		return err
+	}
+	if err := temporary.Sync(); err != nil {
+		return err
+	}
+	if err := temporary.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(temporaryPath, path); err != nil {
+		return err
+	}
+	directoryHandle, err := os.Open(directory)
+	if err != nil {
+		return err
+	}
+	defer directoryHandle.Close()
+	if err := directoryHandle.Sync(); err != nil &&
+		!errors.Is(err, fs.ErrInvalid) {
+		return err
+	}
+	return nil
 }
 
 func DefaultCredentialsPath() (string, error) {

--- a/internal/auth/os_terminal.go
+++ b/internal/auth/os_terminal.go
@@ -32,6 +32,9 @@ func (terminal OSTerminal) ReadSecret(prompt string) (string, error) {
 	}
 	value, err := readSecretWithSignalRestore(terminal.Input)
 	_, _ = io.WriteString(terminal.Output, "\n")
+	if errors.Is(err, ErrInputInvalid) {
+		return "", ErrInputInvalid
+	}
 	if err != nil {
 		return "", ErrUnavailable
 	}

--- a/internal/auth/os_terminal.go
+++ b/internal/auth/os_terminal.go
@@ -1,0 +1,31 @@
+package auth
+
+import (
+	"io"
+	"os"
+	"strings"
+
+	"golang.org/x/term"
+)
+
+type OSTerminal struct {
+	Input  *os.File
+	Output io.Writer
+}
+
+func (terminal OSTerminal) ReadSecret(prompt string) (string, error) {
+	if terminal.Input == nil ||
+		terminal.Output == nil ||
+		!term.IsTerminal(int(terminal.Input.Fd())) {
+		return "", ErrHumanRequired
+	}
+	if _, err := io.WriteString(terminal.Output, prompt); err != nil {
+		return "", ErrUnavailable
+	}
+	value, err := term.ReadPassword(int(terminal.Input.Fd()))
+	_, _ = io.WriteString(terminal.Output, "\n")
+	if err != nil {
+		return "", ErrUnavailable
+	}
+	return strings.TrimSpace(string(value)), nil
+}

--- a/internal/auth/os_terminal.go
+++ b/internal/auth/os_terminal.go
@@ -94,28 +94,41 @@ func readSecretWithSignalRestore(input *os.File) ([]byte, error) {
 func readRawSecret(input io.Reader) ([]byte, error) {
 	value := make([]byte, 0, 32)
 	oneByte := []byte{0}
-	for len(value) < maximumSecretInputBytes {
+	oversized := false
+	for {
 		count, err := input.Read(oneByte)
 		if count > 0 {
 			switch oneByte[0] {
 			case '\r', '\n':
+				if oversized {
+					return nil, ErrInputInvalid
+				}
 				return value, nil
 			case 3:
 				return nil, errTerminalInterrupted
 			case 8, 127:
-				if len(value) > 0 {
+				if !oversized && len(value) > 0 {
 					_, size := utf8.DecodeLastRune(value)
 					value = value[:len(value)-size]
 				}
 			case 21:
 				value = value[:0]
+				oversized = false
 			default:
+				if oversized {
+					break
+				}
 				value = append(value, oneByte[0])
+				if len(value) >= maximumSecretInputBytes {
+					oversized = true
+				}
 			}
 		}
 		if err != nil {
+			if oversized {
+				return nil, ErrInputInvalid
+			}
 			return nil, err
 		}
 	}
-	return nil, ErrInputInvalid
 }

--- a/internal/auth/os_terminal.go
+++ b/internal/auth/os_terminal.go
@@ -1,9 +1,13 @@
 package auth
 
 import (
+	"errors"
 	"io"
 	"os"
+	"os/signal"
 	"strings"
+	"sync"
+	"unicode/utf8"
 
 	"golang.org/x/term"
 )
@@ -12,6 +16,10 @@ type OSTerminal struct {
 	Input  *os.File
 	Output io.Writer
 }
+
+var errTerminalInterrupted = errors.New("terminal input interrupted")
+
+const maximumSecretInputBytes = 4 << 10
 
 func (terminal OSTerminal) ReadSecret(prompt string) (string, error) {
 	if terminal.Input == nil ||
@@ -22,10 +30,89 @@ func (terminal OSTerminal) ReadSecret(prompt string) (string, error) {
 	if _, err := io.WriteString(terminal.Output, prompt); err != nil {
 		return "", ErrUnavailable
 	}
-	value, err := term.ReadPassword(int(terminal.Input.Fd()))
+	value, err := readSecretWithSignalRestore(terminal.Input)
 	_, _ = io.WriteString(terminal.Output, "\n")
 	if err != nil {
 		return "", ErrUnavailable
 	}
 	return strings.TrimSpace(string(value)), nil
+}
+
+func readSecretWithSignalRestore(input *os.File) ([]byte, error) {
+	fileDescriptor := int(input.Fd())
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, passwordSignals()...)
+	defer signal.Stop(signals)
+
+	state, err := term.MakeRaw(fileDescriptor)
+	if err != nil {
+		signal.Stop(signals)
+		select {
+		case received := <-signals:
+			return nil, terminateAfterRestore(received)
+		default:
+		}
+		return nil, err
+	}
+	var restoreOnce sync.Once
+	restore := func() {
+		restoreOnce.Do(func() {
+			_ = term.Restore(fileDescriptor, state)
+		})
+	}
+	defer restore()
+
+	done := make(chan struct{})
+	go func() {
+		select {
+		case received := <-signals:
+			restore()
+			if err := terminateAfterRestore(received); err != nil {
+				os.Exit(1)
+			}
+		case <-done:
+		}
+	}()
+	value, readErr := readRawSecret(input)
+	restore()
+	signal.Stop(signals)
+	select {
+	case received := <-signals:
+		return nil, terminateAfterRestore(received)
+	default:
+	}
+	close(done)
+	if errors.Is(readErr, errTerminalInterrupted) {
+		return nil, terminateAfterRestore(os.Interrupt)
+	}
+	return value, readErr
+}
+
+func readRawSecret(input io.Reader) ([]byte, error) {
+	value := make([]byte, 0, 32)
+	oneByte := []byte{0}
+	for len(value) < maximumSecretInputBytes {
+		count, err := input.Read(oneByte)
+		if count > 0 {
+			switch oneByte[0] {
+			case '\r', '\n':
+				return value, nil
+			case 3:
+				return nil, errTerminalInterrupted
+			case 8, 127:
+				if len(value) > 0 {
+					_, size := utf8.DecodeLastRune(value)
+					value = value[:len(value)-size]
+				}
+			case 21:
+				value = value[:0]
+			default:
+				value = append(value, oneByte[0])
+			}
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+	return nil, ErrInputInvalid
 }

--- a/internal/auth/os_terminal_signals_unix.go
+++ b/internal/auth/os_terminal_signals_unix.go
@@ -1,0 +1,30 @@
+//go:build !windows
+
+package auth
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func passwordSignals() []os.Signal {
+	return []os.Signal{os.Interrupt, syscall.SIGTERM}
+}
+
+func terminateAfterRestore(received os.Signal) error {
+	signal.Reset(received)
+	process, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		return err
+	}
+	if err := process.Signal(received); err != nil {
+		return err
+	}
+	exitCode := 1
+	if unixSignal, ok := received.(syscall.Signal); ok {
+		exitCode = 128 + int(unixSignal)
+	}
+	os.Exit(exitCode)
+	return ErrUnavailable
+}

--- a/internal/auth/os_terminal_signals_windows.go
+++ b/internal/auth/os_terminal_signals_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package auth
+
+import (
+	"os"
+	"syscall"
+)
+
+func passwordSignals() []os.Signal {
+	return []os.Signal{os.Interrupt, syscall.SIGTERM}
+}
+
+func terminateAfterRestore(os.Signal) error {
+	os.Exit(130)
+	return nil
+}

--- a/internal/auth/os_unix.go
+++ b/internal/auth/os_unix.go
@@ -1,0 +1,35 @@
+//go:build !windows
+
+package auth
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func acquireFileLock(file *os.File) (func(), error) {
+	if err := unix.Flock(int(file.Fd()), unix.LOCK_EX); err != nil {
+		return nil, err
+	}
+	return func() {
+		_ = unix.Flock(int(file.Fd()), unix.LOCK_UN)
+	}, nil
+}
+
+func replaceFile(source, destination string) error {
+	return os.Rename(source, destination)
+}
+
+func syncDirectory(directory string) {
+	handle, err := os.Open(directory)
+	if err != nil {
+		return
+	}
+	defer handle.Close()
+	if err := handle.Sync(); err != nil && !errors.Is(err, fs.ErrInvalid) {
+		return
+	}
+}

--- a/internal/auth/os_unix.go
+++ b/internal/auth/os_unix.go
@@ -3,8 +3,6 @@
 package auth
 
 import (
-	"errors"
-	"io/fs"
 	"os"
 
 	"golang.org/x/sys/unix"
@@ -23,13 +21,21 @@ func replaceFile(source, destination string) error {
 	return os.Rename(source, destination)
 }
 
+func secureDirectory(string) error {
+	return nil
+}
+
+func secureFile(string) error {
+	return nil
+}
+
 func syncDirectory(directory string) {
 	handle, err := os.Open(directory)
 	if err != nil {
 		return
 	}
-	defer handle.Close()
-	if err := handle.Sync(); err != nil && !errors.Is(err, fs.ErrInvalid) {
-		return
-	}
+	defer func() {
+		_ = handle.Close()
+	}()
+	_ = handle.Sync()
 }

--- a/internal/auth/os_windows.go
+++ b/internal/auth/os_windows.go
@@ -41,4 +41,38 @@ func replaceFile(source, destination string) error {
 	)
 }
 
+func secureDirectory(path string) error {
+	return setCurrentUserDACL(path, "OICI")
+}
+
+func secureFile(path string) error {
+	return setCurrentUserDACL(path, "")
+}
+
+func setCurrentUserDACL(path, inheritance string) error {
+	user, err := windows.GetCurrentProcessToken().GetTokenUser()
+	if err != nil {
+		return err
+	}
+	descriptor, err := windows.SecurityDescriptorFromString(
+		"D:P(A;" + inheritance + ";FA;;;" + user.User.Sid.String() + ")",
+	)
+	if err != nil {
+		return err
+	}
+	dacl, _, err := descriptor.DACL()
+	if err != nil {
+		return err
+	}
+	return windows.SetNamedSecurityInfo(
+		path,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION,
+		nil,
+		nil,
+		dacl,
+		nil,
+	)
+}
+
 func syncDirectory(string) {}

--- a/internal/auth/os_windows.go
+++ b/internal/auth/os_windows.go
@@ -1,0 +1,44 @@
+//go:build windows
+
+package auth
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func acquireFileLock(file *os.File) (func(), error) {
+	var overlapped windows.Overlapped
+	if err := windows.LockFileEx(
+		windows.Handle(file.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK,
+		0,
+		1,
+		0,
+		&overlapped,
+	); err != nil {
+		return nil, err
+	}
+	return func() {
+		_ = windows.UnlockFileEx(windows.Handle(file.Fd()), 0, 1, 0, &overlapped)
+	}, nil
+}
+
+func replaceFile(source, destination string) error {
+	sourcePath, err := windows.UTF16PtrFromString(source)
+	if err != nil {
+		return err
+	}
+	destinationPath, err := windows.UTF16PtrFromString(destination)
+	if err != nil {
+		return err
+	}
+	return windows.MoveFileEx(
+		sourcePath,
+		destinationPath,
+		windows.MOVEFILE_REPLACE_EXISTING|windows.MOVEFILE_WRITE_THROUGH,
+	)
+}
+
+func syncDirectory(string) {}

--- a/internal/auth/persist.go
+++ b/internal/auth/persist.go
@@ -20,5 +20,8 @@ func saveCredentialsUnlocked(files FileSystem, path string, credentials credenti
 	if err != nil {
 		return ErrUnavailable
 	}
-	return files.WriteFileAtomic(path, document)
+	if err := files.WriteFileAtomic(path, document); err != nil {
+		return ErrPersistence
+	}
+	return nil
 }

--- a/internal/auth/persist.go
+++ b/internal/auth/persist.go
@@ -6,10 +6,9 @@ import (
 )
 
 type Credentials struct {
-	AccessToken        string    `json:"accessToken"`
-	RefreshToken       string    `json:"refreshToken,omitempty"`
-	AccountFingerprint string    `json:"accountFingerprint,omitempty"`
-	ExpiresAt          time.Time `json:"expiresAt"`
+	AccessToken  string    `json:"accessToken"`
+	RefreshToken string    `json:"refreshToken,omitempty"`
+	ExpiresAt    time.Time `json:"expiresAt"`
 }
 
 func SaveCredentials(files FileSystem, path string, credentials Credentials) error {

--- a/internal/auth/persist.go
+++ b/internal/auth/persist.go
@@ -6,16 +6,26 @@ import (
 )
 
 type Credentials struct {
-	AccessToken  string    `json:"accessToken"`
-	RefreshToken string    `json:"refreshToken,omitempty"`
-	UserID       string    `json:"userId,omitempty"`
-	ExpiresAt    time.Time `json:"expiresAt"`
+	AccessToken        string    `json:"accessToken"`
+	RefreshToken       string    `json:"refreshToken,omitempty"`
+	AccountFingerprint string    `json:"accountFingerprint,omitempty"`
+	ExpiresAt          time.Time `json:"expiresAt"`
 }
 
 func SaveCredentials(files FileSystem, path string, credentials Credentials) error {
 	if files == nil || path == "" {
 		return ErrNotConfigured
 	}
+	var saveError error
+	if err := files.WithLock(path, func() {
+		saveError = saveCredentialsUnlocked(files, path, credentials)
+	}); err != nil {
+		return ErrUnavailable
+	}
+	return saveError
+}
+
+func saveCredentialsUnlocked(files FileSystem, path string, credentials Credentials) error {
 	document, err := json.Marshal(credentials)
 	if err != nil {
 		return ErrUnavailable

--- a/internal/auth/persist.go
+++ b/internal/auth/persist.go
@@ -1,0 +1,24 @@
+package auth
+
+import (
+	"encoding/json"
+	"time"
+)
+
+type Credentials struct {
+	AccessToken  string    `json:"accessToken"`
+	RefreshToken string    `json:"refreshToken,omitempty"`
+	UserID       string    `json:"userId,omitempty"`
+	ExpiresAt    time.Time `json:"expiresAt"`
+}
+
+func SaveCredentials(files FileSystem, path string, credentials Credentials) error {
+	if files == nil || path == "" {
+		return ErrNotConfigured
+	}
+	document, err := json.Marshal(credentials)
+	if err != nil {
+		return ErrUnavailable
+	}
+	return files.WriteFileAtomic(path, document)
+}

--- a/internal/auth/persist.go
+++ b/internal/auth/persist.go
@@ -1,17 +1,8 @@
 package auth
 
-import (
-	"encoding/json"
-	"time"
-)
+import "encoding/json"
 
-type Credentials struct {
-	AccessToken  string    `json:"accessToken"`
-	RefreshToken string    `json:"refreshToken,omitempty"`
-	ExpiresAt    time.Time `json:"expiresAt"`
-}
-
-func SaveCredentials(files FileSystem, path string, credentials Credentials) error {
+func saveCredentials(files FileSystem, path string, credentials credentialRecord) error {
 	if files == nil || path == "" {
 		return ErrNotConfigured
 	}
@@ -24,7 +15,7 @@ func SaveCredentials(files FileSystem, path string, credentials Credentials) err
 	return saveError
 }
 
-func saveCredentialsUnlocked(files FileSystem, path string, credentials Credentials) error {
+func saveCredentialsUnlocked(files FileSystem, path string, credentials credentialRecord) error {
 	document, err := json.Marshal(credentials)
 	if err != nil {
 		return ErrUnavailable

--- a/internal/auth/port.go
+++ b/internal/auth/port.go
@@ -1,0 +1,42 @@
+package auth
+
+import (
+	"context"
+	"time"
+)
+
+type RemoteAuth interface {
+	SendAuthCode(context.Context, SendAuthCodeRequest) error
+	GetLoginToken(context.Context, GetLoginTokenRequest) (LoginTokenResponse, error)
+	SignInWithCustomToken(context.Context, string) (SignInResponse, error)
+	RefreshToken(context.Context, string) (RefreshResponse, error)
+}
+
+type SendAuthCodeRequest struct {
+	PhoneNumber        string
+	AmplitudeDeviceID  string
+	AmplitudeSessionID int64
+}
+
+type GetLoginTokenRequest struct {
+	PhoneNumber        string
+	AuthCode           string
+	AmplitudeDeviceID  string
+	AmplitudeSessionID int64
+}
+
+type LoginTokenResponse struct {
+	Token string
+}
+
+type SignInResponse struct {
+	IDToken      string
+	RefreshToken string
+	ExpiresIn    time.Duration
+}
+
+type RefreshResponse struct {
+	IDToken      string
+	RefreshToken string
+	ExpiresIn    time.Duration
+}

--- a/internal/remote/auth.go
+++ b/internal/remote/auth.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"mime"
@@ -13,11 +12,8 @@ import (
 	"strconv"
 	"time"
 	"unicode/utf8"
-)
 
-var (
-	ErrAuthCodeRejected = errors.New("authentication code rejected")
-	ErrAuthExpired      = errors.New("authentication expired")
+	"github.com/KalebCole/partiful-cli/internal/auth"
 )
 
 const (
@@ -32,36 +28,9 @@ type AuthClient struct {
 	HTTP HTTPClient
 }
 
-type SendAuthCodeRequest struct {
-	PhoneNumber        string
-	AmplitudeDeviceID  string
-	AmplitudeSessionID int64
-}
+var _ auth.RemoteAuth = AuthClient{}
 
-type GetLoginTokenRequest struct {
-	PhoneNumber        string
-	AuthCode           string
-	AmplitudeDeviceID  string
-	AmplitudeSessionID int64
-}
-
-type GetLoginTokenResponse struct {
-	Token string
-}
-
-type SignInWithCustomTokenResponse struct {
-	IDToken      string
-	RefreshToken string
-	ExpiresIn    time.Duration
-}
-
-type RefreshTokenResponse struct {
-	IDToken      string
-	RefreshToken string
-	ExpiresIn    time.Duration
-}
-
-func (client AuthClient) SendAuthCode(ctx context.Context, req SendAuthCodeRequest) error {
+func (client AuthClient) SendAuthCode(ctx context.Context, req auth.SendAuthCodeRequest) error {
 	body := callableBody{
 		Data: callableData{
 			Params: sendAuthCodeParams{
@@ -82,7 +51,7 @@ func (client AuthClient) SendAuthCode(ctx context.Context, req SendAuthCodeReque
 	}
 	defer response.Body.Close()
 	if response.StatusCode != http.StatusOK {
-		return fmt.Errorf("%w: status %d", ErrProtocolChanged, response.StatusCode)
+		return fmt.Errorf("%w: status %d", auth.ErrRemoteProtocolChanged, response.StatusCode)
 	}
 	if _, err := readBoundedAuthBody(response); err != nil {
 		return err
@@ -90,7 +59,10 @@ func (client AuthClient) SendAuthCode(ctx context.Context, req SendAuthCodeReque
 	return nil
 }
 
-func (client AuthClient) GetLoginToken(ctx context.Context, req GetLoginTokenRequest) (GetLoginTokenResponse, error) {
+func (client AuthClient) GetLoginToken(
+	ctx context.Context,
+	req auth.GetLoginTokenRequest,
+) (auth.LoginTokenResponse, error) {
 	body := callableBody{
 		Data: callableData{
 			Params: getLoginTokenParams{
@@ -105,63 +77,66 @@ func (client AuthClient) GetLoginToken(ctx context.Context, req GetLoginTokenReq
 	}
 	response, err := client.callablePost(ctx, partifulCallableHost+"/getLoginToken", body)
 	if err != nil {
-		return GetLoginTokenResponse{}, err
+		return auth.LoginTokenResponse{}, err
 	}
 	defer response.Body.Close()
 	if response.StatusCode != http.StatusOK {
 		if response.StatusCode == http.StatusForbidden {
 			data, err := readAuthJSON(response)
 			if err != nil || !validCallableAuthError(data) {
-				return GetLoginTokenResponse{}, fmt.Errorf("%w: response body", ErrProtocolChanged)
+				return auth.LoginTokenResponse{}, fmt.Errorf("%w: response body", auth.ErrRemoteProtocolChanged)
 			}
-			return GetLoginTokenResponse{}, ErrAuthCodeRejected
+			return auth.LoginTokenResponse{}, auth.ErrAuthCodeRejected
 		}
-		return GetLoginTokenResponse{}, fmt.Errorf("%w: status %d", ErrProtocolChanged, response.StatusCode)
+		return auth.LoginTokenResponse{}, fmt.Errorf("%w: status %d", auth.ErrRemoteProtocolChanged, response.StatusCode)
 	}
 	data, err := readAuthJSON(response)
 	if err != nil {
-		return GetLoginTokenResponse{}, err
+		return auth.LoginTokenResponse{}, err
 	}
 	var result loginTokenResult
 	if err := json.Unmarshal(data, &result); err != nil || result.Result.Data.Token == "" {
-		return GetLoginTokenResponse{}, fmt.Errorf("%w: response body", ErrProtocolChanged)
+		return auth.LoginTokenResponse{}, fmt.Errorf("%w: response body", auth.ErrRemoteProtocolChanged)
 	}
-	return GetLoginTokenResponse{Token: result.Result.Data.Token}, nil
+	return auth.LoginTokenResponse{Token: result.Result.Data.Token}, nil
 }
 
-func (client AuthClient) SignInWithCustomToken(ctx context.Context, token string) (SignInWithCustomTokenResponse, error) {
+func (client AuthClient) SignInWithCustomToken(
+	ctx context.Context,
+	token string,
+) (auth.SignInResponse, error) {
 	if client.HTTP == nil {
-		return SignInWithCustomTokenResponse{}, fmt.Errorf("%w: authentication transport", ErrUnavailable)
+		return auth.SignInResponse{}, fmt.Errorf("%w: authentication transport", auth.ErrRemoteUnavailable)
 	}
 	payload, _ := json.Marshal(signInRequest{Token: token, ReturnSecureToken: true})
 	url := firebaseIdentityHost + "/v1/accounts:signInWithCustomToken?key=" + firebaseProjectKey
 	request, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
 	if err != nil {
-		return SignInWithCustomTokenResponse{}, fmt.Errorf("%w: request", ErrUnavailable)
+		return auth.SignInResponse{}, fmt.Errorf("%w: request", auth.ErrRemoteUnavailable)
 	}
 	request.Header.Set("Content-Type", "application/json")
 	request.Header.Set("Referer", "https://partiful.com/")
 	response, err := client.HTTP.Do(request)
 	if err != nil {
-		return SignInWithCustomTokenResponse{}, fmt.Errorf("%w: request failed", ErrUnavailable)
+		return auth.SignInResponse{}, fmt.Errorf("%w: request failed", auth.ErrRemoteUnavailable)
 	}
 	if response == nil || response.Body == nil {
-		return SignInWithCustomTokenResponse{}, fmt.Errorf("%w: missing response", ErrProtocolChanged)
+		return auth.SignInResponse{}, fmt.Errorf("%w: missing response", auth.ErrRemoteProtocolChanged)
 	}
 	defer response.Body.Close()
 	if response.StatusCode == http.StatusBadRequest {
 		data, err := readAuthJSON(response)
 		if err != nil || !validFirebaseValidationError(data) {
-			return SignInWithCustomTokenResponse{}, fmt.Errorf("%w: response body", ErrProtocolChanged)
+			return auth.SignInResponse{}, fmt.Errorf("%w: response body", auth.ErrRemoteProtocolChanged)
 		}
-		return SignInWithCustomTokenResponse{}, ErrAuthExpired
+		return auth.SignInResponse{}, auth.ErrRemoteTokenExpired
 	}
 	if response.StatusCode != http.StatusOK {
-		return SignInWithCustomTokenResponse{}, fmt.Errorf("%w: status %d", ErrProtocolChanged, response.StatusCode)
+		return auth.SignInResponse{}, fmt.Errorf("%w: status %d", auth.ErrRemoteProtocolChanged, response.StatusCode)
 	}
 	data, err := readAuthJSON(response)
 	if err != nil {
-		return SignInWithCustomTokenResponse{}, err
+		return auth.SignInResponse{}, err
 	}
 	var result signInResult
 	if err := json.Unmarshal(data, &result); err != nil ||
@@ -169,13 +144,13 @@ func (client AuthClient) SignInWithCustomToken(ctx context.Context, token string
 		result.RefreshToken == "" ||
 		result.ExpiresIn == "" ||
 		!validOptionalString(result.Kind) {
-		return SignInWithCustomTokenResponse{}, fmt.Errorf("%w: response body", ErrProtocolChanged)
+		return auth.SignInResponse{}, fmt.Errorf("%w: response body", auth.ErrRemoteProtocolChanged)
 	}
 	expiresIn, err := parseExpiresIn(result.ExpiresIn)
 	if err != nil {
-		return SignInWithCustomTokenResponse{}, fmt.Errorf("%w: expiresIn", ErrProtocolChanged)
+		return auth.SignInResponse{}, fmt.Errorf("%w: expiresIn", auth.ErrRemoteProtocolChanged)
 	}
-	return SignInWithCustomTokenResponse{
+	return auth.SignInResponse{
 		IDToken:      result.IDToken,
 		RefreshToken: result.RefreshToken,
 		ExpiresIn:    expiresIn,
@@ -185,9 +160,9 @@ func (client AuthClient) SignInWithCustomToken(ctx context.Context, token string
 func (client AuthClient) RefreshToken(
 	ctx context.Context,
 	refreshToken string,
-) (RefreshTokenResponse, error) {
+) (auth.RefreshResponse, error) {
 	if client.HTTP == nil {
-		return RefreshTokenResponse{}, fmt.Errorf("%w: authentication transport", ErrUnavailable)
+		return auth.RefreshResponse{}, fmt.Errorf("%w: authentication transport", auth.ErrRemoteUnavailable)
 	}
 	form := url.Values{
 		"grant_type":    {"refresh_token"},
@@ -201,31 +176,31 @@ func (client AuthClient) RefreshToken(
 		bytes.NewBufferString(form),
 	)
 	if err != nil {
-		return RefreshTokenResponse{}, fmt.Errorf("%w: request", ErrUnavailable)
+		return auth.RefreshResponse{}, fmt.Errorf("%w: request", auth.ErrRemoteUnavailable)
 	}
 	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	request.Header.Set("Referer", "https://partiful.com/")
 	response, err := client.HTTP.Do(request)
 	if err != nil {
-		return RefreshTokenResponse{}, fmt.Errorf("%w: request failed", ErrUnavailable)
+		return auth.RefreshResponse{}, fmt.Errorf("%w: request failed", auth.ErrRemoteUnavailable)
 	}
 	if response == nil || response.Body == nil {
-		return RefreshTokenResponse{}, fmt.Errorf("%w: missing response", ErrProtocolChanged)
+		return auth.RefreshResponse{}, fmt.Errorf("%w: missing response", auth.ErrRemoteProtocolChanged)
 	}
 	defer response.Body.Close()
 	if response.StatusCode == http.StatusBadRequest {
 		data, err := readAuthJSON(response)
 		if err != nil || !validFirebaseTokenError(data) {
-			return RefreshTokenResponse{}, fmt.Errorf("%w: response body", ErrProtocolChanged)
+			return auth.RefreshResponse{}, fmt.Errorf("%w: response body", auth.ErrRemoteProtocolChanged)
 		}
-		return RefreshTokenResponse{}, ErrAuthExpired
+		return auth.RefreshResponse{}, auth.ErrRemoteTokenExpired
 	}
 	if response.StatusCode != http.StatusOK {
-		return RefreshTokenResponse{}, fmt.Errorf("%w: status %d", ErrProtocolChanged, response.StatusCode)
+		return auth.RefreshResponse{}, fmt.Errorf("%w: status %d", auth.ErrRemoteProtocolChanged, response.StatusCode)
 	}
 	data, err := readAuthJSON(response)
 	if err != nil {
-		return RefreshTokenResponse{}, err
+		return auth.RefreshResponse{}, err
 	}
 	var result refreshResult
 	if json.Unmarshal(data, &result) != nil ||
@@ -236,13 +211,13 @@ func (client AuthClient) RefreshToken(
 		result.TokenType == "" ||
 		!validOptionalString(result.ProjectID) ||
 		!validOptionalString(result.UserID) {
-		return RefreshTokenResponse{}, fmt.Errorf("%w: response body", ErrProtocolChanged)
+		return auth.RefreshResponse{}, fmt.Errorf("%w: response body", auth.ErrRemoteProtocolChanged)
 	}
 	expiresIn, err := parseExpiresIn(result.ExpiresIn)
 	if err != nil {
-		return RefreshTokenResponse{}, fmt.Errorf("%w: expiresIn", ErrProtocolChanged)
+		return auth.RefreshResponse{}, fmt.Errorf("%w: expiresIn", auth.ErrRemoteProtocolChanged)
 	}
-	return RefreshTokenResponse{
+	return auth.RefreshResponse{
 		IDToken:      result.IDToken,
 		RefreshToken: result.RefreshToken,
 		ExpiresIn:    expiresIn,
@@ -252,34 +227,34 @@ func (client AuthClient) RefreshToken(
 func parseExpiresIn(value string) (time.Duration, error) {
 	seconds, err := strconv.ParseInt(value, 10, 64)
 	if err != nil || seconds <= 0 {
-		return 0, ErrProtocolChanged
+		return 0, auth.ErrRemoteProtocolChanged
 	}
 	duration, err := time.ParseDuration(strconv.FormatInt(seconds, 10) + "s")
 	if err != nil {
-		return 0, ErrProtocolChanged
+		return 0, auth.ErrRemoteProtocolChanged
 	}
 	return duration, nil
 }
 
 func (client AuthClient) callablePost(ctx context.Context, url string, body any) (*http.Response, error) {
 	if client.HTTP == nil {
-		return nil, fmt.Errorf("%w: authentication transport", ErrUnavailable)
+		return nil, fmt.Errorf("%w: authentication transport", auth.ErrRemoteUnavailable)
 	}
 	payload, err := json.Marshal(body)
 	if err != nil {
-		return nil, fmt.Errorf("%w: encode", ErrUnavailable)
+		return nil, fmt.Errorf("%w: encode", auth.ErrRemoteUnavailable)
 	}
 	request, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
 	if err != nil {
-		return nil, fmt.Errorf("%w: request", ErrUnavailable)
+		return nil, fmt.Errorf("%w: request", auth.ErrRemoteUnavailable)
 	}
 	request.Header.Set("Content-Type", "application/json")
 	response, err := client.HTTP.Do(request)
 	if err != nil {
-		return nil, fmt.Errorf("%w: request failed", ErrUnavailable)
+		return nil, fmt.Errorf("%w: request failed", auth.ErrRemoteUnavailable)
 	}
 	if response == nil || response.Body == nil {
-		return nil, fmt.Errorf("%w: missing response", ErrProtocolChanged)
+		return nil, fmt.Errorf("%w: missing response", auth.ErrRemoteProtocolChanged)
 	}
 	return response, nil
 }
@@ -287,14 +262,14 @@ func (client AuthClient) callablePost(ctx context.Context, url string, body any)
 func readAuthJSON(response *http.Response) ([]byte, error) {
 	mediaType, _, err := mime.ParseMediaType(response.Header.Get("Content-Type"))
 	if err != nil || mediaType != "application/json" {
-		return nil, fmt.Errorf("%w: content type", ErrProtocolChanged)
+		return nil, fmt.Errorf("%w: content type", auth.ErrRemoteProtocolChanged)
 	}
 	data, err := readBoundedAuthBody(response)
 	if err != nil {
 		return nil, err
 	}
 	if !utf8.Valid(data) || !json.Valid(data) {
-		return nil, fmt.Errorf("%w: response body", ErrProtocolChanged)
+		return nil, fmt.Errorf("%w: response body", auth.ErrRemoteProtocolChanged)
 	}
 	return data, nil
 }
@@ -302,10 +277,10 @@ func readAuthJSON(response *http.Response) ([]byte, error) {
 func readBoundedAuthBody(response *http.Response) ([]byte, error) {
 	data, err := io.ReadAll(io.LimitReader(response.Body, maximumAuthBodyBytes+1))
 	if err != nil {
-		return nil, fmt.Errorf("%w: read body", ErrUnavailable)
+		return nil, fmt.Errorf("%w: read body", auth.ErrRemoteUnavailable)
 	}
 	if len(data) > maximumAuthBodyBytes {
-		return nil, fmt.Errorf("%w: response body", ErrProtocolChanged)
+		return nil, fmt.Errorf("%w: response body", auth.ErrRemoteProtocolChanged)
 	}
 	return data, nil
 }

--- a/internal/remote/auth.go
+++ b/internal/remote/auth.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"mime"
 	"net/http"
+	"net/url"
 	"strconv"
 	"unicode/utf8"
 )
@@ -21,6 +22,7 @@ var (
 const (
 	partifulCallableHost = "https://api.partiful.com"
 	firebaseIdentityHost = "https://identitytoolkit.googleapis.com"
+	firebaseTokenHost    = "https://securetoken.googleapis.com"
 	firebaseProjectKey   = "AIzaSyCky6PJ7cHRdBKk5X7gjuWERWaKWBHr4_k"
 	maximumAuthBodyBytes = 64 << 10
 )
@@ -47,6 +49,12 @@ type GetLoginTokenResponse struct {
 }
 
 type SignInWithCustomTokenResponse struct {
+	IDToken      string
+	RefreshToken string
+	ExpiresIn    int
+}
+
+type RefreshTokenResponse struct {
 	IDToken      string
 	RefreshToken string
 	ExpiresIn    int
@@ -168,6 +176,72 @@ func (client AuthClient) SignInWithCustomToken(ctx context.Context, token string
 	}, nil
 }
 
+func (client AuthClient) RefreshToken(
+	ctx context.Context,
+	refreshToken string,
+) (RefreshTokenResponse, error) {
+	if client.HTTP == nil {
+		return RefreshTokenResponse{}, fmt.Errorf("%w: authentication transport", ErrUnavailable)
+	}
+	form := url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {refreshToken},
+	}.Encode()
+	endpoint := firebaseTokenHost + "/v1/token?key=" + firebaseProjectKey
+	request, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		endpoint,
+		bytes.NewBufferString(form),
+	)
+	if err != nil {
+		return RefreshTokenResponse{}, fmt.Errorf("%w: request", ErrUnavailable)
+	}
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	request.Header.Set("Origin", "https://partiful.com")
+	request.Header.Set("Referer", "https://partiful.com/")
+	response, err := client.HTTP.Do(request)
+	if err != nil {
+		return RefreshTokenResponse{}, fmt.Errorf("%w: request failed", ErrUnavailable)
+	}
+	if response == nil || response.Body == nil {
+		return RefreshTokenResponse{}, fmt.Errorf("%w: missing response", ErrProtocolChanged)
+	}
+	defer response.Body.Close()
+	if response.StatusCode == http.StatusBadRequest {
+		data, err := readAuthJSON(response)
+		if err != nil || !validFirebaseError(data) {
+			return RefreshTokenResponse{}, fmt.Errorf("%w: response body", ErrProtocolChanged)
+		}
+		return RefreshTokenResponse{}, ErrAuthExpired
+	}
+	if response.StatusCode != http.StatusOK {
+		return RefreshTokenResponse{}, fmt.Errorf("%w: status %d", ErrProtocolChanged, response.StatusCode)
+	}
+	data, err := readAuthJSON(response)
+	if err != nil {
+		return RefreshTokenResponse{}, err
+	}
+	var result refreshResult
+	if json.Unmarshal(data, &result) != nil ||
+		result.AccessToken == "" ||
+		result.IDToken == "" ||
+		result.RefreshToken == "" ||
+		result.ExpiresIn == "" ||
+		result.TokenType == "" {
+		return RefreshTokenResponse{}, fmt.Errorf("%w: response body", ErrProtocolChanged)
+	}
+	expiresIn, err := strconv.Atoi(result.ExpiresIn)
+	if err != nil || expiresIn <= 0 {
+		return RefreshTokenResponse{}, fmt.Errorf("%w: expiresIn", ErrProtocolChanged)
+	}
+	return RefreshTokenResponse{
+		IDToken:      result.IDToken,
+		RefreshToken: result.RefreshToken,
+		ExpiresIn:    expiresIn,
+	}, nil
+}
+
 func (client AuthClient) callablePost(ctx context.Context, url string, body any) (*http.Response, error) {
 	if client.HTTP == nil {
 		return nil, fmt.Errorf("%w: authentication transport", ErrUnavailable)
@@ -277,4 +351,12 @@ type signInResult struct {
 	IDToken      string `json:"idToken"`
 	RefreshToken string `json:"refreshToken"`
 	ExpiresIn    string `json:"expiresIn"`
+}
+
+type refreshResult struct {
+	AccessToken  string `json:"access_token"`
+	IDToken      string `json:"id_token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresIn    string `json:"expires_in"`
+	TokenType    string `json:"token_type"`
 }

--- a/internal/remote/auth.go
+++ b/internal/remote/auth.go
@@ -84,6 +84,9 @@ func (client AuthClient) SendAuthCode(ctx context.Context, req SendAuthCodeReque
 	if response.StatusCode != http.StatusOK {
 		return fmt.Errorf("%w: status %d", ErrProtocolChanged, response.StatusCode)
 	}
+	if _, err := readBoundedAuthBody(response); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -162,7 +165,10 @@ func (client AuthClient) SignInWithCustomToken(ctx context.Context, token string
 	}
 	var result signInResult
 	if err := json.Unmarshal(data, &result); err != nil ||
-		result.IDToken == "" || result.RefreshToken == "" || result.ExpiresIn == "" {
+		result.IDToken == "" ||
+		result.RefreshToken == "" ||
+		result.ExpiresIn == "" ||
+		!validOptionalString(result.Kind) {
 		return SignInWithCustomTokenResponse{}, fmt.Errorf("%w: response body", ErrProtocolChanged)
 	}
 	expiresIn, err := parseExpiresIn(result.ExpiresIn)
@@ -227,7 +233,9 @@ func (client AuthClient) RefreshToken(
 		result.IDToken == "" ||
 		result.RefreshToken == "" ||
 		result.ExpiresIn == "" ||
-		result.TokenType == "" {
+		result.TokenType == "" ||
+		!validOptionalString(result.ProjectID) ||
+		!validOptionalString(result.UserID) {
 		return RefreshTokenResponse{}, fmt.Errorf("%w: response body", ErrProtocolChanged)
 	}
 	expiresIn, err := parseExpiresIn(result.ExpiresIn)
@@ -281,11 +289,22 @@ func readAuthJSON(response *http.Response) ([]byte, error) {
 	if err != nil || mediaType != "application/json" {
 		return nil, fmt.Errorf("%w: content type", ErrProtocolChanged)
 	}
+	data, err := readBoundedAuthBody(response)
+	if err != nil {
+		return nil, err
+	}
+	if !utf8.Valid(data) || !json.Valid(data) {
+		return nil, fmt.Errorf("%w: response body", ErrProtocolChanged)
+	}
+	return data, nil
+}
+
+func readBoundedAuthBody(response *http.Response) ([]byte, error) {
 	data, err := io.ReadAll(io.LimitReader(response.Body, maximumAuthBodyBytes+1))
 	if err != nil {
 		return nil, fmt.Errorf("%w: read body", ErrUnavailable)
 	}
-	if len(data) > maximumAuthBodyBytes || !utf8.Valid(data) || !json.Valid(data) {
+	if len(data) > maximumAuthBodyBytes {
 		return nil, fmt.Errorf("%w: response body", ErrProtocolChanged)
 	}
 	return data, nil
@@ -294,27 +313,56 @@ func readAuthJSON(response *http.Response) ([]byte, error) {
 func validCallableAuthError(data []byte) bool {
 	var failure struct {
 		Error *struct {
-			Message *string `json:"message"`
-			Status  *string `json:"status"`
+			Message *string         `json:"message"`
+			Status  *string         `json:"status"`
+			Details json.RawMessage `json:"details"`
 		} `json:"error"`
 	}
 	return json.Unmarshal(data, &failure) == nil &&
 		failure.Error != nil &&
 		failure.Error.Message != nil &&
-		failure.Error.Status != nil
+		failure.Error.Status != nil &&
+		validOptionalCallableDetails(failure.Error.Details)
 }
 
 func validFirebaseError(data []byte) bool {
 	var failure struct {
 		Error *struct {
-			Code    *float64 `json:"code"`
-			Message *string  `json:"message"`
+			Code    *float64        `json:"code"`
+			Message *string         `json:"message"`
+			Status  json.RawMessage `json:"status"`
 		} `json:"error"`
 	}
 	return json.Unmarshal(data, &failure) == nil &&
 		failure.Error != nil &&
 		failure.Error.Code != nil &&
-		failure.Error.Message != nil
+		failure.Error.Message != nil &&
+		validOptionalString(failure.Error.Status)
+}
+
+func validOptionalCallableDetails(raw json.RawMessage) bool {
+	if len(raw) == 0 {
+		return true
+	}
+	if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return false
+	}
+	var details struct {
+		AuthErrorCode json.RawMessage `json:"authErrorCode"`
+	}
+	return json.Unmarshal(raw, &details) == nil &&
+		validOptionalString(details.AuthErrorCode)
+}
+
+func validOptionalString(raw json.RawMessage) bool {
+	if len(raw) == 0 {
+		return true
+	}
+	if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return false
+	}
+	var value string
+	return json.Unmarshal(raw, &value) == nil
 }
 
 type callableBody struct {
@@ -357,15 +405,18 @@ type signInRequest struct {
 }
 
 type signInResult struct {
-	IDToken      string `json:"idToken"`
-	RefreshToken string `json:"refreshToken"`
-	ExpiresIn    string `json:"expiresIn"`
+	IDToken      string          `json:"idToken"`
+	RefreshToken string          `json:"refreshToken"`
+	ExpiresIn    string          `json:"expiresIn"`
+	Kind         json.RawMessage `json:"kind"`
 }
 
 type refreshResult struct {
-	AccessToken  string `json:"access_token"`
-	IDToken      string `json:"id_token"`
-	RefreshToken string `json:"refresh_token"`
-	ExpiresIn    string `json:"expires_in"`
-	TokenType    string `json:"token_type"`
+	AccessToken  string          `json:"access_token"`
+	IDToken      string          `json:"id_token"`
+	RefreshToken string          `json:"refresh_token"`
+	ExpiresIn    string          `json:"expires_in"`
+	TokenType    string          `json:"token_type"`
+	ProjectID    json.RawMessage `json:"project_id"`
+	UserID       json.RawMessage `json:"user_id"`
 }

--- a/internal/remote/auth.go
+++ b/internal/remote/auth.go
@@ -266,8 +266,6 @@ func (client AuthClient) callablePost(ctx context.Context, url string, body any)
 		return nil, fmt.Errorf("%w: request", ErrUnavailable)
 	}
 	request.Header.Set("Content-Type", "application/json")
-	request.Header.Set("Origin", "https://partiful.com")
-	request.Header.Set("Referer", "https://partiful.com/")
 	response, err := client.HTTP.Do(request)
 	if err != nil {
 		return nil, fmt.Errorf("%w: request failed", ErrUnavailable)

--- a/internal/remote/auth.go
+++ b/internal/remote/auth.go
@@ -151,7 +151,7 @@ func (client AuthClient) SignInWithCustomToken(ctx context.Context, token string
 	defer response.Body.Close()
 	if response.StatusCode == http.StatusBadRequest {
 		data, err := readAuthJSON(response)
-		if err != nil || !validFirebaseError(data) {
+		if err != nil || !validFirebaseValidationError(data) {
 			return SignInWithCustomTokenResponse{}, fmt.Errorf("%w: response body", ErrProtocolChanged)
 		}
 		return SignInWithCustomTokenResponse{}, ErrAuthExpired
@@ -215,7 +215,7 @@ func (client AuthClient) RefreshToken(
 	defer response.Body.Close()
 	if response.StatusCode == http.StatusBadRequest {
 		data, err := readAuthJSON(response)
-		if err != nil || !validFirebaseError(data) {
+		if err != nil || !validFirebaseTokenError(data) {
 			return RefreshTokenResponse{}, fmt.Errorf("%w: response body", ErrProtocolChanged)
 		}
 		return RefreshTokenResponse{}, ErrAuthExpired
@@ -325,7 +325,52 @@ func validCallableAuthError(data []byte) bool {
 		validOptionalCallableDetails(failure.Error.Details)
 }
 
-func validFirebaseError(data []byte) bool {
+func validFirebaseValidationError(data []byte) bool {
+	var failure struct {
+		Error *struct {
+			Code    *float64        `json:"code"`
+			Message *string         `json:"message"`
+			Errors  json.RawMessage `json:"errors"`
+		} `json:"error"`
+	}
+	return json.Unmarshal(data, &failure) == nil &&
+		failure.Error != nil &&
+		failure.Error.Code != nil &&
+		failure.Error.Message != nil &&
+		validOptionalFirebaseValidationErrors(failure.Error.Errors)
+}
+
+func validOptionalFirebaseValidationErrors(raw json.RawMessage) bool {
+	if len(raw) == 0 {
+		return true
+	}
+	if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return false
+	}
+	var entries []json.RawMessage
+	if json.Unmarshal(raw, &entries) != nil {
+		return false
+	}
+	for _, entry := range entries {
+		if bytes.Equal(bytes.TrimSpace(entry), []byte("null")) {
+			return false
+		}
+		var item struct {
+			Domain  json.RawMessage `json:"domain"`
+			Message json.RawMessage `json:"message"`
+			Reason  json.RawMessage `json:"reason"`
+		}
+		if json.Unmarshal(entry, &item) != nil ||
+			!validOptionalString(item.Domain) ||
+			!validOptionalString(item.Message) ||
+			!validOptionalString(item.Reason) {
+			return false
+		}
+	}
+	return true
+}
+
+func validFirebaseTokenError(data []byte) bool {
 	var failure struct {
 		Error *struct {
 			Code    *float64        `json:"code"`

--- a/internal/remote/auth.go
+++ b/internal/remote/auth.go
@@ -23,6 +23,7 @@ const (
 	firebaseTokenHost    = "https://securetoken.googleapis.com"
 	firebaseProjectKey   = "AIzaSyCky6PJ7cHRdBKk5X7gjuWERWaKWBHr4_k"
 	maximumAuthBodyBytes = 64 << 10
+	refreshWindow        = 5 * time.Minute
 )
 
 type AuthClient struct {
@@ -250,7 +251,11 @@ func parseExpiresIn(value string) (time.Duration, error) {
 	if seconds > math.MaxInt64/int64(time.Second) {
 		return 0, auth.ErrRemoteProtocolChanged
 	}
-	return time.Duration(seconds) * time.Second, nil
+	duration := time.Duration(seconds) * time.Second
+	if duration <= refreshWindow {
+		return 0, auth.ErrRemoteProtocolChanged
+	}
+	return duration, nil
 }
 
 func (client AuthClient) callablePost(

--- a/internal/remote/auth.go
+++ b/internal/remote/auth.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"time"
 	"unicode/utf8"
 )
 
@@ -51,13 +52,13 @@ type GetLoginTokenResponse struct {
 type SignInWithCustomTokenResponse struct {
 	IDToken      string
 	RefreshToken string
-	ExpiresIn    int
+	ExpiresIn    time.Duration
 }
 
 type RefreshTokenResponse struct {
 	IDToken      string
 	RefreshToken string
-	ExpiresIn    int
+	ExpiresIn    time.Duration
 }
 
 func (client AuthClient) SendAuthCode(ctx context.Context, req SendAuthCodeRequest) error {
@@ -165,8 +166,8 @@ func (client AuthClient) SignInWithCustomToken(ctx context.Context, token string
 		result.IDToken == "" || result.RefreshToken == "" || result.ExpiresIn == "" {
 		return SignInWithCustomTokenResponse{}, fmt.Errorf("%w: response body", ErrProtocolChanged)
 	}
-	expiresIn, err := strconv.Atoi(result.ExpiresIn)
-	if err != nil || expiresIn <= 0 {
+	expiresIn, err := parseExpiresIn(result.ExpiresIn)
+	if err != nil {
 		return SignInWithCustomTokenResponse{}, fmt.Errorf("%w: expiresIn", ErrProtocolChanged)
 	}
 	return SignInWithCustomTokenResponse{
@@ -231,8 +232,8 @@ func (client AuthClient) RefreshToken(
 		result.TokenType == "" {
 		return RefreshTokenResponse{}, fmt.Errorf("%w: response body", ErrProtocolChanged)
 	}
-	expiresIn, err := strconv.Atoi(result.ExpiresIn)
-	if err != nil || expiresIn <= 0 {
+	expiresIn, err := parseExpiresIn(result.ExpiresIn)
+	if err != nil {
 		return RefreshTokenResponse{}, fmt.Errorf("%w: expiresIn", ErrProtocolChanged)
 	}
 	return RefreshTokenResponse{
@@ -240,6 +241,18 @@ func (client AuthClient) RefreshToken(
 		RefreshToken: result.RefreshToken,
 		ExpiresIn:    expiresIn,
 	}, nil
+}
+
+func parseExpiresIn(value string) (time.Duration, error) {
+	seconds, err := strconv.ParseInt(value, 10, 64)
+	if err != nil || seconds <= 0 {
+		return 0, ErrProtocolChanged
+	}
+	duration, err := time.ParseDuration(strconv.FormatInt(seconds, 10) + "s")
+	if err != nil {
+		return 0, ErrProtocolChanged
+	}
+	return duration, nil
 }
 
 func (client AuthClient) callablePost(ctx context.Context, url string, body any) (*http.Response, error) {

--- a/internal/remote/auth.go
+++ b/internal/remote/auth.go
@@ -137,7 +137,6 @@ func (client AuthClient) SignInWithCustomToken(ctx context.Context, token string
 		return SignInWithCustomTokenResponse{}, fmt.Errorf("%w: request", ErrUnavailable)
 	}
 	request.Header.Set("Content-Type", "application/json")
-	request.Header.Set("Origin", "https://partiful.com")
 	request.Header.Set("Referer", "https://partiful.com/")
 	response, err := client.HTTP.Do(request)
 	if err != nil {
@@ -199,7 +198,6 @@ func (client AuthClient) RefreshToken(
 		return RefreshTokenResponse{}, fmt.Errorf("%w: request", ErrUnavailable)
 	}
 	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	request.Header.Set("Origin", "https://partiful.com")
 	request.Header.Set("Referer", "https://partiful.com/")
 	response, err := client.HTTP.Do(request)
 	if err != nil {

--- a/internal/remote/auth.go
+++ b/internal/remote/auth.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"mime"
 	"net/http"
 	"net/url"
@@ -49,7 +50,9 @@ func (client AuthClient) SendAuthCode(ctx context.Context, req auth.SendAuthCode
 	if err != nil {
 		return err
 	}
-	defer response.Body.Close()
+	defer func() {
+		_ = response.Body.Close()
+	}()
 	if response.StatusCode != http.StatusOK {
 		return fmt.Errorf("%w: status %d", auth.ErrRemoteProtocolChanged, response.StatusCode)
 	}
@@ -79,7 +82,9 @@ func (client AuthClient) GetLoginToken(
 	if err != nil {
 		return auth.LoginTokenResponse{}, err
 	}
-	defer response.Body.Close()
+	defer func() {
+		_ = response.Body.Close()
+	}()
 	if response.StatusCode != http.StatusOK {
 		if response.StatusCode == http.StatusForbidden {
 			data, err := readAuthJSON(response)
@@ -109,8 +114,8 @@ func (client AuthClient) SignInWithCustomToken(
 		return auth.SignInResponse{}, fmt.Errorf("%w: authentication transport", auth.ErrRemoteUnavailable)
 	}
 	payload, _ := json.Marshal(signInRequest{Token: token, ReturnSecureToken: true})
-	url := firebaseIdentityHost + "/v1/accounts:signInWithCustomToken?key=" + firebaseProjectKey
-	request, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	endpoint := firebaseIdentityHost + "/v1/accounts:signInWithCustomToken?key=" + firebaseProjectKey
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
 	if err != nil {
 		return auth.SignInResponse{}, fmt.Errorf("%w: request", auth.ErrRemoteUnavailable)
 	}
@@ -123,7 +128,9 @@ func (client AuthClient) SignInWithCustomToken(
 	if response == nil || response.Body == nil {
 		return auth.SignInResponse{}, fmt.Errorf("%w: missing response", auth.ErrRemoteProtocolChanged)
 	}
-	defer response.Body.Close()
+	defer func() {
+		_ = response.Body.Close()
+	}()
 	if response.StatusCode == http.StatusBadRequest {
 		data, err := readAuthJSON(response)
 		if err != nil || !validFirebaseValidationError(data) {
@@ -187,7 +194,9 @@ func (client AuthClient) RefreshToken(
 	if response == nil || response.Body == nil {
 		return auth.RefreshResponse{}, fmt.Errorf("%w: missing response", auth.ErrRemoteProtocolChanged)
 	}
-	defer response.Body.Close()
+	defer func() {
+		_ = response.Body.Close()
+	}()
 	if response.StatusCode == http.StatusBadRequest {
 		data, err := readAuthJSON(response)
 		if err != nil || !validFirebaseTokenError(data) {
@@ -229,14 +238,17 @@ func parseExpiresIn(value string) (time.Duration, error) {
 	if err != nil || seconds <= 0 {
 		return 0, auth.ErrRemoteProtocolChanged
 	}
-	duration, err := time.ParseDuration(strconv.FormatInt(seconds, 10) + "s")
-	if err != nil {
+	if seconds > math.MaxInt64/int64(time.Second) {
 		return 0, auth.ErrRemoteProtocolChanged
 	}
-	return duration, nil
+	return time.Duration(seconds) * time.Second, nil
 }
 
-func (client AuthClient) callablePost(ctx context.Context, url string, body any) (*http.Response, error) {
+func (client AuthClient) callablePost(
+	ctx context.Context,
+	endpoint string,
+	body any,
+) (*http.Response, error) {
 	if client.HTTP == nil {
 		return nil, fmt.Errorf("%w: authentication transport", auth.ErrRemoteUnavailable)
 	}
@@ -244,7 +256,7 @@ func (client AuthClient) callablePost(ctx context.Context, url string, body any)
 	if err != nil {
 		return nil, fmt.Errorf("%w: encode", auth.ErrRemoteUnavailable)
 	}
-	request, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
 	if err != nil {
 		return nil, fmt.Errorf("%w: request", auth.ErrRemoteUnavailable)
 	}

--- a/internal/remote/auth.go
+++ b/internal/remote/auth.go
@@ -1,0 +1,280 @@
+package remote
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"strconv"
+	"unicode/utf8"
+)
+
+var (
+	ErrAuthCodeRejected = errors.New("authentication code rejected")
+	ErrAuthExpired      = errors.New("authentication expired")
+)
+
+const (
+	partifulCallableHost = "https://api.partiful.com"
+	firebaseIdentityHost = "https://identitytoolkit.googleapis.com"
+	firebaseProjectKey   = "AIzaSyCky6PJ7cHRdBKk5X7gjuWERWaKWBHr4_k"
+	maximumAuthBodyBytes = 64 << 10
+)
+
+type AuthClient struct {
+	HTTP HTTPClient
+}
+
+type SendAuthCodeRequest struct {
+	PhoneNumber        string
+	AmplitudeDeviceID  string
+	AmplitudeSessionID int64
+}
+
+type GetLoginTokenRequest struct {
+	PhoneNumber        string
+	AuthCode           string
+	AmplitudeDeviceID  string
+	AmplitudeSessionID int64
+}
+
+type GetLoginTokenResponse struct {
+	Token string
+}
+
+type SignInWithCustomTokenResponse struct {
+	IDToken      string
+	RefreshToken string
+	ExpiresIn    int
+}
+
+func (client AuthClient) SendAuthCode(ctx context.Context, req SendAuthCodeRequest) error {
+	body := callableBody{
+		Data: callableData{
+			Params: sendAuthCodeParams{
+				DisplayName:             "",
+				PhoneNumber:             req.PhoneNumber,
+				Silent:                  false,
+				ChannelPreference:       "sms",
+				CaptchaToken:            nil,
+				UseAppleBusinessUpdates: false,
+			},
+			AmplitudeDeviceID:  req.AmplitudeDeviceID,
+			AmplitudeSessionID: req.AmplitudeSessionID,
+		},
+	}
+	response, err := client.callablePost(ctx, partifulCallableHost+"/sendAuthCodeTrusted", body)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("%w: status %d", ErrProtocolChanged, response.StatusCode)
+	}
+	return nil
+}
+
+func (client AuthClient) GetLoginToken(ctx context.Context, req GetLoginTokenRequest) (GetLoginTokenResponse, error) {
+	body := callableBody{
+		Data: callableData{
+			Params: getLoginTokenParams{
+				PhoneNumber: req.PhoneNumber,
+				AuthCode:    req.AuthCode,
+				AffiliateID: nil,
+				UTMs:        map[string]any{},
+			},
+			AmplitudeDeviceID:  req.AmplitudeDeviceID,
+			AmplitudeSessionID: req.AmplitudeSessionID,
+		},
+	}
+	response, err := client.callablePost(ctx, partifulCallableHost+"/getLoginToken", body)
+	if err != nil {
+		return GetLoginTokenResponse{}, err
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		if response.StatusCode == http.StatusForbidden {
+			data, err := readAuthJSON(response)
+			if err != nil || !validCallableAuthError(data) {
+				return GetLoginTokenResponse{}, fmt.Errorf("%w: response body", ErrProtocolChanged)
+			}
+			return GetLoginTokenResponse{}, ErrAuthCodeRejected
+		}
+		return GetLoginTokenResponse{}, fmt.Errorf("%w: status %d", ErrProtocolChanged, response.StatusCode)
+	}
+	data, err := readAuthJSON(response)
+	if err != nil {
+		return GetLoginTokenResponse{}, err
+	}
+	var result loginTokenResult
+	if err := json.Unmarshal(data, &result); err != nil || result.Result.Data.Token == "" {
+		return GetLoginTokenResponse{}, fmt.Errorf("%w: response body", ErrProtocolChanged)
+	}
+	return GetLoginTokenResponse{Token: result.Result.Data.Token}, nil
+}
+
+func (client AuthClient) SignInWithCustomToken(ctx context.Context, token string) (SignInWithCustomTokenResponse, error) {
+	if client.HTTP == nil {
+		return SignInWithCustomTokenResponse{}, fmt.Errorf("%w: authentication transport", ErrUnavailable)
+	}
+	payload, _ := json.Marshal(signInRequest{Token: token, ReturnSecureToken: true})
+	url := firebaseIdentityHost + "/v1/accounts:signInWithCustomToken?key=" + firebaseProjectKey
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return SignInWithCustomTokenResponse{}, fmt.Errorf("%w: request", ErrUnavailable)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Origin", "https://partiful.com")
+	request.Header.Set("Referer", "https://partiful.com/")
+	response, err := client.HTTP.Do(request)
+	if err != nil {
+		return SignInWithCustomTokenResponse{}, fmt.Errorf("%w: request failed", ErrUnavailable)
+	}
+	if response == nil || response.Body == nil {
+		return SignInWithCustomTokenResponse{}, fmt.Errorf("%w: missing response", ErrProtocolChanged)
+	}
+	defer response.Body.Close()
+	if response.StatusCode == http.StatusBadRequest {
+		data, err := readAuthJSON(response)
+		if err != nil || !validFirebaseError(data) {
+			return SignInWithCustomTokenResponse{}, fmt.Errorf("%w: response body", ErrProtocolChanged)
+		}
+		return SignInWithCustomTokenResponse{}, ErrAuthExpired
+	}
+	if response.StatusCode != http.StatusOK {
+		return SignInWithCustomTokenResponse{}, fmt.Errorf("%w: status %d", ErrProtocolChanged, response.StatusCode)
+	}
+	data, err := readAuthJSON(response)
+	if err != nil {
+		return SignInWithCustomTokenResponse{}, err
+	}
+	var result signInResult
+	if err := json.Unmarshal(data, &result); err != nil ||
+		result.IDToken == "" || result.RefreshToken == "" || result.ExpiresIn == "" {
+		return SignInWithCustomTokenResponse{}, fmt.Errorf("%w: response body", ErrProtocolChanged)
+	}
+	expiresIn, err := strconv.Atoi(result.ExpiresIn)
+	if err != nil || expiresIn <= 0 {
+		return SignInWithCustomTokenResponse{}, fmt.Errorf("%w: expiresIn", ErrProtocolChanged)
+	}
+	return SignInWithCustomTokenResponse{
+		IDToken:      result.IDToken,
+		RefreshToken: result.RefreshToken,
+		ExpiresIn:    expiresIn,
+	}, nil
+}
+
+func (client AuthClient) callablePost(ctx context.Context, url string, body any) (*http.Response, error) {
+	if client.HTTP == nil {
+		return nil, fmt.Errorf("%w: authentication transport", ErrUnavailable)
+	}
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("%w: encode", ErrUnavailable)
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("%w: request", ErrUnavailable)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Origin", "https://partiful.com")
+	request.Header.Set("Referer", "https://partiful.com/")
+	response, err := client.HTTP.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("%w: request failed", ErrUnavailable)
+	}
+	if response == nil || response.Body == nil {
+		return nil, fmt.Errorf("%w: missing response", ErrProtocolChanged)
+	}
+	return response, nil
+}
+
+func readAuthJSON(response *http.Response) ([]byte, error) {
+	mediaType, _, err := mime.ParseMediaType(response.Header.Get("Content-Type"))
+	if err != nil || mediaType != "application/json" {
+		return nil, fmt.Errorf("%w: content type", ErrProtocolChanged)
+	}
+	data, err := io.ReadAll(io.LimitReader(response.Body, maximumAuthBodyBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("%w: read body", ErrUnavailable)
+	}
+	if len(data) > maximumAuthBodyBytes || !utf8.Valid(data) || !json.Valid(data) {
+		return nil, fmt.Errorf("%w: response body", ErrProtocolChanged)
+	}
+	return data, nil
+}
+
+func validCallableAuthError(data []byte) bool {
+	var failure struct {
+		Error *struct {
+			Message *string `json:"message"`
+			Status  *string `json:"status"`
+		} `json:"error"`
+	}
+	return json.Unmarshal(data, &failure) == nil &&
+		failure.Error != nil &&
+		failure.Error.Message != nil &&
+		failure.Error.Status != nil
+}
+
+func validFirebaseError(data []byte) bool {
+	var failure struct {
+		Error *struct {
+			Code    *float64 `json:"code"`
+			Message *string  `json:"message"`
+		} `json:"error"`
+	}
+	return json.Unmarshal(data, &failure) == nil &&
+		failure.Error != nil &&
+		failure.Error.Code != nil &&
+		failure.Error.Message != nil
+}
+
+type callableBody struct {
+	Data callableData `json:"data"`
+}
+
+type callableData struct {
+	Params             any    `json:"params"`
+	AmplitudeDeviceID  string `json:"amplitudeDeviceId"`
+	AmplitudeSessionID int64  `json:"amplitudeSessionId"`
+}
+
+type sendAuthCodeParams struct {
+	DisplayName             string  `json:"displayName"`
+	PhoneNumber             string  `json:"phoneNumber"`
+	Silent                  bool    `json:"silent"`
+	ChannelPreference       string  `json:"channelPreference"`
+	CaptchaToken            *string `json:"captchaToken"`
+	UseAppleBusinessUpdates bool    `json:"useAppleBusinessUpdates"`
+}
+
+type getLoginTokenParams struct {
+	PhoneNumber string         `json:"phoneNumber"`
+	AuthCode    string         `json:"authCode"`
+	AffiliateID *string        `json:"affiliateId"`
+	UTMs        map[string]any `json:"utms"`
+}
+
+type loginTokenResult struct {
+	Result struct {
+		Data struct {
+			Token string `json:"token"`
+		} `json:"data"`
+	} `json:"result"`
+}
+
+type signInRequest struct {
+	Token             string `json:"token"`
+	ReturnSecureToken bool   `json:"returnSecureToken"`
+}
+
+type signInResult struct {
+	IDToken      string `json:"idToken"`
+	RefreshToken string `json:"refreshToken"`
+	ExpiresIn    string `json:"expiresIn"`
+}

--- a/internal/remote/auth.go
+++ b/internal/remote/auth.go
@@ -88,7 +88,10 @@ func (client AuthClient) GetLoginToken(
 	if response.StatusCode != http.StatusOK {
 		if response.StatusCode == http.StatusForbidden {
 			data, err := readAuthJSON(response)
-			if err != nil || !validCallableAuthError(data) {
+			if err != nil {
+				return auth.LoginTokenResponse{}, err
+			}
+			if !validCallableAuthError(data) {
 				return auth.LoginTokenResponse{}, fmt.Errorf("%w: response body", auth.ErrRemoteProtocolChanged)
 			}
 			return auth.LoginTokenResponse{}, auth.ErrAuthCodeRejected
@@ -133,7 +136,10 @@ func (client AuthClient) SignInWithCustomToken(
 	}()
 	if response.StatusCode == http.StatusBadRequest {
 		data, err := readAuthJSON(response)
-		if err != nil || !validFirebaseValidationError(data) {
+		if err != nil {
+			return auth.SignInResponse{}, err
+		}
+		if !validFirebaseValidationError(data) {
 			return auth.SignInResponse{}, fmt.Errorf("%w: response body", auth.ErrRemoteProtocolChanged)
 		}
 		return auth.SignInResponse{}, auth.ErrRemoteTokenExpired
@@ -199,7 +205,10 @@ func (client AuthClient) RefreshToken(
 	}()
 	if response.StatusCode == http.StatusBadRequest {
 		data, err := readAuthJSON(response)
-		if err != nil || !validFirebaseTokenError(data) {
+		if err != nil {
+			return auth.RefreshResponse{}, err
+		}
+		if !validFirebaseTokenError(data) {
 			return auth.RefreshResponse{}, fmt.Errorf("%w: response body", auth.ErrRemoteProtocolChanged)
 		}
 		return auth.RefreshResponse{}, auth.ErrRemoteTokenExpired


### PR DESCRIPTION
## Summary

Implements the complete S2 authentication lifecycle and closes #163 against owner-reviewed Remote API contract revision `2026-08-11.4`.

- Adds private-terminal-only `auth login`, redacted status, and serialized logout.
- Implements exact reviewed callable and Firebase mappings; Firebase uses the public key query parameter and required Referer, never Origin, while callable requests add no uncontracted browser headers.
- Refreshes within five minutes of expiry and atomically replaces credentials under a cross-process lock on Linux, macOS, and Windows.
- Keeps auth and remote separately substitutable: `internal/auth` owns the port and lifecycle vocabulary; `internal/remote` is the checked wire adapter.
- Declares executable parser/auth failures and accurate local-mutation safety through schema.
- Bounds every auth response to 64 KiB, validates declared field types, permits reviewed additional properties, and fails drift closed.

## Slice boundary

The first protected-command `auth.required` tracer and session acquisition materialize in #164 with the first evidence-complete protected event command. The stable private account fingerprint materializes in #166 with its first mutation-plan consumer.

## Safety and validation

No live authentication, SMS, credential entry, browser login, live probe, or Partiful mutation was used. Phone numbers, codes, tokens, identity values, remote bodies, and filesystem details never enter stdout/stderr.

Go race/vet/build/module checks, Linux/macOS/Windows target builds, 20 contract tests plus drift tests, 341 non-live JavaScript tests, typecheck, formatting/diff/privacy guards, and independent Standards/Spec review all pass.

Closes #163

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `auth.login` command for interactive authentication.
  - Added automatic credential refresh for near-expiry sessions.
  - Added secure credential storage with atomic updates and logout safeguards.
  - Added support for terminal validation and unavailable-terminal detection.

- **Bug Fixes**
  - Improved authentication error reporting for expired credentials, rejected codes, unavailable services, and invalid responses.
  - Added response-size and protocol validation to fail safely on malformed authentication responses.

- **Documentation**
  - Updated the CLI contract and authentication behavior documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->