### PR TITLE
fix(contract): close auth Origin audit gaps (#163)

### DIFF
--- a/docs/REMOTE-API-CONTRACT.md
+++ b/docs/REMOTE-API-CONTRACT.md
@@ -1,6 +1,6 @@
 # Remote API contract
 
-`spec/partiful.openapi.json` is proposed revision `2026-08-11.4` of the
+`spec/partiful.openapi.json` is owner-reviewed revision `2026-08-11.4` of the
 remote transport snapshot. It describes only network operations and wire
 shapes. It does not prescribe commands, output, credentials, mutation
 safeguards, or implementation architecture.

--- a/docs/REMOTE-API-CONTRACT.md
+++ b/docs/REMOTE-API-CONTRACT.md
@@ -1,6 +1,6 @@
 # Remote API contract
 
-`spec/partiful.openapi.json` is owner-reviewed revision `2026-08-11.3` of the
+`spec/partiful.openapi.json` is proposed revision `2026-08-11.4` of the
 remote transport snapshot. It describes only network operations and wire
 shapes. It does not prescribe commands, output, credentials, mutation
 safeguards, or implementation architecture.

--- a/docs/research/2026-08-10-contract-evidence-sources.md
+++ b/docs/research/2026-08-10-contract-evidence-sources.md
@@ -109,7 +109,8 @@ A privacy-safe negative probe without a `Referer` header received HTTP 403
 `API_KEY_HTTP_REFERRER_BLOCKED`; probes using the observed
 `Referer: https://partiful.com/` reached the endpoint and returned ordinary
 invalid-input responses. The full allowed Referer set is unknown. Origin is
-unmodelled and remains unknown.
+unmodelled and remains unknown because the reviewed evidence establishes no
+Origin request fact.
 
 ## Dated poster catalog observation
 

--- a/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
+++ b/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
@@ -1,7 +1,7 @@
 # Partiful remote API contract evidence ledger
 
-**Proposed contract revision:** `2026-08-11.4`
-**Status:** Proposed pending delegated orchestrator review
+**Owner-reviewed contract revision:** `2026-08-11.4`
+**Status:** Owner-reviewed under the issue #114 delegation
 **Contract:** `spec/partiful.openapi.json`
 **Machine-readable ledger:** `spec/partiful.api-evidence.json`
 **Stable citation sources:** `docs/research/2026-08-10-contract-evidence-sources.md`

--- a/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
+++ b/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
@@ -1,7 +1,7 @@
 # Partiful remote API contract evidence ledger
 
-**Owner-reviewed contract revision:** `2026-08-11.3`
-**Status:** Owner-reviewed under the issue #114 delegation
+**Proposed contract revision:** `2026-08-11.4`
+**Status:** Proposed pending delegated orchestrator review
 **Contract:** `spec/partiful.openapi.json`
 **Machine-readable ledger:** `spec/partiful.api-evidence.json`
 **Stable citation sources:** `docs/research/2026-08-10-contract-evidence-sources.md`
@@ -133,7 +133,7 @@ configuration fact, not a Partiful callable behavior.
 
 ## Firebase transport configuration
 
-Revision `2026-08-11.3` formalizes two transport configuration facts required
+Revision `2026-08-11.4` formalizes two transport configuration facts required
 by the Go implementation's Firebase requests:
 
 1. **Firebase web API key value**: The `firebaseApiKey` security scheme now

--- a/docs/research/2026-08-11-auth-observation.md
+++ b/docs/research/2026-08-11-auth-observation.md
@@ -221,8 +221,8 @@ contract gate.
 - Whether the 22-byte `sendAuthCodeTrusted` success body ever contains fields.
 - Rate-limiting behavior on any authentication endpoint.
 - Token lifetimes, refresh token rotation policy, and session duration.
-- Whether the Firebase referrer restriction applies to all allowed origins or
-  only specific patterns.
+- Whether the Firebase referrer restriction accepts additional `Referer`
+  values or patterns.
 - Additional fields in `getLoginToken` success (849 bytes, only `result.data.token`
   recorded in sanitized shape).
 - Whether `lookupFirebaseUser` returns additional user fields for accounts with

--- a/spec/partiful.api-evidence.json
+++ b/spec/partiful.api-evidence.json
@@ -379,7 +379,7 @@
     "The full set of Referer values accepted by the Firebase API-key restriction remains unknown; https://partiful.com/ is the only observed accepted value.",
     "Origin is unmodelled and remains unknown because the reviewed evidence establishes no Origin request fact."
   ],
-  "status": "proposed",
+  "status": "owner-reviewed",
   "claims": {
     "#/servers/0/url": {
       "classification": "typescript-derived-inference",

--- a/spec/partiful.api-evidence.json
+++ b/spec/partiful.api-evidence.json
@@ -1,5 +1,5 @@
 {
-  "contractRevision": "2026-08-11.3",
+  "contractRevision": "2026-08-11.4",
   "contractPath": "spec/partiful.openapi.json",
   "allowedClassifications": [
     "dated-live-observation",
@@ -376,9 +376,10 @@
     "Poster catalog membership and order can change; exhaustiveness beyond the complete observed endpoint representation is unknown.",
     "Status codes and error bodies for operations without dated observations.",
     "Unconditional poster-catalog failure statuses and bodies remain unknown; only HTTP 200 is an accepted catalog success.",
-    "The full set of Referer values accepted by the Firebase API-key restriction remains unknown; https://partiful.com/ is the only observed accepted value."
+    "The full set of Referer values accepted by the Firebase API-key restriction remains unknown; https://partiful.com/ is the only observed accepted value.",
+    "Origin remains unmodelled and unknown because reviewed evidence establishes no Origin request fact."
   ],
-  "status": "owner-reviewed",
+  "status": "proposed",
   "claims": {
     "#/servers/0/url": {
       "classification": "typescript-derived-inference",

--- a/spec/partiful.api-evidence.json
+++ b/spec/partiful.api-evidence.json
@@ -377,7 +377,7 @@
     "Status codes and error bodies for operations without dated observations.",
     "Unconditional poster-catalog failure statuses and bodies remain unknown; only HTTP 200 is an accepted catalog success.",
     "The full set of Referer values accepted by the Firebase API-key restriction remains unknown; https://partiful.com/ is the only observed accepted value.",
-    "Origin remains unmodelled and unknown because reviewed evidence establishes no Origin request fact."
+    "Origin is unmodelled and remains unknown because the reviewed evidence establishes no Origin request fact."
   ],
   "status": "proposed",
   "claims": {

--- a/spec/partiful.openapi.json
+++ b/spec/partiful.openapi.json
@@ -2,8 +2,8 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Partiful remote API contract",
-    "version": "2026-08-11.3",
-    "description": "Owner-reviewed, versioned remote-only transport snapshot. Evidence classifications and uncertainty are recorded in spec/partiful.api-evidence.json."
+    "version": "2026-08-11.4",
+    "description": "Proposed, versioned remote-only transport snapshot. Evidence classifications and uncertainty are recorded in spec/partiful.api-evidence.json."
   },
   "servers": [
     {

--- a/spec/partiful.openapi.json
+++ b/spec/partiful.openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Partiful remote API contract",
     "version": "2026-08-11.4",
-    "description": "Proposed, versioned remote-only transport snapshot. Evidence classifications and uncertainty are recorded in spec/partiful.api-evidence.json."
+    "description": "Owner-reviewed, versioned remote-only transport snapshot. Evidence classifications and uncertainty are recorded in spec/partiful.api-evidence.json."
   },
   "servers": [
     {

--- a/tests/remote-api-contract.test.js
+++ b/tests/remote-api-contract.test.js
@@ -14,9 +14,9 @@ const humanEvidencePaths = [
   'docs/research/2026-08-10-contract-evidence-sources.md',
   'docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md',
 ];
-const citedMarkdownPaths = Object.values(evidence.sources)
-  .filter((citation) => typeof citation === 'string' && citation.includes('.md#'))
-  .map((citation) => citation.slice(0, citation.indexOf('#')));
+const citedMarkdownPaths = stringValues(evidence)
+  .map((citation) => citation.split('#', 1)[0])
+  .filter((sourcePath) => sourcePath.endsWith('.md'));
 const originEvidencePaths = [
   ...new Set([...humanEvidencePaths, ...citedMarkdownPaths]),
 ];
@@ -45,6 +45,12 @@ function operations() {
       .filter(([method]) => methods.has(method))
       .map(([method, operation]) => ({ path, method, operation })),
   );
+}
+
+function stringValues(value) {
+  if (typeof value === 'string') return [value];
+  if (value === null || typeof value !== 'object') return [];
+  return Object.values(value).flatMap(stringValues);
 }
 
 function escapePointerSegment(value) {
@@ -776,7 +782,7 @@ describe('remote API contract', () => {
         ...content
           .replace(/\s+/g, ' ')
           .split(/(?<=[.!?])\s+/)
-          .filter((statement) => /\borigin\b/i.test(statement)),
+          .filter((statement) => /\borigins?\b/i.test(statement)),
       );
     }
     expect([...new Set(originStatements)]).toEqual([approvedOriginStatement]);

--- a/tests/remote-api-contract.test.js
+++ b/tests/remote-api-contract.test.js
@@ -14,10 +14,14 @@ const humanEvidencePaths = [
   'docs/research/2026-08-10-contract-evidence-sources.md',
   'docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md',
 ];
+const citedMarkdownPaths = Object.values(evidence.sources)
+  .filter((citation) => typeof citation === 'string' && citation.includes('.md#'))
+  .map((citation) => citation.slice(0, citation.indexOf('#')));
 const originEvidencePaths = [
-  ...humanEvidencePaths,
-  'docs/research/2026-08-11-auth-observation.md',
+  ...new Set([...humanEvidencePaths, ...citedMarkdownPaths]),
 ];
+const approvedOriginStatement =
+  'Origin is unmodelled and remains unknown because the reviewed evidence establishes no Origin request fact.';
 const methods = new Set(['get', 'post', 'put', 'patch', 'delete']);
 const ignoredKeys = new Set(['description', 'summary', 'title']);
 const materialMapKeys = new Set([
@@ -754,7 +758,7 @@ describe('remote API contract', () => {
       'The full set of Referer values accepted by the Firebase API-key restriction remains unknown; https://partiful.com/ is the only observed accepted value.',
     );
     expect(evidence.unresolvedUncertainty).toContain(
-      'Origin remains unmodelled and unknown because reviewed evidence establishes no Origin request fact.',
+      approvedOriginStatement,
     );
   });
 
@@ -764,18 +768,18 @@ describe('remote API contract', () => {
     expect(evidence.sources.firebasePublicApiKeyRedacted).toBe(safeFirebaseKeySource);
     expect(citationResolves(safeFirebaseKeySource)).toBe(true);
 
-    const unsupportedOriginClaims = [
-      /probes?[^.]*without (?:an )?Origin/i,
-      /Origin (?:was|is) not required/i,
-      /succeeded without Origin/i,
-    ];
+    const originStatements = [];
     for (const evidencePath of originEvidencePaths) {
       const content = fs.readFileSync(evidencePath, 'utf8');
       expect(content, evidencePath).not.toContain(unsafeAuthSourcePath);
-      for (const claim of unsupportedOriginClaims) {
-        expect(content, evidencePath).not.toMatch(claim);
-      }
+      originStatements.push(
+        ...content
+          .replace(/\s+/g, ' ')
+          .split(/(?<=[.!?])\s+/)
+          .filter((statement) => /\borigin\b/i.test(statement)),
+      );
     }
+    expect([...new Set(originStatements)]).toEqual([approvedOriginStatement]);
   });
 
   it('keeps the historical auth note privacy-safe while retaining redacted transport structure', () => {

--- a/tests/remote-api-contract.test.js
+++ b/tests/remote-api-contract.test.js
@@ -729,17 +729,32 @@ describe('remote API contract', () => {
       { path: '/v1/accounts:lookup', id: 'lookupFirebaseUser' },
     ];
     for (const { path: opPath, id } of firebaseOps) {
-      const operation = spec.paths[opPath].post;
-      expect(operation.parameters, `${id} has parameters`).toBeDefined();
-      const referer = operation.parameters.find((p) => p.name === 'Referer' && p.in === 'header');
+      const pathItem = spec.paths[opPath];
+      const parameterGroups = [
+        { parameters: pathItem.parameters ?? [], pointer: 'parameters' },
+        { parameters: pathItem.post.parameters ?? [], pointer: 'post/parameters' },
+      ];
+      const refererGroup = parameterGroups.find(({ parameters }) =>
+        parameters.some(
+          (parameter) =>
+            parameter.in === 'header' &&
+            parameter.name?.toLowerCase() === 'referer',
+        ),
+      );
+      const referer = refererGroup?.parameters.find(
+        (parameter) =>
+          parameter.in === 'header' &&
+          parameter.name?.toLowerCase() === 'referer',
+      );
       expect(referer, `${id} has Referer parameter`).toBeDefined();
       expect(referer.required, `${id} Referer is required`).toBe(true);
       expect(referer.schema.const, `${id} Referer value`).toBe('https://partiful.com/');
 
       // Referer claim must have observation-backed provenance
       const escaped = escapePointerSegment(opPath);
-      const refererIdx = operation.parameters.indexOf(referer);
-      const constPointer = `#/paths/${escaped}/post/parameters/${refererIdx}/schema/const`;
+      const refererIdx = refererGroup.parameters.indexOf(referer);
+      const constPointer =
+        `#/paths/${escaped}/${refererGroup.pointer}/${refererIdx}/schema/const`;
       expect(evidence.claims[constPointer], `${id} Referer const claim`).toBeDefined();
       expect(evidence.claims[constPointer].classification).toBe('dated-live-observation');
       expect(evidence.claims[constPointer].citation)
@@ -774,7 +789,8 @@ describe('remote API contract', () => {
     expect(evidence.sources.firebasePublicApiKeyRedacted).toBe(safeFirebaseKeySource);
     expect(citationResolves(safeFirebaseKeySource)).toBe(true);
 
-    const originStatements = [];
+    const originStatements = stringValues(evidence)
+      .filter((statement) => /\borigins?\b/i.test(statement));
     for (const evidencePath of originEvidencePaths) {
       const content = fs.readFileSync(evidencePath, 'utf8');
       expect(content, evidencePath).not.toContain(unsafeAuthSourcePath);

--- a/tests/remote-api-contract.test.js
+++ b/tests/remote-api-contract.test.js
@@ -132,7 +132,7 @@ describe('remote API contract', () => {
     expect(spec.openapi).toBe('3.1.0');
     expect(evidence.contractRevision).toBe('2026-08-11.4');
     expect(spec.info.version).toBe(evidence.contractRevision);
-    expect(evidence.status).toBe('proposed');
+    expect(evidence.status).toBe('owner-reviewed');
     const ids = operations().map(({ operation }) => operation.operationId);
     expect(ids).toHaveLength(27);
     expect(new Set(ids).size).toBe(ids.length);

--- a/tests/remote-api-contract.test.js
+++ b/tests/remote-api-contract.test.js
@@ -14,6 +14,10 @@ const humanEvidencePaths = [
   'docs/research/2026-08-10-contract-evidence-sources.md',
   'docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md',
 ];
+const originEvidencePaths = [
+  ...humanEvidencePaths,
+  'docs/research/2026-08-11-auth-observation.md',
+];
 const methods = new Set(['get', 'post', 'put', 'patch', 'delete']);
 const ignoredKeys = new Set(['description', 'summary', 'title']);
 const materialMapKeys = new Set([
@@ -116,8 +120,9 @@ function citationResolves(citation) {
 describe('remote API contract', () => {
   it('is a consistently versioned OpenAPI 3.1 document with unique operation IDs', () => {
     expect(spec.openapi).toBe('3.1.0');
+    expect(evidence.contractRevision).toBe('2026-08-11.4');
     expect(spec.info.version).toBe(evidence.contractRevision);
-    expect(evidence.status).toBe('owner-reviewed');
+    expect(evidence.status).toBe('proposed');
     const ids = operations().map(({ operation }) => operation.operationId);
     expect(ids).toHaveLength(27);
     expect(new Set(ids).size).toBe(ids.length);
@@ -733,12 +738,23 @@ describe('remote API contract', () => {
 
     // Origin is NOT modelled for Firebase operations — evidence does not support it as required
     for (const { path: opPath, id } of firebaseOps) {
-      const operation = spec.paths[opPath].post;
-      const origin = (operation.parameters ?? []).find((p) => p.name === 'Origin');
+      const pathItem = spec.paths[opPath];
+      const parameters = [
+        ...(pathItem.parameters ?? []),
+        ...(pathItem.post.parameters ?? []),
+      ];
+      const origin = parameters.find(
+        (parameter) =>
+          parameter.in === 'header' &&
+          parameter.name?.toLowerCase() === 'origin',
+      );
       expect(origin, `${id} must not claim Origin`).toBeUndefined();
     }
     expect(evidence.unresolvedUncertainty).toContain(
       'The full set of Referer values accepted by the Firebase API-key restriction remains unknown; https://partiful.com/ is the only observed accepted value.',
+    );
+    expect(evidence.unresolvedUncertainty).toContain(
+      'Origin remains unmodelled and unknown because reviewed evidence establishes no Origin request fact.',
     );
   });
 
@@ -753,7 +769,7 @@ describe('remote API contract', () => {
       /Origin (?:was|is) not required/i,
       /succeeded without Origin/i,
     ];
-    for (const evidencePath of humanEvidencePaths) {
+    for (const evidencePath of originEvidencePaths) {
       const content = fs.readFileSync(evidencePath, 'utf8');
       expect(content, evidencePath).not.toContain(unsafeAuthSourcePath);
       for (const claim of unsupportedOriginClaims) {


### PR DESCRIPTION
Proposes Remote API contract revision 2026-08-11.4 as the follow-up to the merged PR #178 audit. It records Origin uncertainty in the machine ledger, checks Origin header names case-insensitively across path-level and operation-level OpenAPI parameters, and scans the cited auth observation for unsupported Origin claims. The revision remains proposed pending the delegated Standards and Spec review. No live probe or private value was used. Targeted contract tests pass. Linked: #163.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the remote API contract and evidence records to revision 2026-08-11.4.
  - Clarified unresolved Firebase API-key `Referer` and `Origin` behavior.
  - Marked the latest evidence and API specification as proposed pending review.

- **Tests**
  - Enhanced contract validation for citations, origin statements, parameter scopes, provenance, and unsafe-source exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->