### PR TITLE
docs(contract): propose event and contact read evidence (#164, #165)

### DIFF
--- a/docs/CLI-PRODUCT-CONTRACT.md
+++ b/docs/CLI-PRODUCT-CONTRACT.md
@@ -2,7 +2,7 @@
 
 **Status:** Approved product contract  
 **Product contract revision:** `2026-08-10.1`  
-**Remote API contract revision:** `2026-08-11.5` (proposed)
+**Remote API contract revision:** `2026-08-11.4`
 
 This document defines the public behavior of the greenfield Go `partiful` CLI.
 It is the authority for commands, inputs, JSON outputs, failures, and mutation
@@ -78,7 +78,7 @@ Every successful command returns:
     "command": "events.get",
     "cliVersion": "1.0.0",
     "productContractRevision": "2026-08-10.1",
-    "remoteContractRevision": "2026-08-11.5",
+    "remoteContractRevision": "2026-08-11.4",
     "warnings": []
   }
 }
@@ -102,7 +102,7 @@ Every failed command returns:
     "command": "guests.list",
     "cliVersion": "1.0.0",
     "productContractRevision": "2026-08-10.1",
-    "remoteContractRevision": "2026-08-11.5"
+    "remoteContractRevision": "2026-08-11.4"
   }
 }
 ```
@@ -150,7 +150,7 @@ Collection commands return:
     "command": "events.list",
     "cliVersion": "1.0.0",
     "productContractRevision": "2026-08-10.1",
-    "remoteContractRevision": "2026-08-11.5",
+    "remoteContractRevision": "2026-08-11.4",
     "warnings": [],
     "page": {
       "limit": 25,
@@ -203,7 +203,7 @@ remote mutation:
     "command": "events.update",
     "cliVersion": "1.0.0",
     "productContractRevision": "2026-08-10.1",
-    "remoteContractRevision": "2026-08-11.5",
+    "remoteContractRevision": "2026-08-11.4",
     "warnings": []
   }
 }

--- a/docs/CLI-PRODUCT-CONTRACT.md
+++ b/docs/CLI-PRODUCT-CONTRACT.md
@@ -2,7 +2,7 @@
 
 **Status:** Approved product contract  
 **Product contract revision:** `2026-08-10.1`  
-**Remote API contract revision:** `2026-08-11.4`
+**Remote API contract revision:** `2026-08-11.5` (proposed)
 
 This document defines the public behavior of the greenfield Go `partiful` CLI.
 It is the authority for commands, inputs, JSON outputs, failures, and mutation
@@ -78,7 +78,7 @@ Every successful command returns:
     "command": "events.get",
     "cliVersion": "1.0.0",
     "productContractRevision": "2026-08-10.1",
-    "remoteContractRevision": "2026-08-11.4",
+    "remoteContractRevision": "2026-08-11.5",
     "warnings": []
   }
 }
@@ -102,7 +102,7 @@ Every failed command returns:
     "command": "guests.list",
     "cliVersion": "1.0.0",
     "productContractRevision": "2026-08-10.1",
-    "remoteContractRevision": "2026-08-11.4"
+    "remoteContractRevision": "2026-08-11.5"
   }
 }
 ```
@@ -150,7 +150,7 @@ Collection commands return:
     "command": "events.list",
     "cliVersion": "1.0.0",
     "productContractRevision": "2026-08-10.1",
-    "remoteContractRevision": "2026-08-11.4",
+    "remoteContractRevision": "2026-08-11.5",
     "warnings": [],
     "page": {
       "limit": 25,
@@ -203,7 +203,7 @@ remote mutation:
     "command": "events.update",
     "cliVersion": "1.0.0",
     "productContractRevision": "2026-08-10.1",
-    "remoteContractRevision": "2026-08-11.4",
+    "remoteContractRevision": "2026-08-11.5",
     "warnings": []
   }
 }

--- a/docs/CLI-PRODUCT-CONTRACT.md
+++ b/docs/CLI-PRODUCT-CONTRACT.md
@@ -689,8 +689,9 @@ hatch.
 
 ## Implementation gates and remote changes
 
-The remote API contract currently leaves every operation response status and
-body unknown. Before a public command ships, its implementation slice must:
+The proposed remote API contract records observed response statuses and bodies
+for some operations. Unobserved mappings remain unknown. Before a public
+command ships, its implementation slice must:
 
 1. obtain privacy-safe evidence for every remote response and failure mapping
    it needs;

--- a/docs/REMOTE-API-CONTRACT.md
+++ b/docs/REMOTE-API-CONTRACT.md
@@ -1,9 +1,10 @@
 # Remote API contract
 
-`spec/partiful.openapi.json` is owner-reviewed revision `2026-08-11.4` of the
-remote transport snapshot. It describes only network operations and wire
-shapes. It does not prescribe commands, output, credentials, mutation
-safeguards, or implementation architecture.
+`spec/partiful.openapi.json` is proposed revision `2026-08-11.5` of the remote
+transport snapshot. Independent review is required before it can become
+owner-reviewed. It describes only network operations and wire shapes. It does
+not prescribe commands, output, credentials, mutation safeguards, or
+implementation architecture.
 
 ## Authority and change process
 
@@ -22,6 +23,37 @@ means the contract intentionally declines to claim precision. Never replace it
 with guessed fields, captured credentials, real identifiers, or personal data.
 `docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md` is the
 human-readable companion to the machine-readable ledger.
+
+## Proposed read evidence revision
+
+Revision `2026-08-11.5` proposes dated response and status evidence for
+`getMyUpcomingEventsForHomePage`, `getMyPastEventsForHomePage`,
+`getEventInfo`, `getCurrentGuest`, `firestoreGetEvent`,
+`firestoreGetGuest`, and `getContacts`. The sanitized source is
+`spec/research/read-evidence-redacted-20260811.json`.
+
+The two event lists were observed as complete arrays in one response, at
+`result.data.upcomingEvents` and `result.data.pastEvents`. No remote list
+pagination was observed, so pagination remains unknown. One selected event
+was readable both authenticated and signed out. This does not make all events
+public. A synthetic missing event returned `404 NOT_FOUND`.
+
+The current guest callable and its Firestore guest document returned `200`,
+and their guest status matched. Firestore event GET returned
+`403 PERMISSION_DENIED` for both the selected readable ID and a synthetic ID
+with the observed authenticated request context. This does not establish
+attendee denial or Firestore not-found behavior.
+
+`getContacts` used sibling empty `params` and cursor `paging`. Two traversals
+returned 1000, 1000, and 451 items followed by an empty terminal sentinel.
+Name filtering is client-side over the traversed catalog. Private identity is
+modeled only as internal transport data; public product output remains display
+name and shared-event count. Signed-out access returned
+`401 UNAUTHENTICATED`.
+
+Unsupported statuses, ordering, snapshots, invalid cursors, cursor lifetime,
+`useAuthUser`, inaccessible-event permission behavior, and other unobserved
+variants remain explicit unknowns.
 
 ## Historical provenance
 

--- a/docs/REMOTE-API-CONTRACT.md
+++ b/docs/REMOTE-API-CONTRACT.md
@@ -36,10 +36,18 @@ The two event lists were observed as complete arrays in one response, at
 `result.data.upcomingEvents` and `result.data.pastEvents`. No remote list
 pagination was observed, so pagination remains unknown. One selected event
 was readable both authenticated and signed out. This does not make all events
-public. A synthetic missing event returned `404 NOT_FOUND`.
+public. A synthetic missing event returned `404 NOT_FOUND`. That one detail
+object does not establish operation-wide field presence, nullability, or
+alternate variants. `EventInfo` therefore has no required field list.
+Related event-list representations support only optional `endDate`
+string/null and `image` object/null unions; unsupported selected-only variants
+remain unconstrained.
 
 The current guest callable and its Firestore guest document returned `200`,
-and their guest status matched. Firestore event GET returned
+and their guest status matched. The one current-guest object does not
+establish operation-wide field presence or variants, so `CurrentGuest` has no
+required field list. `count`, `plusOnes`, and `userId` remain unconstrained;
+ordinary non-null plus-one shape is unknown. Firestore event GET returned
 `403 PERMISSION_DENIED` for both the selected readable ID and a synthetic ID
 with the observed authenticated request context. This does not establish
 attendee denial or Firestore not-found behavior.

--- a/docs/REMOTE-API-CONTRACT.md
+++ b/docs/REMOTE-API-CONTRACT.md
@@ -1,10 +1,9 @@
 # Remote API contract
 
-`spec/partiful.openapi.json` is proposed revision `2026-08-11.5` of the remote
-transport snapshot. Independent review is required before it can become
-owner-reviewed. It describes only network operations and wire shapes. It does
-not prescribe commands, output, credentials, mutation safeguards, or
-implementation architecture.
+`spec/partiful.openapi.json` is owner-reviewed revision `2026-08-11.5` of the
+remote transport snapshot. It describes only network operations and wire
+shapes. It does not prescribe commands, output, credentials, mutation
+safeguards, or implementation architecture.
 
 ## Authority and change process
 
@@ -24,9 +23,9 @@ with guessed fields, captured credentials, real identifiers, or personal data.
 `docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md` is the
 human-readable companion to the machine-readable ledger.
 
-## Proposed read evidence revision
+## Read evidence revision
 
-Revision `2026-08-11.5` proposes dated response and status evidence for
+Revision `2026-08-11.5` records dated response and status evidence for
 `getMyUpcomingEventsForHomePage`, `getMyPastEventsForHomePage`,
 `getEventInfo`, `getCurrentGuest`, `firestoreGetEvent`,
 `firestoreGetGuest`, and `getContacts`. The sanitized source is

--- a/docs/REMOTE-API-CONTRACT.md
+++ b/docs/REMOTE-API-CONTRACT.md
@@ -46,14 +46,15 @@ attendee denial or Firestore not-found behavior.
 
 `getContacts` used sibling empty `params` and cursor `paging`. Two traversals
 returned 1000, 1000, and 451 items followed by an empty terminal sentinel.
-Name filtering is client-side over the traversed catalog. Private identity is
-modeled only as internal transport data; public product output remains display
-name and shared-event count. Signed-out access returned
+Name filtering and first-occurrence ID deduplication are client-side over the
+traversed catalog. They do not establish server ordering or duplicate behavior.
+Private identity is modeled only as internal transport data; public product
+output remains display name and shared-event count. Signed-out access returned
 `401 UNAUTHENTICATED`.
 
 Unsupported statuses, ordering, snapshots, invalid cursors, cursor lifetime,
-`useAuthUser`, inaccessible-event permission behavior, and other unobserved
-variants remain explicit unknowns.
+`useAuthUser`, rate limiting, future catalog completeness, inaccessible-event
+permission behavior, and other unobserved variants remain explicit unknowns.
 
 ## Historical provenance
 

--- a/docs/REMOTE-API-CONTRACT.md
+++ b/docs/REMOTE-API-CONTRACT.md
@@ -38,7 +38,8 @@ pagination was observed, so pagination remains unknown. One selected event
 was readable both authenticated and signed out. This does not make all events
 public. A synthetic missing event returned `404 NOT_FOUND`. That one detail
 object does not establish operation-wide field presence, nullability, or
-alternate variants. `EventInfo` therefore has no required field list.
+alternate variants. `EventInfo` therefore has no operation-wide top-level
+type and no required field list.
 Related event-list representations support only optional `endDate`
 string/null and `image` object/null unions; unsupported selected-only variants
 remain unconstrained.
@@ -46,8 +47,9 @@ remain unconstrained.
 The current guest callable and its Firestore guest document returned `200`,
 and their guest status matched. The one current-guest object does not
 establish operation-wide field presence or variants, so `CurrentGuest` has no
-required field list. `count`, `plusOnes`, and `userId` remain unconstrained;
-ordinary non-null plus-one shape is unknown. Firestore event GET returned
+operation-wide top-level type and no required field list. `count`, `plusOnes`,
+and `userId` remain unconstrained; ordinary non-null plus-one shape is
+unknown. Firestore event GET returned
 `403 PERMISSION_DENIED` for both the selected readable ID and a synthetic ID
 with the observed authenticated request context. This does not establish
 attendee denial or Firestore not-found behavior.

--- a/docs/research/2026-08-10-contract-evidence-sources.md
+++ b/docs/research/2026-08-10-contract-evidence-sources.md
@@ -121,3 +121,28 @@ fields and their observed types, a `416` specific to an unsatisfiable Range
 request, and the facts needed to bind bounded local pagination to one response
 representation. It does not claim global catalog exhaustiveness, ordinary
 request failure statuses, or rate limiting.
+
+## Dated event and contact read observation
+
+The August 11, 2026 owner-attended read-only observation in
+`docs/research/2026-08-11-event-contacts-read-observation.md`, under “Scope
+and provenance,” records event list, event detail, current guest, Firestore
+guest, Firestore event denial, and contact response evidence. The sanitized
+artifact at `spec/research/read-evidence-redacted-20260811.json` contains only
+allowlisted metadata, paths, types, counts, equality facts, and error codes.
+It contains no raw response values or private identifier values.
+
+The operation-specific sections are the stable human citations for the
+proposed response and status claims. The proposal does not promote any
+unsupported status, pagination rule, permission behavior, ordering rule, or
+snapshot behavior.
+
+## Current public contact pagination assets
+
+The public-asset research in
+`docs/research/2026-08-11-contacts-pagination-public-assets.md`, under “Exact
+callable argument,” records `getContacts` request paging as a sibling of `params`.
+Normal contact loading uses empty `params`; a separate administrator flow can
+send boolean `useAuthUser`. Its behavior remains unknown. The assets also
+record local cursor traversal and client-side name filtering. This is reviewed
+first-party repository research, not a live-server request-shape observation.

--- a/docs/research/2026-08-10-contract-evidence-sources.md
+++ b/docs/research/2026-08-10-contract-evidence-sources.md
@@ -144,5 +144,8 @@ The public-asset research in
 callable argument,” records `getContacts` request paging as a sibling of `params`.
 Normal contact loading uses empty `params`; a separate administrator flow can
 send boolean `useAuthUser`. Its behavior remains unknown. The assets also
-record local cursor traversal and client-side name filtering. This is reviewed
-first-party repository research, not a live-server request-shape observation.
+record local cursor traversal, client-side name filtering, and client-side
+deduplication by contact `id` with the first occurrence winning. These client
+behaviors do not establish server ordering or duplicate behavior. This is
+reviewed first-party repository research, not a live-server request-shape
+observation.

--- a/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
+++ b/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
@@ -55,7 +55,7 @@ rules, and limits are **explicit unknown**. Eleven operations with an observed
 HTTP `200` status have typed response bodies. The schema-free
 send-code `200` and OpenAPI `default` responses do not claim a body.
 
-The 1232 material claims are audited by
+The 1230 material claims are audited by
 `tests/remote-api-contract.test.js`. Each ledger citation resolves either to a
 JSON Pointer in the committed non-authoritative historical artifact or to a
 heading in the committed stable source index. This keeps the audit independent
@@ -155,17 +155,18 @@ event also returned `200` signed out. The proposal does not generalize this
 fact to other events. No inaccessible event was supplied, and no authenticated
 callable permission denial is claimed. One event-detail object cannot
 establish operation-wide field presence, nullability, or alternate variants,
-so `EventInfo` has no required field list. Related event-list representations
-support only optional `endDate` string/null and `image` object/null unions.
-Selected-only fields without related variant evidence remain unconstrained.
+so `EventInfo` has no operation-wide top-level type and no required field
+list. Related event-list representations support only optional `endDate`
+string/null and `image` object/null unions. Selected-only fields without
+related variant evidence remain unconstrained.
 
 `getCurrentGuest` returned `200` with an object at
 `result.data.currentGuest`. This single object cannot establish
 operation-wide field presence, nullability, or alternate variants, so
-`CurrentGuest` has no required field list. Cross-source fields retain only
-their supported types; `count`, `plusOnes`, and `userId` remain
-unconstrained. A null current guest, an ordinary non-null plus-one shape, and
-other variants remain unknown.
+`CurrentGuest` has no operation-wide top-level type and no required field
+list. Cross-source fields retain only their supported types; `count`,
+`plusOnes`, and `userId` remain unconstrained. A null current guest, an
+ordinary non-null plus-one shape, and other variants remain unknown.
 
 `firestoreGetGuest` returned `200` for the current guest document. Its
 document ID and status matched the callable guest. The complete Firestore
@@ -235,7 +236,7 @@ by the Go implementation's Firebase requests:
 Origin is unmodelled and remains unknown because the reviewed evidence
 establishes no Origin request fact.
 
-The 1232 material claims are audited by `tests/remote-api-contract.test.js`.
+The 1230 material claims are audited by `tests/remote-api-contract.test.js`.
 
 ## Resolved conflict
 

--- a/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
+++ b/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
@@ -30,10 +30,11 @@ Fourteen operations have at least one operation-level dated live observation:
 `getPosterCatalog`, `lookupFirebaseUser`, `refreshToken`,
 `sendAuthCodeTrusted`, and `signInWithCustomToken`.
 
-Twelve of these operations have an observed HTTP `200` success status and
-typed response schema. The text-blast operation retains an unknown response.
-The Firestore event read has an observed typed `403` response, not an observed
-success.
+Twelve operations have an observed HTTP `200` status. Eleven of those
+operations have a typed `200` response body. `sendAuthCodeTrusted` has an
+observed `200` status, but its body remains unclaimed. The text-blast operation
+retains an unknown response. The Firestore event read has an observed typed
+`403` response, not an observed success.
 
 ### TypeScript-derived operations
 
@@ -50,9 +51,9 @@ Every operation's request and response claim is enumerated by JSON Pointer in
 the JSON ledger, including operation, parameter, content-type, security,
 schema, constraint, and response claims. Unless a claim is specifically
 observed, callable result payloads, status codes, error bodies, permission
-rules, and limits are **explicit unknown**. Operations with an observed HTTP
-`200` success have typed response schemas; the schema-free OpenAPI `default`
-response is retained for unrecognized statuses.
+rules, and limits are **explicit unknown**. Eleven operations with an observed
+HTTP `200` status have typed response bodies. The schema-free
+send-code `200` and OpenAPI `default` responses do not claim a body.
 
 The 1250 material claims are audited by
 `tests/remote-api-contract.test.js`. Each ledger citation resolves either to a
@@ -184,20 +185,25 @@ Every observed item had string private identity and name fields and a
 nonnegative integer `sharedEventCount`. The private identity is an internal
 transport field only. Public product output remains `displayName` and
 `sharedEventCount`. First-party assets establish client-side name filtering
-after cursor traversal. Signed-out `getContacts` returned
-`401 UNAUTHENTICATED`.
+after cursor traversal. They also establish client-side deduplication by
+contact `id`, with the first occurrence winning. These are client behaviors;
+they do not establish server duplicate or ordering behavior. Signed-out
+`getContacts` returned `401 UNAUTHENTICATED`.
 
 Invalid cursors, cursor lifetime and reuse, backend ordering, snapshot
 behavior, `useAuthUser`, rate limiting, unsupported statuses, and duplicates
-outside these two observations remain unknown.
+outside these two observations remain unknown. Future catalog completeness is
+also unknown.
 
 ## Read evidence privacy
 
 `spec/research/read-evidence-redacted-20260811.json` contains only HTTP
 metadata, allowlisted paths and types, counts, equality facts, and stable error
 codes. It contains no raw response values, credentials, identities, names,
-event ID values, or contact details. Contract tests reject unsafe identity,
-credential, JWT-like, phone, and email value patterns.
+event ID values, or contact details. Contract tests strictly walk every
+aggregate key and string value against an exact allowlist and include
+unknown-key and arbitrary-value mutation checks. They also reject unsafe
+identity, credential, JWT-like, phone, and email value patterns.
 
 ## Firebase transport configuration
 

--- a/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
+++ b/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
@@ -1,7 +1,7 @@
 # Partiful remote API contract evidence ledger
 
-**Owner-reviewed contract revision:** `2026-08-11.4`
-**Status:** Owner-reviewed under the issue #114 delegation
+**Proposed contract revision:** `2026-08-11.5`
+**Status:** Proposed; independent reviews are required
 **Contract:** `spec/partiful.openapi.json`
 **Machine-readable ledger:** `spec/partiful.api-evidence.json`
 **Stable citation sources:** `docs/research/2026-08-10-contract-evidence-sources.md`
@@ -10,7 +10,7 @@
 
 - **Dated live observation:** the March 24 browser-interception research, the
   August 11 public poster-catalog observation, and the August 11
-  owner-attended authentication observation.
+  owner-attended authentication and read-only event/contact observations.
 - **Reviewed first-party repository research:** reviewed repository source,
   without claiming it proves current server behavior.
 - **TypeScript-derived inference:** historical draft or TypeScript transport
@@ -23,26 +23,27 @@ The recovered 27 operations remain in the remote inventory.
 
 ### Dated-live operations
 
-Seven operations have at least one operation-level dated live observation:
-`createTextBlast`, `getLoginToken`, `getPosterCatalog`,
-`lookupFirebaseUser`, `refreshToken`, `sendAuthCodeTrusted`, and
-`signInWithCustomToken`.
+Fourteen operations have at least one operation-level dated live observation:
+`createTextBlast`, `firestoreGetEvent`, `firestoreGetGuest`, `getContacts`,
+`getCurrentGuest`, `getEventInfo`, `getLoginToken`,
+`getMyPastEventsForHomePage`, `getMyUpcomingEventsForHomePage`,
+`getPosterCatalog`, `lookupFirebaseUser`, `refreshToken`,
+`sendAuthCodeTrusted`, and `signInWithCustomToken`.
 
-Of these seven, six have an observed HTTP 200 success status and typed
-response schema (all except createTextBlast, whose response status and body
-remain explicit unknown).
+Twelve of these operations have an observed HTTP `200` success status and
+typed response schema. The text-blast operation retains an unknown response.
+The Firestore event read has an observed typed `403` response, not an observed
+success.
 
 ### TypeScript-derived operations
 
-The other 20 operations remain TypeScript-derived inferences:
+The other 13 operations remain TypeScript-derived inferences:
 
-- callable: `createEvent`, `cancelEvent`, `getEventInfo`, `getContacts`,
-  `addInvitedGuestsAsHost`, `createCohostRequest`, `deleteCohostRequest`,
-  `removeCohost`, `generateEventCohostLink`, `revokeEventCohostLink`,
-  `getMyUpcomingEventsForHomePage`, `getMyPastEventsForHomePage`, `addGuest`,
-  `markEventInterest`, and `getCurrentGuest`;
-- Firestore: `firestoreGetEvent`, `firestorePatchEvent`, `firestoreGetGuest`,
-  and `firestoreListDocuments`;
+- callable: `createEvent`, `cancelEvent`, `addInvitedGuestsAsHost`,
+  `createCohostRequest`, `deleteCohostRequest`, `removeCohost`,
+  `generateEventCohostLink`, `revokeEventCohostLink`, `addGuest`, and
+  `markEventInterest`;
+- Firestore: `firestorePatchEvent` and `firestoreListDocuments`;
 - Firebase auxiliary: `uploadEventPhoto`.
 
 Every operation's request and response claim is enumerated by JSON Pointer in
@@ -53,7 +54,7 @@ rules, and limits are **explicit unknown**. Operations with an observed HTTP
 `200` success have typed response schemas; the schema-free OpenAPI `default`
 response is retained for unrecognized statuses.
 
-The 1008 material claims are audited by
+The 1249 material claims are audited by
 `tests/remote-api-contract.test.js`. Each ledger citation resolves either to a
 JSON Pointer in the committed non-authoritative historical artifact or to a
 heading in the committed stable source index. This keeps the audit independent
@@ -131,6 +132,73 @@ The Firebase Identity Toolkit and Secure Token endpoints require an HTTP
 `Referer` header matching an allowed pattern. This is a Firebase project
 configuration fact, not a Partiful callable behavior.
 
+## Event and guest read evidence
+
+The sanitized owner-attended artifact records one-response arrays at the exact
+paths `result.data.upcomingEvents` and `result.data.pastEvents`. The observed
+counts were 35 and 294. Immediate repeats had the same count, identity
+sequence, and identity set, with no duplicate identity. Only item `id`
+completeness was checked. Named event fields retain their observed types and
+nullability without a broader presence claim.
+
+No remote paging field was observed for either list. Revision
+`2026-08-11.5` records the observed complete array representations but keeps
+remote pagination, limits, ordering, snapshot behavior, and list failures
+unknown. Event ID projection is supported. One selected guest status supports
+an RSVP projection for that item. Product state and full role mappings remain
+implementation gates.
+
+`getEventInfo` returned `200` at `result.data.event` for one selected readable
+event and returned `404 NOT_FOUND` for a synthetic missing ID. The selected
+event also returned `200` signed out. The proposal does not generalize this
+fact to other events. No inaccessible event was supplied, and no authenticated
+callable permission denial is claimed.
+
+`getCurrentGuest` returned `200` with an object at
+`result.data.currentGuest`. Only the observed object fields are formalized.
+A null current guest and other variants remain unknown.
+
+`firestoreGetGuest` returned `200` for the current guest document. Its
+document ID and status matched the callable guest. The complete Firestore
+typed-value grammar remains unknown. `firestoreGetEvent` returned
+`403 PERMISSION_DENIED` for both the selected readable ID and a synthetic
+missing ID with the observed authenticated request context. This does not
+establish attendee denial, resource existence, or Firestore not-found
+behavior.
+
+## Contact read evidence
+
+Current first-party public assets establish the exact relevant request:
+sibling `params` and `paging`, `maxResults: 1000`, and a null or string
+`cursor`. Normal loading uses empty `params`. A separate administrator flow
+can send boolean `useAuthUser`, but its behavior remains unknown. This request
+claim is reviewed first-party repository research. The owner-attended
+observation establishes the response and status claims.
+
+Two authenticated traversals each returned page sizes 1000, 1000, 451, and an
+empty terminal sentinel. Data pages had string `nextCursor` values. The
+terminal response omitted `nextCursor`. Both 2,451-item traversals had the same
+private identity sequence and set, with no observed duplicate identity.
+
+Every observed item had string private identity and name fields and a
+nonnegative integer `sharedEventCount`. The private identity is an internal
+transport field only. Public product output remains `displayName` and
+`sharedEventCount`. First-party assets establish client-side name filtering
+after cursor traversal. Signed-out `getContacts` returned
+`401 UNAUTHENTICATED`.
+
+Invalid cursors, cursor lifetime and reuse, backend ordering, snapshot
+behavior, `useAuthUser`, rate limiting, unsupported statuses, and duplicates
+outside these two observations remain unknown.
+
+## Read evidence privacy
+
+`spec/research/read-evidence-redacted-20260811.json` contains only HTTP
+metadata, allowlisted paths and types, counts, equality facts, and stable error
+codes. It contains no raw response values, credentials, identities, names,
+event ID values, or contact details. Contract tests reject unsafe identity,
+credential, JWT-like, phone, and email value patterns.
+
 ## Firebase transport configuration
 
 Revision `2026-08-11.4` formalizes two transport configuration facts required
@@ -153,7 +221,7 @@ by the Go implementation's Firebase requests:
 Origin is unmodelled and remains unknown because the reviewed evidence
 establishes no Origin request fact.
 
-The 1008 material claims are audited by `tests/remote-api-contract.test.js`.
+The 1249 material claims are audited by `tests/remote-api-contract.test.js`.
 
 ## Resolved conflict
 
@@ -165,7 +233,8 @@ nested `message` object with `text`, `to`, `showOnEventPage`, and optional
 
 ## Open questions
 
-Future safe observations should update both ledgers, preserve privacy-safe
+Future safe observations must update both ledgers, preserve privacy-safe
 evidence, and receive owner review before changing the revision. The remaining
-20 TypeScript-derived operations have no observed success status or response
-shape.
+13 TypeScript-derived operations have no observed response status or shape.
+The read-specific unknowns above remain explicit and must not become inferred
+implementation behavior.

--- a/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
+++ b/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
@@ -1,7 +1,7 @@
 # Partiful remote API contract evidence ledger
 
-**Proposed contract revision:** `2026-08-11.5`
-**Status:** Proposed; independent reviews are required
+**Owner-reviewed contract revision:** `2026-08-11.5`
+**Status:** Owner-reviewed under the issue #114 delegation
 **Contract:** `spec/partiful.openapi.json`
 **Machine-readable ledger:** `spec/partiful.api-evidence.json`
 **Stable citation sources:** `docs/research/2026-08-10-contract-evidence-sources.md`

--- a/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
+++ b/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
@@ -55,7 +55,7 @@ rules, and limits are **explicit unknown**. Eleven operations with an observed
 HTTP `200` status have typed response bodies. The schema-free
 send-code `200` and OpenAPI `default` responses do not claim a body.
 
-The 1250 material claims are audited by
+The 1232 material claims are audited by
 `tests/remote-api-contract.test.js`. Each ledger citation resolves either to a
 JSON Pointer in the committed non-authoritative historical artifact or to a
 heading in the committed stable source index. This keeps the audit independent
@@ -153,11 +153,19 @@ implementation gates.
 event and returned `404 NOT_FOUND` for a synthetic missing ID. The selected
 event also returned `200` signed out. The proposal does not generalize this
 fact to other events. No inaccessible event was supplied, and no authenticated
-callable permission denial is claimed.
+callable permission denial is claimed. One event-detail object cannot
+establish operation-wide field presence, nullability, or alternate variants,
+so `EventInfo` has no required field list. Related event-list representations
+support only optional `endDate` string/null and `image` object/null unions.
+Selected-only fields without related variant evidence remain unconstrained.
 
 `getCurrentGuest` returned `200` with an object at
-`result.data.currentGuest`. Only the observed object fields are formalized.
-A null current guest and other variants remain unknown.
+`result.data.currentGuest`. This single object cannot establish
+operation-wide field presence, nullability, or alternate variants, so
+`CurrentGuest` has no required field list. Cross-source fields retain only
+their supported types; `count`, `plusOnes`, and `userId` remain
+unconstrained. A null current guest, an ordinary non-null plus-one shape, and
+other variants remain unknown.
 
 `firestoreGetGuest` returned `200` for the current guest document. Its
 document ID and status matched the callable guest. The complete Firestore
@@ -227,7 +235,7 @@ by the Go implementation's Firebase requests:
 Origin is unmodelled and remains unknown because the reviewed evidence
 establishes no Origin request fact.
 
-The 1250 material claims are audited by `tests/remote-api-contract.test.js`.
+The 1232 material claims are audited by `tests/remote-api-contract.test.js`.
 
 ## Resolved conflict
 

--- a/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
+++ b/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
@@ -54,7 +54,7 @@ rules, and limits are **explicit unknown**. Operations with an observed HTTP
 `200` success have typed response schemas; the schema-free OpenAPI `default`
 response is retained for unrecognized statuses.
 
-The 1249 material claims are audited by
+The 1250 material claims are audited by
 `tests/remote-api-contract.test.js`. Each ledger citation resolves either to a
 JSON Pointer in the committed non-authoritative historical artifact or to a
 heading in the committed stable source index. This keeps the audit independent
@@ -221,7 +221,7 @@ by the Go implementation's Firebase requests:
 Origin is unmodelled and remains unknown because the reviewed evidence
 establishes no Origin request fact.
 
-The 1249 material claims are audited by `tests/remote-api-contract.test.js`.
+The 1250 material claims are audited by `tests/remote-api-contract.test.js`.
 
 ## Resolved conflict
 

--- a/docs/research/2026-08-11-contacts-pagination-public-assets.md
+++ b/docs/research/2026-08-11-contacts-pagination-public-assets.md
@@ -1,0 +1,152 @@
+# Contact pagination in current public web assets
+
+## Scope
+
+This note records privacy-safe research from Partiful's current public web
+assets. No authentication, credential, account-scoped request, identity-bearing
+response, or mutation was used. Public assets are research evidence, not remote
+contract authority.
+
+## Exact callable argument
+
+Partiful's `_app` asset, module `41886`, calls the Partiful callable wrapper as:
+
+```js
+wF("getContacts", {
+  params: { useAuthUser },
+  paging: {
+    maxResults: 1000,
+    cursor: previousPage?.paging?.nextCursor,
+  },
+});
+```
+
+Source:
+[`pages/_app-05be110884cfdc20.js`, module `41886`](https://partiful.com/_next/static/chunks/pages/_app-05be110884cfdc20.js?dpl=dpl_4w28tFBmSUwoToDpQB8CU8gt16sL).
+
+The ordinary contacts provider omits `useAuthUser`. A separate organization
+administrator flow explicitly passes `useAuthUser: true`.
+
+Sources:
+[`8317-e80fd0b80a07ac2a.js`, module `28339`](https://partiful.com/_next/static/chunks/8317-e80fd0b80a07ac2a.js?dpl=dpl_4w28tFBmSUwoToDpQB8CU8gt16sL);
+[`pages/_app-05be110884cfdc20.js`, module `41886`](https://partiful.com/_next/static/chunks/pages/_app-05be110884cfdc20.js?dpl=dpl_4w28tFBmSUwoToDpQB8CU8gt16sL).
+
+## Partiful wrapper and wire envelope
+
+Partiful wrapper module `95722` adds available device, Amplitude, administrator,
+and user metadata as siblings of `params` and `paging`. It removes undefined
+members from `params`, calls Firebase `httpsCallable`, and returns
+`sdkResult.data` after date normalization.
+
+Source:
+[`pages/_app-05be110884cfdc20.js`, module `95722`](https://partiful.com/_next/static/chunks/pages/_app-05be110884cfdc20.js?dpl=dpl_4w28tFBmSUwoToDpQB8CU8gt16sL).
+
+Firebase SDK module `68997` recursively encodes undefined as null, wraps the
+callable argument under top-level `data`, accepts a response payload under
+`data` or `result`, and returns the decoded payload as `sdkResult.data`.
+Therefore the first relevant request is:
+
+```json
+{
+  "data": {
+    "params": {},
+    "paging": {
+      "maxResults": 1000,
+      "cursor": null
+    }
+  }
+}
+```
+
+Later requests send the previous decoded `paging.nextCursor`.
+
+Source:
+[`pages/_app-05be110884cfdc20.js`, module `68997`](https://partiful.com/_next/static/chunks/pages/_app-05be110884cfdc20.js?dpl=dpl_4w28tFBmSUwoToDpQB8CU8gt16sL);
+[Firebase callable protocol](https://firebase.google.com/docs/functions/callable-reference).
+
+## Response and traversal
+
+After the SDK and Partiful wrappers, module `41886` expects:
+
+```text
+page.data
+page.paging.nextCursor
+```
+
+It makes sequential cursor requests. A non-null `nextCursor` emits that page's
+`data` and starts the next request. A nullish `nextCursor` emits an empty array
+and stops, so the public client expects a terminal sentinel response whose data
+is not consumed. It does not use offsets, page numbers, total counts, response
+length, retries, or repeated-cursor detection.
+
+Source:
+[`pages/_app-05be110884cfdc20.js`, module `41886`](https://partiful.com/_next/static/chunks/pages/_app-05be110884cfdc20.js?dpl=dpl_4w28tFBmSUwoToDpQB8CU8gt16sL).
+
+The raw official-style response paths are `result.data` and
+`result.paging.nextCursor`. The bundled SDK also accepts top-level `data`.
+Public assets do not prove which top-level field the current server emits.
+
+## Ordering, duplicates, and filtering
+
+Provider module `28339` appends emitted pages in order. `_app` module `62629`
+deduplicates cumulatively by contact `id`, keeping the first occurrence.
+Neither asset establishes the backend ordering key or why duplicates can
+occur.
+
+Sources:
+[`8317-e80fd0b80a07ac2a.js`, module `28339`](https://partiful.com/_next/static/chunks/8317-e80fd0b80a07ac2a.js?dpl=dpl_4w28tFBmSUwoToDpQB8CU8gt16sL);
+[`pages/_app-05be110884cfdc20.js`, module `62629`](https://partiful.com/_next/static/chunks/pages/_app-05be110884cfdc20.js?dpl=dpl_4w28tFBmSUwoToDpQB8CU8gt16sL).
+
+Text filtering is local. Modules `2914` and `3710` normalize and substring-match
+contact names. Phone-contact matching can also inspect phone-contact names and
+numbers inside the browser, but the CLI product contract does not expose those
+private values. Prefix matches sort before other matches without a documented
+secondary key. Past-guest, phone-contact, and follower filters are also local.
+
+Source:
+[`pages/_app-05be110884cfdc20.js`, modules `2914` and `3710`](https://partiful.com/_next/static/chunks/pages/_app-05be110884cfdc20.js?dpl=dpl_4w28tFBmSUwoToDpQB8CU8gt16sL).
+
+Invite module `6238` calls `getContactsFilteredByEvent({eventId})`, converts the
+result to an identity set, and intersects it with the already loaded contact
+catalog locally.
+
+Source:
+[`1585-abd7081ec2f9f79f.js`, module `6238`](https://partiful.com/_next/static/chunks/1585-abd7081ec2f9f79f.js?dpl=dpl_4w28tFBmSUwoToDpQB8CU8gt16sL).
+
+## Repository mismatch
+
+The current TypeScript CLI sends empty `params`, reads one `result.data`, filters
+names locally, and truncates locally. It neither sends `paging` nor follows
+`nextCursor`.
+
+Sources:
+`src/commands/contacts.ts:19-44`;
+`src/lib/cohosts.ts:75-98`;
+`src/lib/api/endpoints.ts:158-174`;
+`src/lib/api/endpoints.ts:391-399`.
+
+The owner-reviewed remote contract still permits only empty request `params`
+and keeps response/status behavior unknown.
+
+Sources:
+`spec/partiful.openapi.json#/paths/~1getContacts/post`;
+`spec/partiful.api-evidence.json#/operationClaims/getContacts`.
+
+## Remaining authenticated-only facts
+
+Owner-attended authenticated observation is still required to establish:
+
+- actual page lengths and whether 1,000 is a request size, server cap, or both;
+- the current raw top-level response field;
+- cursor type, lifetime, reuse, invalid-cursor behavior, and terminal response;
+- ordering stability, duplicates within/across pages, and snapshot behavior;
+- the behavior of `useAuthUser`;
+- success and failure status/body mappings; and
+- whether the public client's inferred traversal produces a complete catalog.
+
+Generic Firestore cursor rules do not apply without evidence that this callable
+uses a corresponding Firestore query.
+
+Sources:
+[Firestore order and limit](https://firebase.google.com/docs/firestore/query-data/order-limit-data);
+[Firestore query cursors](https://firebase.google.com/docs/firestore/query-data/query-cursors).

--- a/docs/research/2026-08-11-contacts-pagination-public-assets.md
+++ b/docs/research/2026-08-11-contacts-pagination-public-assets.md
@@ -127,7 +127,7 @@ Sources:
 
 The previous owner-reviewed remote contract, revision `2026-08-11.4`, permits
 only empty request `params` and keeps response/status behavior unknown.
-Proposed revision `2026-08-11.5` incorporates this paging request research and
+Owner-reviewed revision `2026-08-11.5` incorporates this paging request research and
 the separate authenticated response observation. It remains proposed.
 
 Sources:

--- a/docs/research/2026-08-11-contacts-pagination-public-assets.md
+++ b/docs/research/2026-08-11-contacts-pagination-public-assets.md
@@ -145,7 +145,7 @@ assets and that observation still do not establish:
 - cursor lifetime, reuse, and invalid-cursor behavior;
 - the backend ordering key and snapshot behavior;
 - the behavior of `useAuthUser`;
-- unsupported status and error-body mappings; and
+- rate limiting and unsupported status or error-body mappings; and
 - future completeness and duplicates outside the two observed traversals.
 
 The authenticated evidence and remaining limits are recorded in

--- a/docs/research/2026-08-11-contacts-pagination-public-assets.md
+++ b/docs/research/2026-08-11-contacts-pagination-public-assets.md
@@ -125,24 +125,31 @@ Sources:
 `src/lib/api/endpoints.ts:158-174`;
 `src/lib/api/endpoints.ts:391-399`.
 
-The owner-reviewed remote contract still permits only empty request `params`
-and keeps response/status behavior unknown.
+The previous owner-reviewed remote contract, revision `2026-08-11.4`, permits
+only empty request `params` and keeps response/status behavior unknown.
+Proposed revision `2026-08-11.5` incorporates this paging request research and
+the separate authenticated response observation. It remains proposed.
 
 Sources:
 `spec/partiful.openapi.json#/paths/~1getContacts/post`;
 `spec/partiful.api-evidence.json#/operationClaims/getContacts`.
 
-## Remaining authenticated-only facts
+## Facts not established by public assets
 
-Owner-attended authenticated observation is still required to establish:
+The separate owner-attended observation now establishes actual page lengths,
+the current raw response paths, cursor types, the terminal response, two
+stable traversals, and observed success and signed-out responses. Public
+assets and that observation still do not establish:
 
-- actual page lengths and whether 1,000 is a request size, server cap, or both;
-- the current raw top-level response field;
-- cursor type, lifetime, reuse, invalid-cursor behavior, and terminal response;
-- ordering stability, duplicates within/across pages, and snapshot behavior;
+- whether 1,000 is only a request size, a server cap, or both;
+- cursor lifetime, reuse, and invalid-cursor behavior;
+- the backend ordering key and snapshot behavior;
 - the behavior of `useAuthUser`;
-- success and failure status/body mappings; and
-- whether the public client's inferred traversal produces a complete catalog.
+- unsupported status and error-body mappings; and
+- future completeness and duplicates outside the two observed traversals.
+
+The authenticated evidence and remaining limits are recorded in
+`docs/research/2026-08-11-event-contacts-read-observation.md`.
 
 Generic Firestore cursor rules do not apply without evidence that this callable
 uses a corresponding Firestore query.

--- a/docs/research/2026-08-11-event-contacts-read-observation.md
+++ b/docs/research/2026-08-11-event-contacts-read-observation.md
@@ -40,10 +40,15 @@ future completeness remain unknown.
 ## Event detail observations
 
 `getEventInfo` returned HTTP `200` for one selected readable event. The
-response used `result.data.event` and had the named fields and types in
-`EventInfo`. The same selected event returned HTTP `200` while signed out.
-This is a fact about that selected event only. It does not establish that all
-events are public.
+response used `result.data.event`. The one object had the field presence and
+value types recorded by the sanitized aggregate. It does not establish
+operation-wide field presence, nullability, or alternate variants, so
+`EventInfo` has no required field list. Related event-list representations
+support only the optional `endDate` string/null and `image` object/null
+unions; selected-only fields without related support remain unconstrained.
+The same selected event returned HTTP `200` while signed out. This is a fact
+about that selected event only. It does not establish that all events are
+public.
 
 A synthetic missing ID returned HTTP `404` with callable error status
 `NOT_FOUND`. No known inaccessible event was supplied. An authenticated
@@ -54,7 +59,11 @@ callable permission denial was not observed and is not claimed.
 `getCurrentGuest` returned HTTP `200` for the selected event. The observed
 path was `result.data.currentGuest`. It was an object with string `id`,
 `name`, `status`, and `userId`, integer `count`, and null `plusOnes`.
-No null `currentGuest` or other variant was observed.
+This one object does not establish operation-wide field presence,
+nullability, or alternate variants, so `CurrentGuest` has no required field
+list. The proposed schema leaves `count`, `plusOnes`, and `userId`
+unconstrained. In particular, the shape of an ordinary non-null plus-one
+value is unknown. No null `currentGuest` or other variant was observed.
 
 `firestoreGetGuest` returned HTTP `200` for the document selected by the
 observed current guest ID. The document had `name`, `fields`, `createTime`,
@@ -111,5 +120,7 @@ Unsupported statuses and error bodies remain unknown. No claim is made for
 rate limiting, request retries, invalid cursors, cursor lifetime or reuse,
 backend ordering, snapshot behavior, `useAuthUser`, duplicates outside the
 two contact traversals, future catalog completeness, list pagination, or null
-and alternate current-guest variants. No inaccessible-event permission probe
+and alternate current-guest variants. Event-detail field presence and
+alternate variants, including plus-one shape, remain unknown beyond the
+stated related event-list support. No inaccessible-event permission probe
 exists.

--- a/docs/research/2026-08-11-event-contacts-read-observation.md
+++ b/docs/research/2026-08-11-event-contacts-read-observation.md
@@ -1,0 +1,110 @@
+# Event and contact read observation
+
+## Scope and provenance
+
+On August 11, 2026, the repository owner attended authenticated, read-only
+calls for event and contact reads. The agent did not handle credentials,
+identities, names, event IDs, or contact details. No mutation or additional
+live request was made.
+
+The sanitized source is
+`spec/research/read-evidence-redacted-20260811.json`. It contains only HTTP
+metadata, normalized paths and types, counts, equality facts, and allowlisted
+error codes. Revision `2026-08-11.5` is a proposal. This observation does not
+make it owner-reviewed.
+
+## Event list observations
+
+`getMyUpcomingEventsForHomePage` and
+`getMyPastEventsForHomePage` each returned HTTP `200` JSON callable
+envelopes. The exact array paths were
+`result.data.upcomingEvents` and `result.data.pastEvents`. One response held
+35 upcoming items and one response held 294 past items.
+
+An immediate repeat returned the same count, identity sequence, and identity
+set for each operation. No duplicate identity occurred in either observed
+sequence. This is stability evidence for two observations only. It does not
+establish an ordering key or snapshot behavior.
+
+The observations establish the named item fields and types in the proposed
+schemas. Only `id` was present on every item by an explicit aggregate check.
+The selected upcoming item also had a guest object with a string status. This
+supports the event ID projection and one selected RSVP-status projection. It
+does not establish the remote status-to-product-state mapping or a complete
+`userRole` mapping.
+
+No list paging request or response was observed. The arrays were complete
+representations in each observed response. Remote pagination, limits, and
+future completeness remain unknown.
+
+## Event detail observations
+
+`getEventInfo` returned HTTP `200` for one selected readable event. The
+response used `result.data.event` and had the named fields and types in
+`EventInfo`. The same selected event returned HTTP `200` while signed out.
+This is a fact about that selected event only. It does not establish that all
+events are public.
+
+A synthetic missing ID returned HTTP `404` with callable error status
+`NOT_FOUND`. No known inaccessible event was supplied. An authenticated
+callable permission denial was not observed and is not claimed.
+
+## Guest and Firestore observations
+
+`getCurrentGuest` returned HTTP `200` for the selected event. The observed
+path was `result.data.currentGuest`. It was an object with string `id`,
+`name`, `status`, and `userId`, integer `count`, and null `plusOnes`.
+No null `currentGuest` or other variant was observed.
+
+`firestoreGetGuest` returned HTTP `200` for the document selected by the
+observed current guest ID. The document had `name`, `fields`, `createTime`,
+and `updateTime`. The named `count`, `createdAt`, `name`, and `status` fields
+were typed Firestore value objects with string children. The document ID
+matched the current guest ID, and its status matched the callable guest
+status. The complete Firestore typed-value grammar remains unknown.
+
+With the observed authenticated credential, `firestoreGetEvent` returned
+HTTP `403` and `PERMISSION_DENIED` for both the selected readable event ID and
+a synthetic missing ID. This exact operation and credential behavior does not
+show attendee denial, resource existence, or Firestore not-found behavior.
+
+## Contact observations
+
+The public-asset request evidence is in
+`docs/research/2026-08-11-contacts-pagination-public-assets.md`. It establishes
+sibling `params` and `paging` with `maxResults: 1000`; normal loading uses
+empty `params`, and `cursor` is null on the first request and a string on later
+data-page requests. A separate administrator flow can send boolean
+`useAuthUser`; its behavior remains unknown.
+
+The authenticated observation traversed 2,451 contacts twice. Both traversals
+returned pages of 1000, 1000, and 451 items, then an empty terminal sentinel.
+Each data page had a string `nextCursor`. The terminal response omitted
+`nextCursor`. Both traversals had the same private identity sequence and set,
+and no duplicate identity was observed.
+
+Every observed contact had a string private `id`, string `name`, and
+nonnegative integer `sharedEventCount`. The private identity is transport
+data for internal resolution only. Public product output remains
+`displayName` and `sharedEventCount`.
+
+The current first-party client traverses the cursor sequence and then filters
+names locally. Thus the product name filter applies to the complete traversed
+catalog, not to a remote filter parameter. Signed-out `getContacts` returned
+HTTP `401` with callable error status `UNAUTHENTICATED`.
+
+## Privacy boundary
+
+The committed artifact contains no raw body values, credentials, identities,
+names, IDs, phone numbers, email addresses, or tokens. Tests reject identity
+or credential value keys, JWT-like values, phone numbers, and email
+addresses. Only allowlisted metadata, paths, types, counts, equality facts,
+and stable error codes can remain.
+
+## Remaining unknowns
+
+Unsupported statuses and error bodies remain unknown. No claim is made for
+rate limiting, request retries, invalid cursors, cursor lifetime or reuse,
+backend ordering, snapshot behavior, `useAuthUser`, duplicates outside the
+two contact traversals, list pagination, or null and alternate current-guest
+variants. No inaccessible-event permission probe exists.

--- a/docs/research/2026-08-11-event-contacts-read-observation.md
+++ b/docs/research/2026-08-11-event-contacts-read-observation.md
@@ -43,9 +43,10 @@ future completeness remain unknown.
 response used `result.data.event`. The one object had the field presence and
 value types recorded by the sanitized aggregate. It does not establish
 operation-wide field presence, nullability, or alternate variants, so
-`EventInfo` has no required field list. Related event-list representations
-support only the optional `endDate` string/null and `image` object/null
-unions; selected-only fields without related support remain unconstrained.
+`EventInfo` has no operation-wide top-level type and no required field list.
+Related event-list representations support only the optional `endDate`
+string/null and `image` object/null unions; selected-only fields without
+related support remain unconstrained.
 The same selected event returned HTTP `200` while signed out. This is a fact
 about that selected event only. It does not establish that all events are
 public.
@@ -60,10 +61,11 @@ callable permission denial was not observed and is not claimed.
 path was `result.data.currentGuest`. It was an object with string `id`,
 `name`, `status`, and `userId`, integer `count`, and null `plusOnes`.
 This one object does not establish operation-wide field presence,
-nullability, or alternate variants, so `CurrentGuest` has no required field
-list. The proposed schema leaves `count`, `plusOnes`, and `userId`
-unconstrained. In particular, the shape of an ordinary non-null plus-one
-value is unknown. No null `currentGuest` or other variant was observed.
+nullability, or alternate variants, so `CurrentGuest` has no operation-wide
+top-level type and no required field list. The proposed schema leaves `count`,
+`plusOnes`, and `userId` unconstrained. In particular, the shape of an
+ordinary non-null plus-one value is unknown. No null `currentGuest` or other
+variant was observed.
 
 `firestoreGetGuest` returned HTTP `200` for the document selected by the
 observed current guest ID. The document had `name`, `fields`, `createTime`,

--- a/docs/research/2026-08-11-event-contacts-read-observation.md
+++ b/docs/research/2026-08-11-event-contacts-read-observation.md
@@ -90,14 +90,18 @@ data for internal resolution only. Public product output remains
 
 The current first-party client traverses the cursor sequence and then filters
 names locally. Thus the product name filter applies to the complete traversed
-catalog, not to a remote filter parameter. Signed-out `getContacts` returned
-HTTP `401` with callable error status `UNAUTHENTICATED`.
+catalog, not to a remote filter parameter. The client also deduplicates by
+contact `id` and keeps the first occurrence. This does not establish server
+duplicate or ordering behavior. Signed-out `getContacts` returned HTTP `401`
+with callable error status `UNAUTHENTICATED`.
 
 ## Privacy boundary
 
 The committed artifact contains no raw body values, credentials, identities,
-names, IDs, phone numbers, email addresses, or tokens. Tests reject identity
-or credential value keys, JWT-like values, phone numbers, and email
+names, IDs, phone numbers, email addresses, or tokens. Tests strictly walk
+every aggregate key and string value against an exact allowlist, including
+mutation checks for unknown keys and arbitrary values. They also reject
+identity or credential value keys, JWT-like values, phone numbers, and email
 addresses. Only allowlisted metadata, paths, types, counts, equality facts,
 and stable error codes can remain.
 
@@ -106,5 +110,6 @@ and stable error codes can remain.
 Unsupported statuses and error bodies remain unknown. No claim is made for
 rate limiting, request retries, invalid cursors, cursor lifetime or reuse,
 backend ordering, snapshot behavior, `useAuthUser`, duplicates outside the
-two contact traversals, list pagination, or null and alternate current-guest
-variants. No inaccessible-event permission probe exists.
+two contact traversals, future catalog completeness, list pagination, or null
+and alternate current-guest variants. No inaccessible-event permission probe
+exists.

--- a/spec/partiful.api-evidence.json
+++ b/spec/partiful.api-evidence.json
@@ -394,7 +394,7 @@
     "Firestore event GET returned PERMISSION_DENIED for selected readable and synthetic IDs with one credential; success, not-found, attendee-denial, and other credential behavior remain unknown.",
     "Contact invalid-cursor behavior, cursor lifetime and reuse, ordering key, snapshot behavior, useAuthUser, rate limiting, unsupported statuses, future catalog completeness, server duplicate behavior, and duplicates outside two traversals remain unknown."
   ],
-  "status": "proposed",
+  "status": "owner-reviewed",
   "claims": {
     "#/servers/0/url": {
       "classification": "typescript-derived-inference",

--- a/spec/partiful.api-evidence.json
+++ b/spec/partiful.api-evidence.json
@@ -389,7 +389,8 @@
     "Origin is unmodelled and remains unknown because the reviewed evidence establishes no Origin request fact.",
     "Event-list remote pagination, limits, ordering key, snapshot behavior, unsupported statuses, and failure bodies remain unknown.",
     "Only the selected getEventInfo event was observed signed out; readability of other events and authenticated inaccessible-event denial remain unknown.",
-    "Current-guest null and alternate variants, unsupported statuses, and failure bodies remain unknown.",
+    "Only one selected EventInfo object was observed; operation-wide field presence, nullability, and alternate variants remain unknown. Related event-list representations support only the optional endDate string/null and image object/null unions.",
+    "Only one CurrentGuest object was observed; operation-wide field presence, nullability, alternate variants, plus-one shape, unsupported statuses, and failure bodies remain unknown.",
     "Firestore event GET returned PERMISSION_DENIED for selected readable and synthetic IDs with one credential; success, not-found, attendee-denial, and other credential behavior remain unknown.",
     "Contact invalid-cursor behavior, cursor lifetime and reuse, ordering key, snapshot behavior, useAuthUser, rate limiting, unsupported statuses, future catalog completeness, server duplicate behavior, and duplicates outside two traversals remain unknown."
   ],
@@ -4779,53 +4780,13 @@
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
     },
-    "#/components/schemas/EventInfo/required/0": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
-    },
-    "#/components/schemas/EventInfo/required/1": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
-    },
-    "#/components/schemas/EventInfo/required/2": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
-    },
-    "#/components/schemas/EventInfo/required/3": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
-    },
-    "#/components/schemas/EventInfo/required/4": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
-    },
-    "#/components/schemas/EventInfo/required/5": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
-    },
-    "#/components/schemas/EventInfo/required/6": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
-    },
-    "#/components/schemas/EventInfo/required/7": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
-    },
-    "#/components/schemas/EventInfo/required/8": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
-    },
-    "#/components/schemas/EventInfo/required/9": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
-    },
     "#/components/schemas/EventInfo/properties/id": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
     },
     "#/components/schemas/EventInfo/properties/id/type": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
     },
     "#/components/schemas/EventInfo/properties/title": {
       "classification": "dated-live-observation",
@@ -4837,15 +4798,19 @@
     },
     "#/components/schemas/EventInfo/properties/startDate/type": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
     },
     "#/components/schemas/EventInfo/properties/endDate": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
     },
-    "#/components/schemas/EventInfo/properties/endDate/type": {
+    "#/components/schemas/EventInfo/properties/endDate/type/0": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/components/schemas/EventInfo/properties/endDate/type/1": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
     },
     "#/components/schemas/EventInfo/properties/timezone": {
       "classification": "dated-live-observation",
@@ -4853,7 +4818,7 @@
     },
     "#/components/schemas/EventInfo/properties/timezone/type": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
     },
     "#/components/schemas/EventInfo/properties/status": {
       "classification": "dated-live-observation",
@@ -4861,7 +4826,7 @@
     },
     "#/components/schemas/EventInfo/properties/status/type": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
     },
     "#/components/schemas/EventInfo/properties/description": {
       "classification": "dated-live-observation",
@@ -4873,21 +4838,21 @@
     },
     "#/components/schemas/EventInfo/properties/displaySettings/type": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
     },
     "#/components/schemas/EventInfo/properties/image": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
     },
-    "#/components/schemas/EventInfo/properties/image/type": {
+    "#/components/schemas/EventInfo/properties/image/type/0": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/components/schemas/EventInfo/properties/image/type/1": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
     },
     "#/components/schemas/EventInfo/properties/visibility": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
-    },
-    "#/components/schemas/EventInfo/properties/visibility/type": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
     },
@@ -4979,30 +4944,6 @@
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
     },
-    "#/components/schemas/CurrentGuest/required/0": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
-    },
-    "#/components/schemas/CurrentGuest/required/1": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
-    },
-    "#/components/schemas/CurrentGuest/required/2": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
-    },
-    "#/components/schemas/CurrentGuest/required/3": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
-    },
-    "#/components/schemas/CurrentGuest/required/4": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
-    },
-    "#/components/schemas/CurrentGuest/required/5": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
-    },
     "#/components/schemas/CurrentGuest/properties/id": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
@@ -5012,10 +4953,6 @@
       "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
     },
     "#/components/schemas/CurrentGuest/properties/count": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
-    },
-    "#/components/schemas/CurrentGuest/properties/count/type": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
     },
@@ -5031,10 +4968,6 @@
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
     },
-    "#/components/schemas/CurrentGuest/properties/plusOnes/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
-    },
     "#/components/schemas/CurrentGuest/properties/status": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
@@ -5044,10 +4977,6 @@
       "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
     },
     "#/components/schemas/CurrentGuest/properties/userId": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
-    },
-    "#/components/schemas/CurrentGuest/properties/userId/type": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
     },
@@ -5534,13 +5463,30 @@
       "syntheticMissingStatus": 404,
       "syntheticMissingCode": "NOT_FOUND",
       "authenticatedPermission": "not-observed",
-      "inaccessibleEvent": "not-observed"
+      "inaccessibleEvent": "not-observed",
+      "sampleScope": "one-selected-event",
+      "fieldPresence": "selected-object-only",
+      "fieldNullabilityAndAlternateVariants": "explicit-unknown",
+      "relatedEventRepresentationTypes": {
+        "endDate": [
+          "string",
+          "null"
+        ],
+        "image": [
+          "object",
+          "null"
+        ]
+      }
     },
     "getCurrentGuest": {
       "status": 200,
       "rawPath": "result.data.currentGuest",
       "otherVariants": "explicit-unknown",
-      "currentGuestNullability": "explicit-unknown"
+      "currentGuestNullability": "explicit-unknown",
+      "sampleScope": "one-selected-event",
+      "fieldPresence": "selected-object-only",
+      "fieldNullabilityAndAlternateVariants": "explicit-unknown",
+      "plusOnesVariants": "explicit-unknown"
     },
     "firestoreGuest": {
       "status": 200,

--- a/spec/partiful.api-evidence.json
+++ b/spec/partiful.api-evidence.json
@@ -4776,10 +4776,6 @@
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
     },
-    "#/components/schemas/EventInfo/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
-    },
     "#/components/schemas/EventInfo/properties/id": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
@@ -4939,10 +4935,6 @@
     "#/components/schemas/CallableNotFoundError/properties/error/properties/status/const": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
-    },
-    "#/components/schemas/CurrentGuest/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
     },
     "#/components/schemas/CurrentGuest/properties/id": {
       "classification": "dated-live-observation",

--- a/spec/partiful.api-evidence.json
+++ b/spec/partiful.api-evidence.json
@@ -31,7 +31,8 @@
     "readContacts20260811": "docs/research/2026-08-11-event-contacts-read-observation.md#contact-observations",
     "readPrivacy20260811": "docs/research/2026-08-11-event-contacts-read-observation.md#privacy-boundary",
     "readUnknowns20260811": "docs/research/2026-08-11-event-contacts-read-observation.md#remaining-unknowns",
-    "publicContactPaging20260811": "docs/research/2026-08-11-contacts-pagination-public-assets.md#exact-callable-argument"
+    "publicContactPaging20260811": "docs/research/2026-08-11-contacts-pagination-public-assets.md#exact-callable-argument",
+    "publicContactDeduplication20260811": "docs/research/2026-08-11-contacts-pagination-public-assets.md#ordering-duplicates-and-filtering"
   },
   "operations": {
     "createEvent": {
@@ -390,7 +391,7 @@
     "Only the selected getEventInfo event was observed signed out; readability of other events and authenticated inaccessible-event denial remain unknown.",
     "Current-guest null and alternate variants, unsupported statuses, and failure bodies remain unknown.",
     "Firestore event GET returned PERMISSION_DENIED for selected readable and synthetic IDs with one credential; success, not-found, attendee-denial, and other credential behavior remain unknown.",
-    "Contact invalid-cursor behavior, cursor lifetime and reuse, ordering key, snapshot behavior, useAuthUser, unsupported statuses, and duplicates outside two traversals remain unknown."
+    "Contact invalid-cursor behavior, cursor lifetime and reuse, ordering key, snapshot behavior, useAuthUser, rate limiting, unsupported statuses, future catalog completeness, server duplicate behavior, and duplicates outside two traversals remain unknown."
   ],
   "status": "proposed",
   "claims": {
@@ -5581,6 +5582,12 @@
         "sharedEventCount"
       ],
       "privateIdentityField": "id",
+      "clientDeduplication": {
+        "classification": "reviewed-first-party-repository-research",
+        "citation": "docs/research/2026-08-11-contacts-pagination-public-assets.md#ordering-duplicates-and-filtering",
+        "identityField": "id",
+        "duplicateResolution": "first-occurrence-wins"
+      },
       "signedOutStatus": 401,
       "signedOutCode": "UNAUTHENTICATED",
       "unknowns": [
@@ -5589,10 +5596,16 @@
         "backend ordering key",
         "snapshot behavior",
         "useAuthUser behavior",
-        "duplicates outside the two observations"
+        "duplicates outside the two observations",
+        "rate limiting",
+        "future catalog completeness"
       ],
       "normalParams": {},
-      "useAuthUserBehavior": "explicit-unknown"
+      "useAuthUserBehavior": "explicit-unknown",
+      "rateLimiting": "explicit-unknown",
+      "futureCatalogCompleteness": "explicit-unknown",
+      "serverDuplicateBehavior": "explicit-unknown",
+      "serverOrderingBehavior": "explicit-unknown"
     },
     "failureBoundary": {
       "unsupportedStatuses": "explicit-unknown",

--- a/spec/partiful.api-evidence.json
+++ b/spec/partiful.api-evidence.json
@@ -1,5 +1,5 @@
 {
-  "contractRevision": "2026-08-11.4",
+  "contractRevision": "2026-08-11.5",
   "contractPath": "spec/partiful.openapi.json",
   "allowedClassifications": [
     "dated-live-observation",
@@ -23,7 +23,15 @@
     "authRefresh20260811": "docs/research/2026-08-11-auth-observation.md#refreshtoken",
     "authLookup20260811": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser",
     "firebasePublicApiKeyRedacted": "docs/research/2026-08-11-firebase-public-api-key-redacted.md#firebase-public-api-key",
-    "augRefererRestriction": "docs/research/2026-08-11-auth-observation.md#firebase-api-key-referrer-restriction"
+    "augRefererRestriction": "docs/research/2026-08-11-auth-observation.md#firebase-api-key-referrer-restriction",
+    "readObservation20260811": "docs/research/2026-08-11-event-contacts-read-observation.md#scope-and-provenance",
+    "readEventLists20260811": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations",
+    "readEventInfo20260811": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations",
+    "readGuestFirestore20260811": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations",
+    "readContacts20260811": "docs/research/2026-08-11-event-contacts-read-observation.md#contact-observations",
+    "readPrivacy20260811": "docs/research/2026-08-11-event-contacts-read-observation.md#privacy-boundary",
+    "readUnknowns20260811": "docs/research/2026-08-11-event-contacts-read-observation.md#remaining-unknowns",
+    "publicContactPaging20260811": "docs/research/2026-08-11-contacts-pagination-public-assets.md#exact-callable-argument"
   },
   "operations": {
     "createEvent": {
@@ -35,12 +43,12 @@
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post"
     },
     "getEventInfo": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getEventInfo/post"
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
     },
     "getContacts": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post"
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#contact-observations"
     },
     "createTextBlast": {
       "classification": "dated-live-observation",
@@ -71,12 +79,12 @@
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post"
     },
     "getMyUpcomingEventsForHomePage": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyUpcomingEventsForHomePage/post"
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
     },
     "getMyPastEventsForHomePage": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyPastEventsForHomePage/post"
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
     },
     "addGuest": {
       "classification": "typescript-derived-inference",
@@ -87,20 +95,20 @@
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1markEventInterest/post"
     },
     "getCurrentGuest": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getCurrentGuest/post"
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
     },
     "firestoreGetEvent": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get"
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
     },
     "firestorePatchEvent": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch"
     },
     "firestoreGetGuest": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get"
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
     },
     "firestoreListDocuments": {
       "classification": "typescript-derived-inference",
@@ -155,18 +163,18 @@
     "getEventInfo": {
       "request": "typescript-derived-inference",
       "requestCitation": "spec/research/historical-27-operation-draft.json#/paths/~1getEventInfo/post",
-      "response": "explicit-unknown",
-      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
-      "status": "explicit-unknown",
-      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+      "response": "dated-live-observation",
+      "responseCitation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations",
+      "status": "dated-live-observation",
+      "statusCitation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
     },
     "getContacts": {
-      "request": "typescript-derived-inference",
-      "requestCitation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post",
-      "response": "explicit-unknown",
-      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
-      "status": "explicit-unknown",
-      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+      "request": "reviewed-first-party-repository-research",
+      "requestCitation": "docs/research/2026-08-11-contacts-pagination-public-assets.md#exact-callable-argument",
+      "response": "dated-live-observation",
+      "responseCitation": "docs/research/2026-08-11-event-contacts-read-observation.md#contact-observations",
+      "status": "dated-live-observation",
+      "statusCitation": "docs/research/2026-08-11-event-contacts-read-observation.md#contact-observations"
     },
     "createTextBlast": {
       "request": "dated-live-observation",
@@ -227,18 +235,18 @@
     "getMyUpcomingEventsForHomePage": {
       "request": "typescript-derived-inference",
       "requestCitation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyUpcomingEventsForHomePage/post",
-      "response": "explicit-unknown",
-      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
-      "status": "explicit-unknown",
-      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+      "response": "dated-live-observation",
+      "responseCitation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations",
+      "status": "dated-live-observation",
+      "statusCitation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
     },
     "getMyPastEventsForHomePage": {
       "request": "typescript-derived-inference",
       "requestCitation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyPastEventsForHomePage/post",
-      "response": "explicit-unknown",
-      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
-      "status": "explicit-unknown",
-      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+      "response": "dated-live-observation",
+      "responseCitation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations",
+      "status": "dated-live-observation",
+      "statusCitation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
     },
     "addGuest": {
       "request": "typescript-derived-inference",
@@ -259,18 +267,18 @@
     "getCurrentGuest": {
       "request": "typescript-derived-inference",
       "requestCitation": "spec/research/historical-27-operation-draft.json#/paths/~1getCurrentGuest/post",
-      "response": "explicit-unknown",
-      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
-      "status": "explicit-unknown",
-      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+      "response": "dated-live-observation",
+      "responseCitation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations",
+      "status": "dated-live-observation",
+      "statusCitation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
     },
     "firestoreGetEvent": {
       "request": "typescript-derived-inference",
       "requestCitation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get",
-      "response": "explicit-unknown",
-      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
-      "status": "explicit-unknown",
-      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+      "response": "dated-live-observation",
+      "responseCitation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations",
+      "status": "dated-live-observation",
+      "statusCitation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
     },
     "firestorePatchEvent": {
       "request": "typescript-derived-inference",
@@ -283,10 +291,10 @@
     "firestoreGetGuest": {
       "request": "typescript-derived-inference",
       "requestCitation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get",
-      "response": "explicit-unknown",
-      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
-      "status": "explicit-unknown",
-      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+      "response": "dated-live-observation",
+      "responseCitation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations",
+      "status": "dated-live-observation",
+      "statusCitation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
     },
     "firestoreListDocuments": {
       "request": "typescript-derived-inference",
@@ -377,9 +385,14 @@
     "Status codes and error bodies for operations without dated observations.",
     "Unconditional poster-catalog failure statuses and bodies remain unknown; only HTTP 200 is an accepted catalog success.",
     "The full set of Referer values accepted by the Firebase API-key restriction remains unknown; https://partiful.com/ is the only observed accepted value.",
-    "Origin is unmodelled and remains unknown because the reviewed evidence establishes no Origin request fact."
+    "Origin is unmodelled and remains unknown because the reviewed evidence establishes no Origin request fact.",
+    "Event-list remote pagination, limits, ordering key, snapshot behavior, unsupported statuses, and failure bodies remain unknown.",
+    "Only the selected getEventInfo event was observed signed out; readability of other events and authenticated inaccessible-event denial remain unknown.",
+    "Current-guest null and alternate variants, unsupported statuses, and failure bodies remain unknown.",
+    "Firestore event GET returned PERMISSION_DENIED for selected readable and synthetic IDs with one credential; success, not-found, attendee-denial, and other credential behavior remain unknown.",
+    "Contact invalid-cursor behavior, cursor lifetime and reuse, ordering key, snapshot behavior, useAuthUser, unsupported statuses, and duplicates outside two traversals remain unknown."
   ],
-  "status": "owner-reviewed",
+  "status": "proposed",
   "claims": {
     "#/servers/0/url": {
       "classification": "typescript-derived-inference",
@@ -717,6 +730,30 @@
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getEventInfo/post/requestBody/content/application~1json/schema/additionalProperties"
     },
+    "#/paths/~1getEventInfo/post/responses/200": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/paths/~1getEventInfo/post/responses/200/content/application~1json": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/paths/~1getEventInfo/post/responses/200/content/application~1json/schema/$ref": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/paths/~1getEventInfo/post/responses/404": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/paths/~1getEventInfo/post/responses/404/content/application~1json": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/paths/~1getEventInfo/post/responses/404/content/application~1json/schema/$ref": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
     "#/paths/~1getEventInfo/post/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
@@ -734,8 +771,8 @@
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post/requestBody/required"
     },
     "#/paths/~1getContacts/post/requestBody/content/application~1json": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post/requestBody/content/application~1json"
+      "classification": "reviewed-first-party-repository-research",
+      "citation": "docs/research/2026-08-11-contacts-pagination-public-assets.md#exact-callable-argument"
     },
     "#/paths/~1getContacts/post/requestBody/content/application~1json/schema/type": {
       "classification": "typescript-derived-inference",
@@ -746,8 +783,8 @@
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post/requestBody/content/application~1json/schema/required/0"
     },
     "#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data"
+      "classification": "reviewed-first-party-repository-research",
+      "citation": "docs/research/2026-08-11-contacts-pagination-public-assets.md#exact-callable-argument"
     },
     "#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/type": {
       "classification": "typescript-derived-inference",
@@ -761,13 +798,25 @@
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/required/1"
     },
+    "#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/required/2": {
+      "classification": "reviewed-first-party-repository-research",
+      "citation": "docs/research/2026-08-11-contacts-pagination-public-assets.md#exact-callable-argument"
+    },
     "#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/properties/params": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/properties/params"
+      "classification": "reviewed-first-party-repository-research",
+      "citation": "docs/research/2026-08-11-contacts-pagination-public-assets.md#exact-callable-argument"
     },
     "#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/properties/params/type": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/properties/params/type"
+    },
+    "#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/useAuthUser": {
+      "classification": "reviewed-first-party-repository-research",
+      "citation": "docs/research/2026-08-11-contacts-pagination-public-assets.md#exact-callable-argument"
+    },
+    "#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/useAuthUser/type": {
+      "classification": "reviewed-first-party-repository-research",
+      "citation": "docs/research/2026-08-11-contacts-pagination-public-assets.md#exact-callable-argument"
     },
     "#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties": {
       "classification": "typescript-derived-inference",
@@ -805,6 +854,50 @@
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1"
     },
+    "#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/properties/paging": {
+      "classification": "reviewed-first-party-repository-research",
+      "citation": "docs/research/2026-08-11-contacts-pagination-public-assets.md#exact-callable-argument"
+    },
+    "#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/properties/paging/type": {
+      "classification": "reviewed-first-party-repository-research",
+      "citation": "docs/research/2026-08-11-contacts-pagination-public-assets.md#exact-callable-argument"
+    },
+    "#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/properties/paging/required/0": {
+      "classification": "reviewed-first-party-repository-research",
+      "citation": "docs/research/2026-08-11-contacts-pagination-public-assets.md#exact-callable-argument"
+    },
+    "#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/properties/paging/required/1": {
+      "classification": "reviewed-first-party-repository-research",
+      "citation": "docs/research/2026-08-11-contacts-pagination-public-assets.md#exact-callable-argument"
+    },
+    "#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/properties/paging/properties/maxResults": {
+      "classification": "reviewed-first-party-repository-research",
+      "citation": "docs/research/2026-08-11-contacts-pagination-public-assets.md#exact-callable-argument"
+    },
+    "#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/properties/paging/properties/maxResults/type": {
+      "classification": "reviewed-first-party-repository-research",
+      "citation": "docs/research/2026-08-11-contacts-pagination-public-assets.md#exact-callable-argument"
+    },
+    "#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/properties/paging/properties/maxResults/const": {
+      "classification": "reviewed-first-party-repository-research",
+      "citation": "docs/research/2026-08-11-contacts-pagination-public-assets.md#exact-callable-argument"
+    },
+    "#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/properties/paging/properties/cursor": {
+      "classification": "reviewed-first-party-repository-research",
+      "citation": "docs/research/2026-08-11-contacts-pagination-public-assets.md#exact-callable-argument"
+    },
+    "#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/properties/paging/properties/cursor/type/0": {
+      "classification": "reviewed-first-party-repository-research",
+      "citation": "docs/research/2026-08-11-contacts-pagination-public-assets.md#exact-callable-argument"
+    },
+    "#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/properties/paging/properties/cursor/type/1": {
+      "classification": "reviewed-first-party-repository-research",
+      "citation": "docs/research/2026-08-11-contacts-pagination-public-assets.md#exact-callable-argument"
+    },
+    "#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/properties/paging/additionalProperties": {
+      "classification": "reviewed-first-party-repository-research",
+      "citation": "docs/research/2026-08-11-contacts-pagination-public-assets.md#exact-callable-argument"
+    },
     "#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/additionalProperties": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post/requestBody/content/application~1json/schema/properties/data/additionalProperties"
@@ -812,6 +905,30 @@
     "#/paths/~1getContacts/post/requestBody/content/application~1json/schema/additionalProperties": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getContacts/post/requestBody/content/application~1json/schema/additionalProperties"
+    },
+    "#/paths/~1getContacts/post/responses/200": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#contact-observations"
+    },
+    "#/paths/~1getContacts/post/responses/200/content/application~1json": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#contact-observations"
+    },
+    "#/paths/~1getContacts/post/responses/200/content/application~1json/schema/$ref": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#contact-observations"
+    },
+    "#/paths/~1getContacts/post/responses/401": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#contact-observations"
+    },
+    "#/paths/~1getContacts/post/responses/401/content/application~1json": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#contact-observations"
+    },
+    "#/paths/~1getContacts/post/responses/401/content/application~1json/schema/$ref": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#contact-observations"
     },
     "#/paths/~1getContacts/post/responses/default": {
       "classification": "explicit-unknown",
@@ -1793,6 +1910,58 @@
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyUpcomingEventsForHomePage/post/requestBody/content/application~1json/schema/additionalProperties"
     },
+    "#/paths/~1getMyUpcomingEventsForHomePage/post/responses/200": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/paths/~1getMyUpcomingEventsForHomePage/post/responses/200/content/application~1json": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/paths/~1getMyUpcomingEventsForHomePage/post/responses/200/content/application~1json/schema/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/paths/~1getMyUpcomingEventsForHomePage/post/responses/200/content/application~1json/schema/required/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/paths/~1getMyUpcomingEventsForHomePage/post/responses/200/content/application~1json/schema/properties/result": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/paths/~1getMyUpcomingEventsForHomePage/post/responses/200/content/application~1json/schema/properties/result/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/paths/~1getMyUpcomingEventsForHomePage/post/responses/200/content/application~1json/schema/properties/result/required/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/paths/~1getMyUpcomingEventsForHomePage/post/responses/200/content/application~1json/schema/properties/result/properties/data": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/paths/~1getMyUpcomingEventsForHomePage/post/responses/200/content/application~1json/schema/properties/result/properties/data/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/paths/~1getMyUpcomingEventsForHomePage/post/responses/200/content/application~1json/schema/properties/result/properties/data/required/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/paths/~1getMyUpcomingEventsForHomePage/post/responses/200/content/application~1json/schema/properties/result/properties/data/properties/upcomingEvents": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/paths/~1getMyUpcomingEventsForHomePage/post/responses/200/content/application~1json/schema/properties/result/properties/data/properties/upcomingEvents/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/paths/~1getMyUpcomingEventsForHomePage/post/responses/200/content/application~1json/schema/properties/result/properties/data/properties/upcomingEvents/items/$ref": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
     "#/paths/~1getMyUpcomingEventsForHomePage/post/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
@@ -1888,6 +2057,58 @@
     "#/paths/~1getMyPastEventsForHomePage/post/requestBody/content/application~1json/schema/additionalProperties": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getMyPastEventsForHomePage/post/requestBody/content/application~1json/schema/additionalProperties"
+    },
+    "#/paths/~1getMyPastEventsForHomePage/post/responses/200": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/paths/~1getMyPastEventsForHomePage/post/responses/200/content/application~1json": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/paths/~1getMyPastEventsForHomePage/post/responses/200/content/application~1json/schema/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/paths/~1getMyPastEventsForHomePage/post/responses/200/content/application~1json/schema/required/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/paths/~1getMyPastEventsForHomePage/post/responses/200/content/application~1json/schema/properties/result": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/paths/~1getMyPastEventsForHomePage/post/responses/200/content/application~1json/schema/properties/result/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/paths/~1getMyPastEventsForHomePage/post/responses/200/content/application~1json/schema/properties/result/required/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/paths/~1getMyPastEventsForHomePage/post/responses/200/content/application~1json/schema/properties/result/properties/data": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/paths/~1getMyPastEventsForHomePage/post/responses/200/content/application~1json/schema/properties/result/properties/data/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/paths/~1getMyPastEventsForHomePage/post/responses/200/content/application~1json/schema/properties/result/properties/data/required/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/paths/~1getMyPastEventsForHomePage/post/responses/200/content/application~1json/schema/properties/result/properties/data/properties/pastEvents": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/paths/~1getMyPastEventsForHomePage/post/responses/200/content/application~1json/schema/properties/result/properties/data/properties/pastEvents/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/paths/~1getMyPastEventsForHomePage/post/responses/200/content/application~1json/schema/properties/result/properties/data/properties/pastEvents/items/$ref": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
     },
     "#/paths/~1getMyPastEventsForHomePage/post/responses/default": {
       "classification": "explicit-unknown",
@@ -2249,6 +2470,18 @@
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getCurrentGuest/post/requestBody/content/application~1json/schema/additionalProperties"
     },
+    "#/paths/~1getCurrentGuest/post/responses/200": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/paths/~1getCurrentGuest/post/responses/200/content/application~1json": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/paths/~1getCurrentGuest/post/responses/200/content/application~1json/schema/$ref": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
     "#/paths/~1getCurrentGuest/post/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
@@ -2276,6 +2509,18 @@
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/parameters/0/schema/type": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/parameters/0/schema/type"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/responses/403": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/responses/403/content/application~1json": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/responses/403/content/application~1json/schema/$ref": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/responses/default": {
       "classification": "explicit-unknown",
@@ -2396,6 +2641,18 @@
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/parameters/1/schema/type": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/parameters/1/schema/type"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/responses/200": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/responses/200/content/application~1json": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/responses/200/content/application~1json/schema/$ref": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/responses/default": {
       "classification": "explicit-unknown",
@@ -2521,9 +2778,33 @@
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1token/post/requestBody/content/application~1x-www-form-urlencoded/schema/additionalProperties"
     },
+    "#/paths/~1v1~1token/post/responses/200": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
+    },
+    "#/paths/~1v1~1token/post/responses/200/content/application~1json": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
+    },
+    "#/paths/~1v1~1token/post/responses/200/content/application~1json/schema/$ref": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
+    },
     "#/paths/~1v1~1token/post/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+    },
+    "#/paths/~1v1~1token/post/responses/400": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
+    },
+    "#/paths/~1v1~1token/post/responses/400/content/application~1json": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
+    },
+    "#/paths/~1v1~1token/post/responses/400/content/application~1json/schema/$ref": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
     },
     "#/paths/~1v1~1token/post/security/0/firebaseApiKey": {
       "classification": "typescript-derived-inference",
@@ -2532,6 +2813,26 @@
     "#/paths/~1v1~1token/post/servers/0/url": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1token/post/servers/0/url"
+    },
+    "#/paths/~1v1~1token/post/parameters/0/name": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#firebase-api-key-referrer-restriction"
+    },
+    "#/paths/~1v1~1token/post/parameters/0/in": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#firebase-api-key-referrer-restriction"
+    },
+    "#/paths/~1v1~1token/post/parameters/0/required": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#firebase-api-key-referrer-restriction"
+    },
+    "#/paths/~1v1~1token/post/parameters/0/schema/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#firebase-api-key-referrer-restriction"
+    },
+    "#/paths/~1v1~1token/post/parameters/0/schema/const": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#firebase-api-key-referrer-restriction"
     },
     "#/paths/~1sendAuthCodeTrusted/post/operationId": {
       "classification": "typescript-derived-inference",
@@ -2689,6 +2990,10 @@
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1sendAuthCodeTrusted/post/requestBody/content/application~1json/schema/additionalProperties"
     },
+    "#/paths/~1sendAuthCodeTrusted/post/responses/200": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#sendauthcodetrusted"
+    },
     "#/paths/~1sendAuthCodeTrusted/post/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
@@ -2825,9 +3130,33 @@
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1getLoginToken/post/requestBody/content/application~1json/schema/additionalProperties"
     },
+    "#/paths/~1getLoginToken/post/responses/200": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
+    },
+    "#/paths/~1getLoginToken/post/responses/200/content/application~1json": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
+    },
+    "#/paths/~1getLoginToken/post/responses/200/content/application~1json/schema/$ref": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
+    },
     "#/paths/~1getLoginToken/post/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+    },
+    "#/paths/~1getLoginToken/post/responses/403": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
+    },
+    "#/paths/~1getLoginToken/post/responses/403/content/application~1json": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
+    },
+    "#/paths/~1getLoginToken/post/responses/403/content/application~1json/schema/$ref": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
     },
     "#/paths/~1v1~1accounts:signInWithCustomToken/post/operationId": {
       "classification": "typescript-derived-inference",
@@ -2873,9 +3202,33 @@
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1accounts:signInWithCustomToken/post/requestBody/content/application~1json/schema/additionalProperties"
     },
+    "#/paths/~1v1~1accounts:signInWithCustomToken/post/responses/200": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
+    },
+    "#/paths/~1v1~1accounts:signInWithCustomToken/post/responses/200/content/application~1json": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
+    },
+    "#/paths/~1v1~1accounts:signInWithCustomToken/post/responses/200/content/application~1json/schema/$ref": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
+    },
     "#/paths/~1v1~1accounts:signInWithCustomToken/post/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+    },
+    "#/paths/~1v1~1accounts:signInWithCustomToken/post/responses/400": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
+    },
+    "#/paths/~1v1~1accounts:signInWithCustomToken/post/responses/400/content/application~1json": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
+    },
+    "#/paths/~1v1~1accounts:signInWithCustomToken/post/responses/400/content/application~1json/schema/$ref": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
     },
     "#/paths/~1v1~1accounts:signInWithCustomToken/post/security/0/firebaseApiKey": {
       "classification": "typescript-derived-inference",
@@ -2884,6 +3237,26 @@
     "#/paths/~1v1~1accounts:signInWithCustomToken/post/servers/0/url": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1accounts:signInWithCustomToken/post/servers/0/url"
+    },
+    "#/paths/~1v1~1accounts:signInWithCustomToken/post/parameters/0/name": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#firebase-api-key-referrer-restriction"
+    },
+    "#/paths/~1v1~1accounts:signInWithCustomToken/post/parameters/0/in": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#firebase-api-key-referrer-restriction"
+    },
+    "#/paths/~1v1~1accounts:signInWithCustomToken/post/parameters/0/required": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#firebase-api-key-referrer-restriction"
+    },
+    "#/paths/~1v1~1accounts:signInWithCustomToken/post/parameters/0/schema/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#firebase-api-key-referrer-restriction"
+    },
+    "#/paths/~1v1~1accounts:signInWithCustomToken/post/parameters/0/schema/const": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#firebase-api-key-referrer-restriction"
     },
     "#/paths/~1v1~1accounts:lookup/post/operationId": {
       "classification": "typescript-derived-inference",
@@ -2917,9 +3290,33 @@
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1accounts:lookup/post/requestBody/content/application~1json/schema/additionalProperties"
     },
+    "#/paths/~1v1~1accounts:lookup/post/responses/200": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
+    },
+    "#/paths/~1v1~1accounts:lookup/post/responses/200/content/application~1json": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
+    },
+    "#/paths/~1v1~1accounts:lookup/post/responses/200/content/application~1json/schema/$ref": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
+    },
     "#/paths/~1v1~1accounts:lookup/post/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+    },
+    "#/paths/~1v1~1accounts:lookup/post/responses/400": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
+    },
+    "#/paths/~1v1~1accounts:lookup/post/responses/400/content/application~1json": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
+    },
+    "#/paths/~1v1~1accounts:lookup/post/responses/400/content/application~1json/schema/$ref": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
     },
     "#/paths/~1v1~1accounts:lookup/post/security/0/firebaseApiKey": {
       "classification": "typescript-derived-inference",
@@ -2928,6 +3325,26 @@
     "#/paths/~1v1~1accounts:lookup/post/servers/0/url": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1accounts:lookup/post/servers/0/url"
+    },
+    "#/paths/~1v1~1accounts:lookup/post/parameters/0/name": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#firebase-api-key-referrer-restriction"
+    },
+    "#/paths/~1v1~1accounts:lookup/post/parameters/0/in": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#firebase-api-key-referrer-restriction"
+    },
+    "#/paths/~1v1~1accounts:lookup/post/parameters/0/required": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#firebase-api-key-referrer-restriction"
+    },
+    "#/paths/~1v1~1accounts:lookup/post/parameters/0/schema/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#firebase-api-key-referrer-restriction"
+    },
+    "#/paths/~1v1~1accounts:lookup/post/parameters/0/schema/const": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#firebase-api-key-referrer-restriction"
     },
     "#/paths/~1uploadPhoto/post/operationId": {
       "classification": "typescript-derived-inference",
@@ -2997,6 +3414,34 @@
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1uploadPhoto/post/servers/0/url"
     },
+    "#/paths/~1posters.json/get/operationId": {
+      "classification": "typescript-derived-inference",
+      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1posters.json/get/operationId"
+    },
+    "#/paths/~1posters.json/get/responses/200": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
+    },
+    "#/paths/~1posters.json/get/responses/200/content/application~1json": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
+    },
+    "#/paths/~1posters.json/get/responses/200/content/application~1json/schema/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
+    },
+    "#/paths/~1posters.json/get/responses/200/content/application~1json/schema/items/$ref": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
+    },
+    "#/paths/~1posters.json/get/responses/default": {
+      "classification": "explicit-unknown",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+    },
+    "#/paths/~1posters.json/get/servers/0/url": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
+    },
     "#/components/securitySchemes/firebaseBearer/type": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/components/securitySchemes/firebaseBearer/type"
@@ -3016,6 +3461,10 @@
     "#/components/securitySchemes/firebaseApiKey/name": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/components/securitySchemes/firebaseApiKey/name"
+    },
+    "#/components/securitySchemes/firebaseApiKey/x-publicValue": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-firebase-public-api-key-redacted.md#firebase-public-api-key"
     },
     "#/components/schemas/EventDraft/type": {
       "classification": "typescript-derived-inference",
@@ -3449,6 +3898,82 @@
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/RefreshTokenResponse/type"
     },
+    "#/components/schemas/RefreshTokenResponse/required/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
+    },
+    "#/components/schemas/RefreshTokenResponse/required/1": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
+    },
+    "#/components/schemas/RefreshTokenResponse/required/2": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
+    },
+    "#/components/schemas/RefreshTokenResponse/required/3": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
+    },
+    "#/components/schemas/RefreshTokenResponse/required/4": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
+    },
+    "#/components/schemas/RefreshTokenResponse/properties/access_token": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
+    },
+    "#/components/schemas/RefreshTokenResponse/properties/access_token/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
+    },
+    "#/components/schemas/RefreshTokenResponse/properties/expires_in": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
+    },
+    "#/components/schemas/RefreshTokenResponse/properties/expires_in/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
+    },
+    "#/components/schemas/RefreshTokenResponse/properties/id_token": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
+    },
+    "#/components/schemas/RefreshTokenResponse/properties/id_token/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
+    },
+    "#/components/schemas/RefreshTokenResponse/properties/project_id": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
+    },
+    "#/components/schemas/RefreshTokenResponse/properties/project_id/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
+    },
+    "#/components/schemas/RefreshTokenResponse/properties/refresh_token": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
+    },
+    "#/components/schemas/RefreshTokenResponse/properties/refresh_token/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
+    },
+    "#/components/schemas/RefreshTokenResponse/properties/token_type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
+    },
+    "#/components/schemas/RefreshTokenResponse/properties/token_type/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
+    },
+    "#/components/schemas/RefreshTokenResponse/properties/user_id": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
+    },
+    "#/components/schemas/RefreshTokenResponse/properties/user_id/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
+    },
     "#/components/schemas/RefreshTokenResponse/additionalProperties": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/RefreshTokenResponse/additionalProperties"
@@ -3457,6 +3982,50 @@
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirebaseSignInResponse/type"
     },
+    "#/components/schemas/FirebaseSignInResponse/required/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
+    },
+    "#/components/schemas/FirebaseSignInResponse/required/1": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
+    },
+    "#/components/schemas/FirebaseSignInResponse/required/2": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
+    },
+    "#/components/schemas/FirebaseSignInResponse/properties/idToken": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
+    },
+    "#/components/schemas/FirebaseSignInResponse/properties/idToken/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
+    },
+    "#/components/schemas/FirebaseSignInResponse/properties/refreshToken": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
+    },
+    "#/components/schemas/FirebaseSignInResponse/properties/refreshToken/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
+    },
+    "#/components/schemas/FirebaseSignInResponse/properties/expiresIn": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
+    },
+    "#/components/schemas/FirebaseSignInResponse/properties/expiresIn/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
+    },
+    "#/components/schemas/FirebaseSignInResponse/properties/kind": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
+    },
+    "#/components/schemas/FirebaseSignInResponse/properties/kind/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
+    },
     "#/components/schemas/FirebaseSignInResponse/additionalProperties": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirebaseSignInResponse/additionalProperties"
@@ -3464,6 +4033,30 @@
     "#/components/schemas/FirebaseLookupResponse/type": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirebaseLookupResponse/type"
+    },
+    "#/components/schemas/FirebaseLookupResponse/required/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
+    },
+    "#/components/schemas/FirebaseLookupResponse/properties/kind": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
+    },
+    "#/components/schemas/FirebaseLookupResponse/properties/kind/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
+    },
+    "#/components/schemas/FirebaseLookupResponse/properties/users": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
+    },
+    "#/components/schemas/FirebaseLookupResponse/properties/users/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
+    },
+    "#/components/schemas/FirebaseLookupResponse/properties/users/items/$ref": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
     },
     "#/components/schemas/FirebaseLookupResponse/additionalProperties": {
       "classification": "typescript-derived-inference",
@@ -3553,67 +4146,7 @@
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/UploadPhotoResponse/additionalProperties"
     },
-    "#/paths/~1posters.json/get/operationId": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1posters.json/get/operationId"
-    },
-    "#/paths/~1posters.json/get/responses/200": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
-    },
-    "#/paths/~1posters.json/get/responses/200/content/application~1json": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
-    },
-    "#/paths/~1posters.json/get/responses/200/content/application~1json/schema/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
-    },
-    "#/paths/~1posters.json/get/responses/200/content/application~1json/schema/items/$ref": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
-    },
-    "#/paths/~1posters.json/get/responses/default": {
-      "classification": "explicit-unknown",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
-    },
-    "#/paths/~1posters.json/get/servers/0/url": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
-    },
     "#/components/schemas/Poster/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
-    },
-    "#/components/schemas/Poster/required/0": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
-    },
-    "#/components/schemas/Poster/required/1": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
-    },
-    "#/components/schemas/Poster/required/2": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
-    },
-    "#/components/schemas/Poster/required/3": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
-    },
-    "#/components/schemas/Poster/required/4": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
-    },
-    "#/components/schemas/Poster/required/5": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
-    },
-    "#/components/schemas/Poster/required/6": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
-    },
-    "#/components/schemas/Poster/required/7": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
     },
@@ -3713,71 +4246,95 @@
       "classification": "typescript-derived-inference",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#poster-interface"
     },
-    "#/components/schemas/FirebaseLookupResponse/properties/kind": {
+    "#/components/schemas/Poster/required/0": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
     },
-    "#/components/schemas/FirebaseLookupResponse/properties/kind/type": {
+    "#/components/schemas/Poster/required/1": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
     },
-    "#/components/schemas/FirebaseLookupResponse/properties/users": {
+    "#/components/schemas/Poster/required/2": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
     },
-    "#/components/schemas/FirebaseLookupResponse/properties/users/items/$ref": {
+    "#/components/schemas/Poster/required/3": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
     },
-    "#/components/schemas/FirebaseLookupResponse/properties/users/type": {
+    "#/components/schemas/Poster/required/4": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
     },
-    "#/components/schemas/FirebaseLookupResponse/required/0": {
+    "#/components/schemas/Poster/required/5": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
     },
-    "#/components/schemas/FirebaseLookupUser/additionalProperties": {
+    "#/components/schemas/Poster/required/6": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
+    },
+    "#/components/schemas/Poster/required/7": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
+    },
+    "#/components/schemas/LoginTokenResponse/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
+    },
+    "#/components/schemas/LoginTokenResponse/required/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
+    },
+    "#/components/schemas/LoginTokenResponse/properties/result": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
+    },
+    "#/components/schemas/LoginTokenResponse/properties/result/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
+    },
+    "#/components/schemas/LoginTokenResponse/properties/result/required/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
+    },
+    "#/components/schemas/LoginTokenResponse/properties/result/properties/data": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
+    },
+    "#/components/schemas/LoginTokenResponse/properties/result/properties/data/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
+    },
+    "#/components/schemas/LoginTokenResponse/properties/result/properties/data/required/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
+    },
+    "#/components/schemas/LoginTokenResponse/properties/result/properties/data/properties/token": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
+    },
+    "#/components/schemas/LoginTokenResponse/properties/result/properties/data/properties/token/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
+    },
+    "#/components/schemas/LoginTokenResponse/properties/result/properties/data/additionalProperties": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
+      "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
     },
-    "#/components/schemas/FirebaseLookupUser/properties/createdAt": {
+    "#/components/schemas/LoginTokenResponse/properties/result/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
+    },
+    "#/components/schemas/LoginTokenResponse/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
+    },
+    "#/components/schemas/FirebaseLookupUser/type": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
     },
-    "#/components/schemas/FirebaseLookupUser/properties/createdAt/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
-    },
-    "#/components/schemas/FirebaseLookupUser/properties/customAuth": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
-    },
-    "#/components/schemas/FirebaseLookupUser/properties/customAuth/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
-    },
-    "#/components/schemas/FirebaseLookupUser/properties/displayName": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
-    },
-    "#/components/schemas/FirebaseLookupUser/properties/displayName/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
-    },
-    "#/components/schemas/FirebaseLookupUser/properties/lastLoginAt": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
-    },
-    "#/components/schemas/FirebaseLookupUser/properties/lastLoginAt/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
-    },
-    "#/components/schemas/FirebaseLookupUser/properties/lastRefreshAt": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
-    },
-    "#/components/schemas/FirebaseLookupUser/properties/lastRefreshAt/type": {
+    "#/components/schemas/FirebaseLookupUser/required/0": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
     },
@@ -3786,6 +4343,14 @@
       "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
     },
     "#/components/schemas/FirebaseLookupUser/properties/localId/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
+    },
+    "#/components/schemas/FirebaseLookupUser/properties/displayName": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
+    },
+    "#/components/schemas/FirebaseLookupUser/properties/displayName/type": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
     },
@@ -3805,15 +4370,35 @@
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
     },
-    "#/components/schemas/FirebaseLookupUser/properties/providerUserInfo": {
+    "#/components/schemas/FirebaseLookupUser/properties/customAuth": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
     },
-    "#/components/schemas/FirebaseLookupUser/properties/providerUserInfo/items/$ref": {
+    "#/components/schemas/FirebaseLookupUser/properties/customAuth/type": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
     },
-    "#/components/schemas/FirebaseLookupUser/properties/providerUserInfo/type": {
+    "#/components/schemas/FirebaseLookupUser/properties/createdAt": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
+    },
+    "#/components/schemas/FirebaseLookupUser/properties/createdAt/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
+    },
+    "#/components/schemas/FirebaseLookupUser/properties/lastLoginAt": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
+    },
+    "#/components/schemas/FirebaseLookupUser/properties/lastLoginAt/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
+    },
+    "#/components/schemas/FirebaseLookupUser/properties/lastRefreshAt": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
+    },
+    "#/components/schemas/FirebaseLookupUser/properties/lastRefreshAt/type": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
     },
@@ -3825,23 +4410,23 @@
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
     },
-    "#/components/schemas/FirebaseLookupUser/required/0": {
+    "#/components/schemas/FirebaseLookupUser/properties/providerUserInfo": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
     },
-    "#/components/schemas/FirebaseLookupUser/type": {
+    "#/components/schemas/FirebaseLookupUser/properties/providerUserInfo/type": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
     },
-    "#/components/schemas/FirebaseProviderUserInfo/additionalProperties": {
+    "#/components/schemas/FirebaseLookupUser/properties/providerUserInfo/items/$ref": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
+    },
+    "#/components/schemas/FirebaseLookupUser/additionalProperties": {
       "classification": "typescript-derived-inference",
       "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
     },
-    "#/components/schemas/FirebaseProviderUserInfo/properties/phoneNumber": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
-    },
-    "#/components/schemas/FirebaseProviderUserInfo/properties/phoneNumber/type": {
+    "#/components/schemas/FirebaseProviderUserInfo/type": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
     },
@@ -3853,6 +4438,14 @@
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
     },
+    "#/components/schemas/FirebaseProviderUserInfo/properties/phoneNumber": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
+    },
+    "#/components/schemas/FirebaseProviderUserInfo/properties/phoneNumber/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
+    },
     "#/components/schemas/FirebaseProviderUserInfo/properties/rawId": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
@@ -3861,263 +4454,31 @@
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
     },
-    "#/components/schemas/FirebaseProviderUserInfo/type": {
-      "classification": "dated-live-observation",
+    "#/components/schemas/FirebaseProviderUserInfo/additionalProperties": {
+      "classification": "typescript-derived-inference",
       "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
     },
-    "#/components/schemas/FirebaseSignInResponse/properties/expiresIn": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
-    },
-    "#/components/schemas/FirebaseSignInResponse/properties/expiresIn/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
-    },
-    "#/components/schemas/FirebaseSignInResponse/properties/idToken": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
-    },
-    "#/components/schemas/FirebaseSignInResponse/properties/idToken/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
-    },
-    "#/components/schemas/FirebaseSignInResponse/properties/kind": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
-    },
-    "#/components/schemas/FirebaseSignInResponse/properties/kind/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
-    },
-    "#/components/schemas/FirebaseSignInResponse/properties/refreshToken": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
-    },
-    "#/components/schemas/FirebaseSignInResponse/properties/refreshToken/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
-    },
-    "#/components/schemas/FirebaseSignInResponse/required/0": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
-    },
-    "#/components/schemas/FirebaseSignInResponse/required/1": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
-    },
-    "#/components/schemas/FirebaseSignInResponse/required/2": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
-    },
-    "#/components/schemas/LoginTokenResponse/additionalProperties": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
-    },
-    "#/components/schemas/LoginTokenResponse/properties/result": {
+    "#/components/schemas/CallableAuthError/type": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
     },
-    "#/components/schemas/LoginTokenResponse/properties/result/additionalProperties": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
-    },
-    "#/components/schemas/LoginTokenResponse/properties/result/properties/data": {
+    "#/components/schemas/CallableAuthError/required/0": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
-    },
-    "#/components/schemas/LoginTokenResponse/properties/result/properties/data/additionalProperties": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
-    },
-    "#/components/schemas/LoginTokenResponse/properties/result/properties/data/properties/token": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
-    },
-    "#/components/schemas/LoginTokenResponse/properties/result/properties/data/properties/token/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
-    },
-    "#/components/schemas/LoginTokenResponse/properties/result/properties/data/required/0": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
-    },
-    "#/components/schemas/LoginTokenResponse/properties/result/properties/data/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
-    },
-    "#/components/schemas/LoginTokenResponse/properties/result/required/0": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
-    },
-    "#/components/schemas/LoginTokenResponse/properties/result/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
-    },
-    "#/components/schemas/LoginTokenResponse/required/0": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
-    },
-    "#/components/schemas/LoginTokenResponse/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
-    },
-    "#/components/schemas/RefreshTokenResponse/properties/access_token": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
-    },
-    "#/components/schemas/RefreshTokenResponse/properties/access_token/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
-    },
-    "#/components/schemas/RefreshTokenResponse/properties/expires_in": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
-    },
-    "#/components/schemas/RefreshTokenResponse/properties/expires_in/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
-    },
-    "#/components/schemas/RefreshTokenResponse/properties/id_token": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
-    },
-    "#/components/schemas/RefreshTokenResponse/properties/id_token/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
-    },
-    "#/components/schemas/RefreshTokenResponse/properties/project_id": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
-    },
-    "#/components/schemas/RefreshTokenResponse/properties/project_id/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
-    },
-    "#/components/schemas/RefreshTokenResponse/properties/refresh_token": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
-    },
-    "#/components/schemas/RefreshTokenResponse/properties/refresh_token/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
-    },
-    "#/components/schemas/RefreshTokenResponse/properties/token_type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
-    },
-    "#/components/schemas/RefreshTokenResponse/properties/token_type/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
-    },
-    "#/components/schemas/RefreshTokenResponse/properties/user_id": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
-    },
-    "#/components/schemas/RefreshTokenResponse/properties/user_id/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
-    },
-    "#/components/schemas/RefreshTokenResponse/required/0": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
-    },
-    "#/components/schemas/RefreshTokenResponse/required/1": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
-    },
-    "#/components/schemas/RefreshTokenResponse/required/2": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
-    },
-    "#/components/schemas/RefreshTokenResponse/required/3": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
-    },
-    "#/components/schemas/RefreshTokenResponse/required/4": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
-    },
-    "#/paths/~1getLoginToken/post/responses/200": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
-    },
-    "#/paths/~1getLoginToken/post/responses/200/content/application~1json": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
-    },
-    "#/paths/~1getLoginToken/post/responses/200/content/application~1json/schema/$ref": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
-    },
-    "#/paths/~1sendAuthCodeTrusted/post/responses/200": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#sendauthcodetrusted"
-    },
-    "#/paths/~1v1~1accounts:lookup/post/responses/200": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
-    },
-    "#/paths/~1v1~1accounts:lookup/post/responses/200/content/application~1json": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
-    },
-    "#/paths/~1v1~1accounts:lookup/post/responses/200/content/application~1json/schema/$ref": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
-    },
-    "#/paths/~1v1~1accounts:signInWithCustomToken/post/responses/200": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
-    },
-    "#/paths/~1v1~1accounts:signInWithCustomToken/post/responses/200/content/application~1json": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
-    },
-    "#/paths/~1v1~1accounts:signInWithCustomToken/post/responses/200/content/application~1json/schema/$ref": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
-    },
-    "#/paths/~1v1~1token/post/responses/200": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
-    },
-    "#/paths/~1v1~1token/post/responses/200/content/application~1json": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
-    },
-    "#/paths/~1v1~1token/post/responses/200/content/application~1json/schema/$ref": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
-    },
-    "#/components/schemas/CallableAuthError/additionalProperties": {
-      "classification": "typescript-derived-inference",
       "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
     },
     "#/components/schemas/CallableAuthError/properties/error": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
     },
-    "#/components/schemas/CallableAuthError/properties/error/additionalProperties": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
-    },
-    "#/components/schemas/CallableAuthError/properties/error/properties/details": {
+    "#/components/schemas/CallableAuthError/properties/error/type": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
     },
-    "#/components/schemas/CallableAuthError/properties/error/properties/details/additionalProperties": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
-    },
-    "#/components/schemas/CallableAuthError/properties/error/properties/details/properties/authErrorCode": {
+    "#/components/schemas/CallableAuthError/properties/error/required/0": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
     },
-    "#/components/schemas/CallableAuthError/properties/error/properties/details/properties/authErrorCode/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
-    },
-    "#/components/schemas/CallableAuthError/properties/error/properties/details/type": {
+    "#/components/schemas/CallableAuthError/properties/error/required/1": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
     },
@@ -4137,92 +4498,56 @@
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
     },
-    "#/components/schemas/CallableAuthError/properties/error/required/0": {
+    "#/components/schemas/CallableAuthError/properties/error/properties/details": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
     },
-    "#/components/schemas/CallableAuthError/properties/error/required/1": {
+    "#/components/schemas/CallableAuthError/properties/error/properties/details/type": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
     },
-    "#/components/schemas/CallableAuthError/properties/error/type": {
+    "#/components/schemas/CallableAuthError/properties/error/properties/details/properties/authErrorCode": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
     },
-    "#/components/schemas/CallableAuthError/required/0": {
+    "#/components/schemas/CallableAuthError/properties/error/properties/details/properties/authErrorCode/type": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
     },
-    "#/components/schemas/CallableAuthError/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
-    },
-    "#/components/schemas/FirebaseTokenError/additionalProperties": {
+    "#/components/schemas/CallableAuthError/properties/error/properties/details/additionalProperties": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
+      "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
     },
-    "#/components/schemas/FirebaseTokenError/properties/error": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
-    },
-    "#/components/schemas/FirebaseTokenError/properties/error/additionalProperties": {
+    "#/components/schemas/CallableAuthError/properties/error/additionalProperties": {
       "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
+      "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
     },
-    "#/components/schemas/FirebaseTokenError/properties/error/properties/code": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
-    },
-    "#/components/schemas/FirebaseTokenError/properties/error/properties/code/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
-    },
-    "#/components/schemas/FirebaseTokenError/properties/error/properties/message": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
-    },
-    "#/components/schemas/FirebaseTokenError/properties/error/properties/message/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
-    },
-    "#/components/schemas/FirebaseTokenError/properties/error/properties/status": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
-    },
-    "#/components/schemas/FirebaseTokenError/properties/error/properties/status/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
-    },
-    "#/components/schemas/FirebaseTokenError/properties/error/required/0": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
-    },
-    "#/components/schemas/FirebaseTokenError/properties/error/required/1": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
-    },
-    "#/components/schemas/FirebaseTokenError/properties/error/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
-    },
-    "#/components/schemas/FirebaseTokenError/required/0": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
-    },
-    "#/components/schemas/FirebaseTokenError/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
-    },
-    "#/components/schemas/FirebaseValidationError/additionalProperties": {
+    "#/components/schemas/CallableAuthError/additionalProperties": {
       "classification": "typescript-derived-inference",
+      "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
+    },
+    "#/components/schemas/FirebaseValidationError/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
+    },
+    "#/components/schemas/FirebaseValidationError/required/0": {
+      "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
     },
     "#/components/schemas/FirebaseValidationError/properties/error": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
     },
-    "#/components/schemas/FirebaseValidationError/properties/error/additionalProperties": {
-      "classification": "typescript-derived-inference",
+    "#/components/schemas/FirebaseValidationError/properties/error/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
+    },
+    "#/components/schemas/FirebaseValidationError/properties/error/required/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
+    },
+    "#/components/schemas/FirebaseValidationError/properties/error/required/1": {
+      "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
     },
     "#/components/schemas/FirebaseValidationError/properties/error/properties/code": {
@@ -4233,12 +4558,24 @@
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
     },
+    "#/components/schemas/FirebaseValidationError/properties/error/properties/message": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
+    },
+    "#/components/schemas/FirebaseValidationError/properties/error/properties/message/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
+    },
     "#/components/schemas/FirebaseValidationError/properties/error/properties/errors": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
     },
-    "#/components/schemas/FirebaseValidationError/properties/error/properties/errors/items/additionalProperties": {
-      "classification": "typescript-derived-inference",
+    "#/components/schemas/FirebaseValidationError/properties/error/properties/errors/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
+    },
+    "#/components/schemas/FirebaseValidationError/properties/error/properties/errors/items/type": {
+      "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
     },
     "#/components/schemas/FirebaseValidationError/properties/error/properties/errors/items/properties/domain": {
@@ -4265,153 +4602,793 @@
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
     },
-    "#/components/schemas/FirebaseValidationError/properties/error/properties/errors/items/type": {
-      "classification": "dated-live-observation",
+    "#/components/schemas/FirebaseValidationError/properties/error/properties/errors/items/additionalProperties": {
+      "classification": "typescript-derived-inference",
       "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
     },
-    "#/components/schemas/FirebaseValidationError/properties/error/properties/errors/type": {
-      "classification": "dated-live-observation",
+    "#/components/schemas/FirebaseValidationError/properties/error/additionalProperties": {
+      "classification": "typescript-derived-inference",
       "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
     },
-    "#/components/schemas/FirebaseValidationError/properties/error/properties/message": {
-      "classification": "dated-live-observation",
+    "#/components/schemas/FirebaseValidationError/additionalProperties": {
+      "classification": "typescript-derived-inference",
       "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
     },
-    "#/components/schemas/FirebaseValidationError/properties/error/properties/message/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
-    },
-    "#/components/schemas/FirebaseValidationError/properties/error/required/0": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
-    },
-    "#/components/schemas/FirebaseValidationError/properties/error/required/1": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
-    },
-    "#/components/schemas/FirebaseValidationError/properties/error/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
-    },
-    "#/components/schemas/FirebaseValidationError/required/0": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
-    },
-    "#/components/schemas/FirebaseValidationError/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
-    },
-    "#/paths/~1getLoginToken/post/responses/403": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
-    },
-    "#/paths/~1getLoginToken/post/responses/403/content/application~1json": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
-    },
-    "#/paths/~1getLoginToken/post/responses/403/content/application~1json/schema/$ref": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
-    },
-    "#/paths/~1v1~1accounts:lookup/post/responses/400": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
-    },
-    "#/paths/~1v1~1accounts:lookup/post/responses/400/content/application~1json": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
-    },
-    "#/paths/~1v1~1accounts:lookup/post/responses/400/content/application~1json/schema/$ref": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
-    },
-    "#/paths/~1v1~1accounts:signInWithCustomToken/post/responses/400": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
-    },
-    "#/paths/~1v1~1accounts:signInWithCustomToken/post/responses/400/content/application~1json": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
-    },
-    "#/paths/~1v1~1accounts:signInWithCustomToken/post/responses/400/content/application~1json/schema/$ref": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
-    },
-    "#/paths/~1v1~1token/post/responses/400": {
+    "#/components/schemas/FirebaseTokenError/type": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
     },
-    "#/paths/~1v1~1token/post/responses/400/content/application~1json": {
+    "#/components/schemas/FirebaseTokenError/required/0": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
     },
-    "#/paths/~1v1~1token/post/responses/400/content/application~1json/schema/$ref": {
+    "#/components/schemas/FirebaseTokenError/properties/error": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
     },
-    "#/components/securitySchemes/firebaseApiKey/x-publicValue": {
+    "#/components/schemas/FirebaseTokenError/properties/error/type": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-firebase-public-api-key-redacted.md#firebase-public-api-key"
+      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
     },
-    "#/paths/~1v1~1accounts:lookup/post/parameters/0/in": {
+    "#/components/schemas/FirebaseTokenError/properties/error/required/0": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#firebase-api-key-referrer-restriction"
+      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
     },
-    "#/paths/~1v1~1accounts:lookup/post/parameters/0/name": {
+    "#/components/schemas/FirebaseTokenError/properties/error/required/1": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#firebase-api-key-referrer-restriction"
+      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
     },
-    "#/paths/~1v1~1accounts:lookup/post/parameters/0/required": {
+    "#/components/schemas/FirebaseTokenError/properties/error/properties/code": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#firebase-api-key-referrer-restriction"
+      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
     },
-    "#/paths/~1v1~1accounts:lookup/post/parameters/0/schema/const": {
+    "#/components/schemas/FirebaseTokenError/properties/error/properties/code/type": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#firebase-api-key-referrer-restriction"
+      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
     },
-    "#/paths/~1v1~1accounts:lookup/post/parameters/0/schema/type": {
+    "#/components/schemas/FirebaseTokenError/properties/error/properties/message": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#firebase-api-key-referrer-restriction"
+      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
     },
-    "#/paths/~1v1~1accounts:signInWithCustomToken/post/parameters/0/in": {
+    "#/components/schemas/FirebaseTokenError/properties/error/properties/message/type": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#firebase-api-key-referrer-restriction"
+      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
     },
-    "#/paths/~1v1~1accounts:signInWithCustomToken/post/parameters/0/name": {
+    "#/components/schemas/FirebaseTokenError/properties/error/properties/status": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#firebase-api-key-referrer-restriction"
+      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
     },
-    "#/paths/~1v1~1accounts:signInWithCustomToken/post/parameters/0/required": {
+    "#/components/schemas/FirebaseTokenError/properties/error/properties/status/type": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#firebase-api-key-referrer-restriction"
+      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
     },
-    "#/paths/~1v1~1accounts:signInWithCustomToken/post/parameters/0/schema/const": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#firebase-api-key-referrer-restriction"
+    "#/components/schemas/FirebaseTokenError/properties/error/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
     },
-    "#/paths/~1v1~1accounts:signInWithCustomToken/post/parameters/0/schema/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#firebase-api-key-referrer-restriction"
+    "#/components/schemas/FirebaseTokenError/additionalProperties": {
+      "classification": "typescript-derived-inference",
+      "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
     },
-    "#/paths/~1v1~1token/post/parameters/0/in": {
+    "#/components/schemas/HomePageEvent/type": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#firebase-api-key-referrer-restriction"
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
     },
-    "#/paths/~1v1~1token/post/parameters/0/name": {
+    "#/components/schemas/HomePageEvent/required/0": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#firebase-api-key-referrer-restriction"
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
     },
-    "#/paths/~1v1~1token/post/parameters/0/required": {
+    "#/components/schemas/HomePageEvent/properties/id": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#firebase-api-key-referrer-restriction"
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
     },
-    "#/paths/~1v1~1token/post/parameters/0/schema/const": {
+    "#/components/schemas/HomePageEvent/properties/id/type": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#firebase-api-key-referrer-restriction"
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
     },
-    "#/paths/~1v1~1token/post/parameters/0/schema/type": {
+    "#/components/schemas/HomePageEvent/properties/title": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-auth-observation.md#firebase-api-key-referrer-restriction"
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/components/schemas/HomePageEvent/properties/startDate": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/components/schemas/HomePageEvent/properties/startDate/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/components/schemas/HomePageEvent/properties/endDate": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/components/schemas/HomePageEvent/properties/endDate/type/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/components/schemas/HomePageEvent/properties/endDate/type/1": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/components/schemas/HomePageEvent/properties/timezone": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/components/schemas/HomePageEvent/properties/timezone/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/components/schemas/HomePageEvent/properties/status": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/components/schemas/HomePageEvent/properties/status/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/components/schemas/HomePageEvent/properties/location": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/components/schemas/HomePageEvent/properties/location/type/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/components/schemas/HomePageEvent/properties/location/type/1": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/components/schemas/HomePageEvent/properties/displaySettings": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/components/schemas/HomePageEvent/properties/displaySettings/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/components/schemas/HomePageEvent/properties/image": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/components/schemas/HomePageEvent/properties/image/type/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/components/schemas/HomePageEvent/properties/image/type/1": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/components/schemas/HomePageEvent/properties/guest": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/components/schemas/HomePageEvent/properties/guest/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/components/schemas/HomePageEvent/properties/guest/properties/status": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/components/schemas/HomePageEvent/properties/guest/properties/status/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    },
+    "#/components/schemas/EventInfo/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/EventInfo/required/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/EventInfo/required/1": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/EventInfo/required/2": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/EventInfo/required/3": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/EventInfo/required/4": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/EventInfo/required/5": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/EventInfo/required/6": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/EventInfo/required/7": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/EventInfo/required/8": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/EventInfo/required/9": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/EventInfo/properties/id": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/EventInfo/properties/id/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/EventInfo/properties/title": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/EventInfo/properties/startDate": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/EventInfo/properties/startDate/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/EventInfo/properties/endDate": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/EventInfo/properties/endDate/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/EventInfo/properties/timezone": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/EventInfo/properties/timezone/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/EventInfo/properties/status": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/EventInfo/properties/status/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/EventInfo/properties/description": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/EventInfo/properties/displaySettings": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/EventInfo/properties/displaySettings/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/EventInfo/properties/image": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/EventInfo/properties/image/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/EventInfo/properties/visibility": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/EventInfo/properties/visibility/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/GetEventInfoResponse/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/GetEventInfoResponse/required/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/GetEventInfoResponse/properties/result": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/GetEventInfoResponse/properties/result/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/GetEventInfoResponse/properties/result/required/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/GetEventInfoResponse/properties/result/properties/data": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/GetEventInfoResponse/properties/result/properties/data/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/GetEventInfoResponse/properties/result/properties/data/required/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/GetEventInfoResponse/properties/result/properties/data/properties/event": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/GetEventInfoResponse/properties/result/properties/data/properties/event/$ref": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/CallableNotFoundError/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/CallableNotFoundError/required/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/CallableNotFoundError/properties/error": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/CallableNotFoundError/properties/error/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/CallableNotFoundError/properties/error/required/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/CallableNotFoundError/properties/error/required/1": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/CallableNotFoundError/properties/error/properties/message": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/CallableNotFoundError/properties/error/properties/message/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/CallableNotFoundError/properties/error/properties/status": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/CallableNotFoundError/properties/error/properties/status/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/CallableNotFoundError/properties/error/properties/status/const": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
+    },
+    "#/components/schemas/CurrentGuest/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/CurrentGuest/required/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/CurrentGuest/required/1": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/CurrentGuest/required/2": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/CurrentGuest/required/3": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/CurrentGuest/required/4": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/CurrentGuest/required/5": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/CurrentGuest/properties/id": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/CurrentGuest/properties/id/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/CurrentGuest/properties/count": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/CurrentGuest/properties/count/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/CurrentGuest/properties/name": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/CurrentGuest/properties/name/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/CurrentGuest/properties/plusOnes": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/CurrentGuest/properties/plusOnes/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/CurrentGuest/properties/status": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/CurrentGuest/properties/status/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/CurrentGuest/properties/userId": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/CurrentGuest/properties/userId/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/GetCurrentGuestResponse/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/GetCurrentGuestResponse/required/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/GetCurrentGuestResponse/properties/result": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/GetCurrentGuestResponse/properties/result/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/GetCurrentGuestResponse/properties/result/required/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/GetCurrentGuestResponse/properties/result/properties/data": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/GetCurrentGuestResponse/properties/result/properties/data/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/GetCurrentGuestResponse/properties/result/properties/data/properties/currentGuest": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/GetCurrentGuestResponse/properties/result/properties/data/properties/currentGuest/anyOf/0/$ref": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/FirestoreObservedStringValue/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/FirestoreObservedStringValue/additionalProperties/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/FirestoreGuestDocument/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/FirestoreGuestDocument/required/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/FirestoreGuestDocument/required/1": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/FirestoreGuestDocument/required/2": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/FirestoreGuestDocument/required/3": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/FirestoreGuestDocument/properties/name": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/FirestoreGuestDocument/properties/name/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/FirestoreGuestDocument/properties/fields": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/FirestoreGuestDocument/properties/fields/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/FirestoreGuestDocument/properties/fields/required/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/FirestoreGuestDocument/properties/fields/required/1": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/FirestoreGuestDocument/properties/fields/required/2": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/FirestoreGuestDocument/properties/fields/required/3": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/FirestoreGuestDocument/properties/fields/properties/count": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/FirestoreGuestDocument/properties/fields/properties/count/$ref": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/FirestoreGuestDocument/properties/fields/properties/createdAt": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/FirestoreGuestDocument/properties/fields/properties/createdAt/$ref": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/FirestoreGuestDocument/properties/fields/properties/name": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/FirestoreGuestDocument/properties/fields/properties/name/$ref": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/FirestoreGuestDocument/properties/fields/properties/status": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/FirestoreGuestDocument/properties/fields/properties/status/$ref": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/FirestoreGuestDocument/properties/createTime": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/FirestoreGuestDocument/properties/createTime/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/FirestoreGuestDocument/properties/updateTime": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/FirestoreGuestDocument/properties/updateTime/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/FirestorePermissionDeniedError/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/FirestorePermissionDeniedError/required/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/FirestorePermissionDeniedError/properties/error": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/FirestorePermissionDeniedError/properties/error/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/FirestorePermissionDeniedError/properties/error/required/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/FirestorePermissionDeniedError/properties/error/required/1": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/FirestorePermissionDeniedError/properties/error/required/2": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/FirestorePermissionDeniedError/properties/error/properties/code": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/FirestorePermissionDeniedError/properties/error/properties/code/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/FirestorePermissionDeniedError/properties/error/properties/message": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/FirestorePermissionDeniedError/properties/error/properties/message/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/FirestorePermissionDeniedError/properties/error/properties/status": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/FirestorePermissionDeniedError/properties/error/properties/status/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/FirestorePermissionDeniedError/properties/error/properties/status/const": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/Contact/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#contact-observations"
+    },
+    "#/components/schemas/Contact/required/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#contact-observations"
+    },
+    "#/components/schemas/Contact/required/1": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#contact-observations"
+    },
+    "#/components/schemas/Contact/required/2": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#contact-observations"
+    },
+    "#/components/schemas/Contact/properties/id": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#contact-observations"
+    },
+    "#/components/schemas/Contact/properties/id/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#contact-observations"
+    },
+    "#/components/schemas/Contact/properties/name": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#contact-observations"
+    },
+    "#/components/schemas/Contact/properties/name/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#contact-observations"
+    },
+    "#/components/schemas/Contact/properties/sharedEventCount": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#contact-observations"
+    },
+    "#/components/schemas/Contact/properties/sharedEventCount/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#contact-observations"
+    },
+    "#/components/schemas/Contact/properties/sharedEventCount/minimum": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#contact-observations"
+    },
+    "#/components/schemas/GetContactsResponse/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#contact-observations"
+    },
+    "#/components/schemas/GetContactsResponse/required/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#contact-observations"
+    },
+    "#/components/schemas/GetContactsResponse/properties/result": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#contact-observations"
+    },
+    "#/components/schemas/GetContactsResponse/properties/result/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#contact-observations"
+    },
+    "#/components/schemas/GetContactsResponse/properties/result/required/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#contact-observations"
+    },
+    "#/components/schemas/GetContactsResponse/properties/result/required/1": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#contact-observations"
+    },
+    "#/components/schemas/GetContactsResponse/properties/result/properties/data": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#contact-observations"
+    },
+    "#/components/schemas/GetContactsResponse/properties/result/properties/data/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#contact-observations"
+    },
+    "#/components/schemas/GetContactsResponse/properties/result/properties/data/items/$ref": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#contact-observations"
+    },
+    "#/components/schemas/GetContactsResponse/properties/result/properties/paging": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#contact-observations"
+    },
+    "#/components/schemas/GetContactsResponse/properties/result/properties/paging/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#contact-observations"
+    },
+    "#/components/schemas/GetContactsResponse/properties/result/properties/paging/properties/nextCursor": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#contact-observations"
+    },
+    "#/components/schemas/GetContactsResponse/properties/result/properties/paging/properties/nextCursor/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#contact-observations"
+    },
+    "#/components/schemas/CallableUnauthenticatedError/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#contact-observations"
+    },
+    "#/components/schemas/CallableUnauthenticatedError/required/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#contact-observations"
+    },
+    "#/components/schemas/CallableUnauthenticatedError/properties/error": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#contact-observations"
+    },
+    "#/components/schemas/CallableUnauthenticatedError/properties/error/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#contact-observations"
+    },
+    "#/components/schemas/CallableUnauthenticatedError/properties/error/required/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#contact-observations"
+    },
+    "#/components/schemas/CallableUnauthenticatedError/properties/error/required/1": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#contact-observations"
+    },
+    "#/components/schemas/CallableUnauthenticatedError/properties/error/properties/message": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#contact-observations"
+    },
+    "#/components/schemas/CallableUnauthenticatedError/properties/error/properties/message/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#contact-observations"
+    },
+    "#/components/schemas/CallableUnauthenticatedError/properties/error/properties/status": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#contact-observations"
+    },
+    "#/components/schemas/CallableUnauthenticatedError/properties/error/properties/status/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#contact-observations"
+    },
+    "#/components/schemas/CallableUnauthenticatedError/properties/error/properties/status/const": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#contact-observations"
     }
   },
   "posterCatalogObservation": {
@@ -4511,5 +5488,113 @@
       }
     },
     "probeArtifactPath": "spec/research/auth-error-probes-redacted-20260811.json"
+  },
+  "readObservation": {
+    "artifactPath": "spec/research/read-evidence-redacted-20260811.json",
+    "sourceCitation": "docs/research/2026-08-11-event-contacts-read-observation.md#scope-and-provenance",
+    "observedAt": "2026-08-11T22:42:33.146Z",
+    "eventLists": {
+      "upcomingEvents": {
+        "rawPath": "result.data.upcomingEvents",
+        "firstCount": 35,
+        "secondCount": 35,
+        "sameIdentitySequence": true,
+        "sameIdentitySet": true,
+        "duplicateIdentityCount": 0,
+        "representation": "one-response-observed-complete-array",
+        "remotePagination": "explicit-unknown"
+      },
+      "pastEvents": {
+        "rawPath": "result.data.pastEvents",
+        "firstCount": 294,
+        "secondCount": 294,
+        "sameIdentitySequence": true,
+        "sameIdentitySet": true,
+        "duplicateIdentityCount": 0,
+        "representation": "one-response-observed-complete-array",
+        "remotePagination": "explicit-unknown"
+      }
+    },
+    "productProjection": {
+      "eventId": "supported-by-complete-item-id",
+      "titleStartEndTimezone": "observed-types-only-presence-not-proven",
+      "myRsvp": "selected-item-guest-status-observed",
+      "stateMapping": "explicit-unknown",
+      "userRoleMapping": "explicit-unknown"
+    },
+    "getEventInfo": {
+      "selectedAuthenticatedStatus": 200,
+      "selectedSignedOutStatus": 200,
+      "signedOutScope": "selected-readable-event-only",
+      "syntheticMissingStatus": 404,
+      "syntheticMissingCode": "NOT_FOUND",
+      "authenticatedPermission": "not-observed",
+      "inaccessibleEvent": "not-observed"
+    },
+    "getCurrentGuest": {
+      "status": 200,
+      "rawPath": "result.data.currentGuest",
+      "otherVariants": "explicit-unknown",
+      "currentGuestNullability": "explicit-unknown"
+    },
+    "firestoreGuest": {
+      "status": 200,
+      "documentIdMatchesCurrentGuestId": true,
+      "statusMatchesCurrentGuest": true,
+      "completeTypedValueGrammar": "explicit-unknown"
+    },
+    "firestoreEvent": {
+      "selectedReadableEventStatus": 403,
+      "syntheticMissingIdStatus": 403,
+      "normalizedCode": "PERMISSION_DENIED",
+      "attendeeDenial": "not-claimed",
+      "notFoundBehavior": "explicit-unknown"
+    },
+    "contacts": {
+      "catalogCount": 2451,
+      "runPageItemCounts": [
+        [
+          1000,
+          1000,
+          451,
+          0
+        ],
+        [
+          1000,
+          1000,
+          451,
+          0
+        ]
+      ],
+      "dataPageNextCursorType": "string",
+      "terminalNextCursor": "missing",
+      "sameIdentitySequence": true,
+      "sameIdentitySet": true,
+      "duplicateIdentityCount": 0,
+      "filtering": "client-side-name-filter-over-complete-traversed-catalog",
+      "publicProjection": [
+        "displayName",
+        "sharedEventCount"
+      ],
+      "privateIdentityField": "id",
+      "signedOutStatus": 401,
+      "signedOutCode": "UNAUTHENTICATED",
+      "unknowns": [
+        "invalid-cursor behavior",
+        "cursor lifetime and reuse",
+        "backend ordering key",
+        "snapshot behavior",
+        "useAuthUser behavior",
+        "duplicates outside the two observations"
+      ],
+      "normalParams": {},
+      "useAuthUserBehavior": "explicit-unknown"
+    },
+    "failureBoundary": {
+      "unsupportedStatuses": "explicit-unknown",
+      "inaccessibleEventPermission": "not-observed",
+      "listFailures": "explicit-unknown",
+      "currentGuestFailures": "explicit-unknown"
+    }
   }
 }

--- a/spec/partiful.api-evidence.json
+++ b/spec/partiful.api-evidence.json
@@ -5078,11 +5078,15 @@
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
     },
+    "#/components/schemas/GetCurrentGuestResponse/properties/result/properties/data/required/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
     "#/components/schemas/GetCurrentGuestResponse/properties/result/properties/data/properties/currentGuest": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
     },
-    "#/components/schemas/GetCurrentGuestResponse/properties/result/properties/data/properties/currentGuest/anyOf/0/$ref": {
+    "#/components/schemas/GetCurrentGuestResponse/properties/result/properties/data/properties/currentGuest/$ref": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
     },

--- a/spec/partiful.openapi.json
+++ b/spec/partiful.openapi.json
@@ -2561,7 +2561,6 @@
         }
       },
       "EventInfo": {
-        "type": "object",
         "properties": {
           "id": {
             "type": "string"
@@ -2649,7 +2648,6 @@
         }
       },
       "CurrentGuest": {
-        "type": "object",
         "properties": {
           "id": {
             "type": "string"

--- a/spec/partiful.openapi.json
+++ b/spec/partiful.openapi.json
@@ -2704,15 +2704,12 @@
             "properties": {
               "data": {
                 "type": "object",
+                "required": [
+                  "currentGuest"
+                ],
                 "properties": {
                   "currentGuest": {
-                    "description": "The observed object shape is listed first. Nullability and other variants remain unknown.",
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/CurrentGuest"
-                      },
-                      {}
-                    ]
+                    "$ref": "#/components/schemas/CurrentGuest"
                   }
                 }
               }

--- a/spec/partiful.openapi.json
+++ b/spec/partiful.openapi.json
@@ -207,7 +207,7 @@
         },
         "responses": {
           "200": {
-            "description": "Observed selected readable event response, both authenticated and signed out; other events are not claimed readable signed out.",
+            "description": "Observed selected readable event response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -233,8 +233,7 @@
         "security": [
           {
             "firebaseBearer": []
-          },
-          {}
+          }
         ]
       }
     },

--- a/spec/partiful.openapi.json
+++ b/spec/partiful.openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Partiful remote API contract",
     "version": "2026-08-11.5",
-    "description": "Proposed, versioned remote-only transport snapshot. Evidence classifications and uncertainty are recorded in spec/partiful.api-evidence.json."
+    "description": "Owner-reviewed, versioned remote-only transport snapshot. Evidence classifications and uncertainty are recorded in spec/partiful.api-evidence.json."
   },
   "servers": [
     {

--- a/spec/partiful.openapi.json
+++ b/spec/partiful.openapi.json
@@ -2562,18 +2562,6 @@
       },
       "EventInfo": {
         "type": "object",
-        "required": [
-          "id",
-          "title",
-          "startDate",
-          "endDate",
-          "timezone",
-          "status",
-          "description",
-          "displaySettings",
-          "image",
-          "visibility"
-        ],
         "properties": {
           "id": {
             "type": "string"
@@ -2585,7 +2573,10 @@
             "type": "string"
           },
           "endDate": {
-            "type": "null"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "timezone": {
             "type": "string"
@@ -2593,18 +2584,17 @@
           "status": {
             "type": "string"
           },
-          "description": {
-            "type": "string"
-          },
+          "description": {},
           "displaySettings": {
             "type": "object"
           },
           "image": {
-            "type": "object"
+            "type": [
+              "object",
+              "null"
+            ]
           },
-          "visibility": {
-            "type": "string"
-          }
+          "visibility": {}
         }
       },
       "GetEventInfoResponse": {
@@ -2660,33 +2650,19 @@
       },
       "CurrentGuest": {
         "type": "object",
-        "required": [
-          "id",
-          "count",
-          "name",
-          "plusOnes",
-          "status",
-          "userId"
-        ],
         "properties": {
           "id": {
             "type": "string"
           },
-          "count": {
-            "type": "integer"
-          },
+          "count": {},
           "name": {
             "type": "string"
           },
-          "plusOnes": {
-            "type": "null"
-          },
+          "plusOnes": {},
           "status": {
             "type": "string"
           },
-          "userId": {
-            "type": "string"
-          }
+          "userId": {}
         }
       },
       "GetCurrentGuestResponse": {

--- a/spec/partiful.openapi.json
+++ b/spec/partiful.openapi.json
@@ -2,8 +2,8 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Partiful remote API contract",
-    "version": "2026-08-11.4",
-    "description": "Owner-reviewed, versioned remote-only transport snapshot. Evidence classifications and uncertainty are recorded in spec/partiful.api-evidence.json."
+    "version": "2026-08-11.5",
+    "description": "Proposed, versioned remote-only transport snapshot. Evidence classifications and uncertainty are recorded in spec/partiful.api-evidence.json."
   },
   "servers": [
     {
@@ -206,14 +206,35 @@
           }
         },
         "responses": {
+          "200": {
+            "description": "Observed selected readable event response, both authenticated and signed out; other events are not claimed readable signed out.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetEventInfoResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Observed synthetic missing event response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallableNotFoundError"
+                }
+              }
+            }
+          },
           "default": {
-            "description": "Response status and body are unknown."
+            "description": "Unobserved response status or body."
           }
         },
         "security": [
           {
             "firebaseBearer": []
-          }
+          },
+          {}
         ]
       }
     },
@@ -234,12 +255,17 @@
                     "type": "object",
                     "required": [
                       "params",
-                      "amplitudeDeviceId"
+                      "amplitudeDeviceId",
+                      "paging"
                     ],
                     "properties": {
                       "params": {
                         "type": "object",
-                        "properties": {},
+                        "properties": {
+                          "useAuthUser": {
+                            "type": "boolean"
+                          }
+                        },
                         "additionalProperties": false
                       },
                       "amplitudeDeviceId": {
@@ -254,6 +280,26 @@
                           "string",
                           "null"
                         ]
+                      },
+                      "paging": {
+                        "type": "object",
+                        "required": [
+                          "maxResults",
+                          "cursor"
+                        ],
+                        "properties": {
+                          "maxResults": {
+                            "type": "integer",
+                            "const": 1000
+                          },
+                          "cursor": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "additionalProperties": false
                       }
                     },
                     "additionalProperties": false
@@ -265,8 +311,28 @@
           }
         },
         "responses": {
+          "200": {
+            "description": "Observed authenticated cursor page response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetContactsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Observed signed-out response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallableUnauthenticatedError"
+                }
+              }
+            }
+          },
           "default": {
-            "description": "Response status and body are unknown."
+            "description": "Unobserved response status or body."
           }
         },
         "security": [
@@ -835,8 +901,45 @@
           }
         },
         "responses": {
+          "200": {
+            "description": "Observed one-response upcomingEvents array.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "result"
+                  ],
+                  "properties": {
+                    "result": {
+                      "type": "object",
+                      "required": [
+                        "data"
+                      ],
+                      "properties": {
+                        "data": {
+                          "type": "object",
+                          "required": [
+                            "upcomingEvents"
+                          ],
+                          "properties": {
+                            "upcomingEvents": {
+                              "type": "array",
+                              "items": {
+                                "$ref": "#/components/schemas/HomePageEvent"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "default": {
-            "description": "Response status and body are unknown."
+            "description": "Unobserved response status or body."
           }
         },
         "security": [
@@ -894,8 +997,45 @@
           }
         },
         "responses": {
+          "200": {
+            "description": "Observed one-response pastEvents array.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "result"
+                  ],
+                  "properties": {
+                    "result": {
+                      "type": "object",
+                      "required": [
+                        "data"
+                      ],
+                      "properties": {
+                        "data": {
+                          "type": "object",
+                          "required": [
+                            "pastEvents"
+                          ],
+                          "properties": {
+                            "pastEvents": {
+                              "type": "array",
+                              "items": {
+                                "$ref": "#/components/schemas/HomePageEvent"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "default": {
-            "description": "Response status and body are unknown."
+            "description": "Unobserved response status or body."
           }
         },
         "security": [
@@ -1104,8 +1244,18 @@
           }
         },
         "responses": {
+          "200": {
+            "description": "Observed current guest response for the selected event.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetCurrentGuestResponse"
+                }
+              }
+            }
+          },
           "default": {
-            "description": "Response status and body are unknown."
+            "description": "Unobserved response status or body."
           }
         },
         "security": [
@@ -1129,8 +1279,18 @@
           }
         ],
         "responses": {
+          "403": {
+            "description": "Observed with the authenticated request context for both the selected readable event ID and a synthetic missing ID; resource existence and attendee denial are not inferred.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FirestorePermissionDeniedError"
+                }
+              }
+            }
+          },
           "default": {
-            "description": "Response status and body are unknown."
+            "description": "Unobserved response status or body."
           }
         },
         "security": [
@@ -1218,8 +1378,18 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "Observed current-guest document response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FirestoreGuestDocument"
+                }
+              }
+            }
+          },
           "default": {
-            "description": "Response status and body are unknown."
+            "description": "Unobserved response status or body."
           }
         },
         "security": [
@@ -2338,6 +2508,369 @@
           }
         },
         "additionalProperties": true
+      },
+      "HomePageEvent": {
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "startDate": {
+            "type": "string"
+          },
+          "endDate": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "timezone": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "location": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "displaySettings": {
+            "type": "object"
+          },
+          "image": {
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "guest": {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "EventInfo": {
+        "type": "object",
+        "required": [
+          "id",
+          "title",
+          "startDate",
+          "endDate",
+          "timezone",
+          "status",
+          "description",
+          "displaySettings",
+          "image",
+          "visibility"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "startDate": {
+            "type": "string"
+          },
+          "endDate": {
+            "type": "null"
+          },
+          "timezone": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "displaySettings": {
+            "type": "object"
+          },
+          "image": {
+            "type": "object"
+          },
+          "visibility": {
+            "type": "string"
+          }
+        }
+      },
+      "GetEventInfoResponse": {
+        "type": "object",
+        "required": [
+          "result"
+        ],
+        "properties": {
+          "result": {
+            "type": "object",
+            "required": [
+              "data"
+            ],
+            "properties": {
+              "data": {
+                "type": "object",
+                "required": [
+                  "event"
+                ],
+                "properties": {
+                  "event": {
+                    "$ref": "#/components/schemas/EventInfo"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "CallableNotFoundError": {
+        "type": "object",
+        "required": [
+          "error"
+        ],
+        "properties": {
+          "error": {
+            "type": "object",
+            "required": [
+              "message",
+              "status"
+            ],
+            "properties": {
+              "message": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string",
+                "const": "NOT_FOUND"
+              }
+            }
+          }
+        }
+      },
+      "CurrentGuest": {
+        "type": "object",
+        "required": [
+          "id",
+          "count",
+          "name",
+          "plusOnes",
+          "status",
+          "userId"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "count": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "plusOnes": {
+            "type": "null"
+          },
+          "status": {
+            "type": "string"
+          },
+          "userId": {
+            "type": "string"
+          }
+        }
+      },
+      "GetCurrentGuestResponse": {
+        "type": "object",
+        "required": [
+          "result"
+        ],
+        "properties": {
+          "result": {
+            "type": "object",
+            "required": [
+              "data"
+            ],
+            "properties": {
+              "data": {
+                "type": "object",
+                "properties": {
+                  "currentGuest": {
+                    "description": "The observed object shape is listed first. Nullability and other variants remain unknown.",
+                    "anyOf": [
+                      {
+                        "$ref": "#/components/schemas/CurrentGuest"
+                      },
+                      {}
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "FirestoreObservedStringValue": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        }
+      },
+      "FirestoreGuestDocument": {
+        "type": "object",
+        "required": [
+          "name",
+          "fields",
+          "createTime",
+          "updateTime"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "fields": {
+            "type": "object",
+            "required": [
+              "count",
+              "createdAt",
+              "name",
+              "status"
+            ],
+            "properties": {
+              "count": {
+                "$ref": "#/components/schemas/FirestoreObservedStringValue"
+              },
+              "createdAt": {
+                "$ref": "#/components/schemas/FirestoreObservedStringValue"
+              },
+              "name": {
+                "$ref": "#/components/schemas/FirestoreObservedStringValue"
+              },
+              "status": {
+                "$ref": "#/components/schemas/FirestoreObservedStringValue"
+              }
+            }
+          },
+          "createTime": {
+            "type": "string"
+          },
+          "updateTime": {
+            "type": "string"
+          }
+        }
+      },
+      "FirestorePermissionDeniedError": {
+        "type": "object",
+        "required": [
+          "error"
+        ],
+        "properties": {
+          "error": {
+            "type": "object",
+            "required": [
+              "code",
+              "message",
+              "status"
+            ],
+            "properties": {
+              "code": {
+                "type": "integer"
+              },
+              "message": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string",
+                "const": "PERMISSION_DENIED"
+              }
+            }
+          }
+        }
+      },
+      "Contact": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "sharedEventCount"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "sharedEventCount": {
+            "type": "integer",
+            "minimum": 0
+          }
+        }
+      },
+      "GetContactsResponse": {
+        "type": "object",
+        "required": [
+          "result"
+        ],
+        "properties": {
+          "result": {
+            "type": "object",
+            "required": [
+              "data",
+              "paging"
+            ],
+            "properties": {
+              "data": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Contact"
+                }
+              },
+              "paging": {
+                "type": "object",
+                "properties": {
+                  "nextCursor": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "CallableUnauthenticatedError": {
+        "type": "object",
+        "required": [
+          "error"
+        ],
+        "properties": {
+          "error": {
+            "type": "object",
+            "required": [
+              "message",
+              "status"
+            ],
+            "properties": {
+              "message": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string",
+                "const": "UNAUTHENTICATED"
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/spec/research/read-evidence-redacted-20260811.json
+++ b/spec/research/read-evidence-redacted-20260811.json
@@ -1,0 +1,3181 @@
+{
+  "purpose": "Privacy-safe Partiful event-read and contact remote-contract evidence",
+  "observedAt": "2026-08-11T22:42:33.146Z",
+  "redaction": "Only HTTP metadata, normalized JSON paths/types, allowlisted stable error codes, collection counts, and equality/projection facts are retained. No other body values, credentials, identities, names, event IDs, or contact details are written.",
+  "probeMethod": "Owner-attended authenticated read-only calls. No mutation, retry, pagination guess, or rate-limit probe.",
+  "observations": [
+    {
+      "operation": "getMyUpcomingEventsForHomePage",
+      "phase": "authenticated-first",
+      "endpoint": "/getMyUpcomingEventsForHomePage",
+      "status": 200,
+      "contentType": "application/json; charset=utf-8",
+      "bodyKind": "json",
+      "bodyBytes": 74747,
+      "shape": [
+        {
+          "path": "result",
+          "type": "object"
+        },
+        {
+          "path": "result.data",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*",
+          "type": "array"
+        },
+        {
+          "path": "result.data.*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[]",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].*",
+          "type": "array"
+        },
+        {
+          "path": "result.data.*.[].*",
+          "type": "boolean"
+        },
+        {
+          "path": "result.data.*.[].*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].*",
+          "type": "null"
+        },
+        {
+          "path": "result.data.*.[].*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.[]",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.*",
+          "type": "array"
+        },
+        {
+          "path": "result.data.*.[].*.*",
+          "type": "boolean"
+        },
+        {
+          "path": "result.data.*.[].*.*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].*.*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].*.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.*.[]",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].*.*.[].*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].*.*.[].*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].*.*.[].*.*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].*.*.[].id",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.*.[].text",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.*.*",
+          "type": "null"
+        },
+        {
+          "path": "result.data.*.[].*.*.*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].*.*.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.*.*.*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].*.*.*.*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].*.*.*.*.*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].*.*.*.id",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.*.*.text",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.createdAt",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.eventId",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.id",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.status",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.userId",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].displaySettings",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*",
+          "type": "null"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].endDate",
+          "type": "null"
+        },
+        {
+          "path": "result.data.*.[].endDate",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].id",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image",
+          "type": "null"
+        },
+        {
+          "path": "result.data.*.[].image",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].image.*",
+          "type": "null"
+        },
+        {
+          "path": "result.data.*.[].image.*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].image.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.*.*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].image.*.*",
+          "type": "null"
+        },
+        {
+          "path": "result.data.*.[].image.*.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.*.contentType",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.*.height",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].image.*.id",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.*.images",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].image.*.images.*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].image.*.images.*.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.*.images.*.height",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].image.*.images.*.url",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.*.images.*.width",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].image.*.name",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.*.title",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.*.url",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.*.width",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].image.blurHash",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.contentType",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.height",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].image.name",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.source",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.url",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.width",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].location",
+          "type": "null"
+        },
+        {
+          "path": "result.data.*.[].location",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].startDate",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].status",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].timezone",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].title",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.*",
+          "type": "integer"
+        }
+      ],
+      "unknownKeyCount": 1699,
+      "normalizedErrorCode": null
+    },
+    {
+      "operation": "getMyUpcomingEventsForHomePage",
+      "phase": "authenticated-repeat",
+      "endpoint": "/getMyUpcomingEventsForHomePage",
+      "status": 200,
+      "contentType": "application/json; charset=utf-8",
+      "bodyKind": "json",
+      "bodyBytes": 74747,
+      "shape": [
+        {
+          "path": "result",
+          "type": "object"
+        },
+        {
+          "path": "result.data",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*",
+          "type": "array"
+        },
+        {
+          "path": "result.data.*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[]",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].*",
+          "type": "array"
+        },
+        {
+          "path": "result.data.*.[].*",
+          "type": "boolean"
+        },
+        {
+          "path": "result.data.*.[].*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].*",
+          "type": "null"
+        },
+        {
+          "path": "result.data.*.[].*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.[]",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.*",
+          "type": "array"
+        },
+        {
+          "path": "result.data.*.[].*.*",
+          "type": "boolean"
+        },
+        {
+          "path": "result.data.*.[].*.*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].*.*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].*.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.*.[]",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].*.*.[].*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].*.*.[].*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].*.*.[].*.*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].*.*.[].id",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.*.[].text",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.*.*",
+          "type": "null"
+        },
+        {
+          "path": "result.data.*.[].*.*.*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].*.*.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.*.*.*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].*.*.*.*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].*.*.*.*.*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].*.*.*.id",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.*.*.text",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.createdAt",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.eventId",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.id",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.status",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.userId",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].displaySettings",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*",
+          "type": "null"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].endDate",
+          "type": "null"
+        },
+        {
+          "path": "result.data.*.[].endDate",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].id",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image",
+          "type": "null"
+        },
+        {
+          "path": "result.data.*.[].image",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].image.*",
+          "type": "null"
+        },
+        {
+          "path": "result.data.*.[].image.*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].image.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.*.*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].image.*.*",
+          "type": "null"
+        },
+        {
+          "path": "result.data.*.[].image.*.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.*.contentType",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.*.height",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].image.*.id",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.*.images",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].image.*.images.*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].image.*.images.*.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.*.images.*.height",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].image.*.images.*.url",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.*.images.*.width",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].image.*.name",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.*.title",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.*.url",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.*.width",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].image.blurHash",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.contentType",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.height",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].image.name",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.source",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.url",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.width",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].location",
+          "type": "null"
+        },
+        {
+          "path": "result.data.*.[].location",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].startDate",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].status",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].timezone",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].title",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.*",
+          "type": "integer"
+        }
+      ],
+      "unknownKeyCount": 1699,
+      "normalizedErrorCode": null
+    },
+    {
+      "operation": "getMyPastEventsForHomePage",
+      "phase": "authenticated-first",
+      "endpoint": "/getMyPastEventsForHomePage",
+      "status": 200,
+      "contentType": "application/json; charset=utf-8",
+      "bodyKind": "json",
+      "bodyBytes": 773455,
+      "shape": [
+        {
+          "path": "result",
+          "type": "object"
+        },
+        {
+          "path": "result.data",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*",
+          "type": "array"
+        },
+        {
+          "path": "result.data.*.[]",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].*",
+          "type": "array"
+        },
+        {
+          "path": "result.data.*.[].*",
+          "type": "boolean"
+        },
+        {
+          "path": "result.data.*.[].*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].*",
+          "type": "null"
+        },
+        {
+          "path": "result.data.*.[].*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.[]",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.*",
+          "type": "array"
+        },
+        {
+          "path": "result.data.*.[].*.*",
+          "type": "boolean"
+        },
+        {
+          "path": "result.data.*.[].*.*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].*.*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].*.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.*.[]",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].*.*.[].*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].*.*.[].*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].*.*.[].*.*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].*.*.[].id",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.*.[].text",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.*.*",
+          "type": "null"
+        },
+        {
+          "path": "result.data.*.[].*.*.*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].*.*.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.*.*.*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].*.*.*.*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].*.*.*.*.*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].*.*.*.id",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.*.*.text",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.createdAt",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.eventId",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.id",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.status",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.userId",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].displaySettings",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*",
+          "type": "null"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*.*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*.*.*",
+          "type": "number"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*.image",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*.image.*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*.image.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*.image.*.*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*.image.*.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*.image.*.contentType",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*.image.*.height",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*.image.*.name",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*.image.*.url",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*.image.*.width",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*.image.contentType",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*.image.height",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*.image.name",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*.image.source",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*.image.url",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*.image.width",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].endDate",
+          "type": "null"
+        },
+        {
+          "path": "result.data.*.[].endDate",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].id",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image",
+          "type": "null"
+        },
+        {
+          "path": "result.data.*.[].image",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].image.*",
+          "type": "null"
+        },
+        {
+          "path": "result.data.*.[].image.*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].image.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.*.*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].image.*.*",
+          "type": "null"
+        },
+        {
+          "path": "result.data.*.[].image.*.*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].image.*.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.*.*.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.*.contentType",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.*.height",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].image.*.id",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.*.images",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].image.*.images.*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].image.*.images.*.*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].image.*.images.*.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.*.images.*.height",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].image.*.images.*.url",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.*.images.*.width",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].image.*.name",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.*.title",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.*.url",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.*.width",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].image.blurHash",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.contentType",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.height",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].image.name",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.source",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.url",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.width",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].location",
+          "type": "null"
+        },
+        {
+          "path": "result.data.*.[].location",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].startDate",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].status",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].timezone",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].title",
+          "type": "string"
+        }
+      ],
+      "unknownKeyCount": 14408,
+      "normalizedErrorCode": null
+    },
+    {
+      "operation": "getMyPastEventsForHomePage",
+      "phase": "authenticated-repeat",
+      "endpoint": "/getMyPastEventsForHomePage",
+      "status": 200,
+      "contentType": "application/json; charset=utf-8",
+      "bodyKind": "json",
+      "bodyBytes": 773455,
+      "shape": [
+        {
+          "path": "result",
+          "type": "object"
+        },
+        {
+          "path": "result.data",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*",
+          "type": "array"
+        },
+        {
+          "path": "result.data.*.[]",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].*",
+          "type": "array"
+        },
+        {
+          "path": "result.data.*.[].*",
+          "type": "boolean"
+        },
+        {
+          "path": "result.data.*.[].*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].*",
+          "type": "null"
+        },
+        {
+          "path": "result.data.*.[].*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.[]",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.*",
+          "type": "array"
+        },
+        {
+          "path": "result.data.*.[].*.*",
+          "type": "boolean"
+        },
+        {
+          "path": "result.data.*.[].*.*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].*.*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].*.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.*.[]",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].*.*.[].*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].*.*.[].*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].*.*.[].*.*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].*.*.[].id",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.*.[].text",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.*.*",
+          "type": "null"
+        },
+        {
+          "path": "result.data.*.[].*.*.*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].*.*.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.*.*.*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].*.*.*.*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].*.*.*.*.*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].*.*.*.id",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.*.*.text",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.createdAt",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.eventId",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.id",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.status",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].*.userId",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].displaySettings",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*",
+          "type": "null"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*.*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*.*.*",
+          "type": "number"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*.image",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*.image.*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*.image.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*.image.*.*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*.image.*.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*.image.*.contentType",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*.image.*.height",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*.image.*.name",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*.image.*.url",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*.image.*.width",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*.image.contentType",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*.image.height",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*.image.name",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*.image.source",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*.image.url",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].displaySettings.*.image.width",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].endDate",
+          "type": "null"
+        },
+        {
+          "path": "result.data.*.[].endDate",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].id",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image",
+          "type": "null"
+        },
+        {
+          "path": "result.data.*.[].image",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].image.*",
+          "type": "null"
+        },
+        {
+          "path": "result.data.*.[].image.*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].image.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.*.*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].image.*.*",
+          "type": "null"
+        },
+        {
+          "path": "result.data.*.[].image.*.*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].image.*.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.*.*.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.*.contentType",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.*.height",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].image.*.id",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.*.images",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].image.*.images.*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.[].image.*.images.*.*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].image.*.images.*.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.*.images.*.height",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].image.*.images.*.url",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.*.images.*.width",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].image.*.name",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.*.title",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.*.url",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.*.width",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].image.blurHash",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.contentType",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.height",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].image.name",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.source",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.url",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].image.width",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.[].location",
+          "type": "null"
+        },
+        {
+          "path": "result.data.*.[].location",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].startDate",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].status",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].timezone",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.[].title",
+          "type": "string"
+        }
+      ],
+      "unknownKeyCount": 14408,
+      "normalizedErrorCode": null
+    },
+    {
+      "operation": "getContacts",
+      "phase": "authenticated-first-page-1",
+      "endpoint": "/getContacts",
+      "status": 200,
+      "contentType": "application/json; charset=utf-8",
+      "bodyKind": "json",
+      "bodyBytes": 829708,
+      "shape": [
+        {
+          "path": "result",
+          "type": "object"
+        },
+        {
+          "path": "result.data",
+          "type": "array"
+        },
+        {
+          "path": "result.data.[]",
+          "type": "object"
+        },
+        {
+          "path": "result.data.[].*",
+          "type": "boolean"
+        },
+        {
+          "path": "result.data.[].*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.[].*",
+          "type": "null"
+        },
+        {
+          "path": "result.data.[].*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.[].*.*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.[].*.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.*.*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.[].*.*.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.*.contentType",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.*.height",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.[].*.*.name",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.*.url",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.*.width",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.[].*.contentType",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.height",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.[].*.id",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.name",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.source",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.startDate",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.title",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.url",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.width",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.[].id",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].name",
+          "type": "string"
+        },
+        {
+          "path": "result.paging",
+          "type": "object"
+        },
+        {
+          "path": "result.paging.*",
+          "type": "integer"
+        },
+        {
+          "path": "result.paging.nextCursor",
+          "type": "string"
+        }
+      ],
+      "unknownKeyCount": 12212,
+      "normalizedErrorCode": null
+    },
+    {
+      "operation": "getContacts",
+      "phase": "authenticated-first-page-2",
+      "endpoint": "/getContacts",
+      "status": 200,
+      "contentType": "application/json; charset=utf-8",
+      "bodyKind": "json",
+      "bodyBytes": 696727,
+      "shape": [
+        {
+          "path": "result",
+          "type": "object"
+        },
+        {
+          "path": "result.data",
+          "type": "array"
+        },
+        {
+          "path": "result.data.[]",
+          "type": "object"
+        },
+        {
+          "path": "result.data.[].*",
+          "type": "boolean"
+        },
+        {
+          "path": "result.data.[].*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.[].*",
+          "type": "null"
+        },
+        {
+          "path": "result.data.[].*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.[].*.*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.[].*.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.*.*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.[].*.*.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.*.contentType",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.*.height",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.[].*.*.name",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.*.url",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.*.width",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.[].*.contentType",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.height",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.[].*.id",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.name",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.source",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.startDate",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.title",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.url",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.width",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.[].id",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].name",
+          "type": "string"
+        },
+        {
+          "path": "result.paging",
+          "type": "object"
+        },
+        {
+          "path": "result.paging.*",
+          "type": "integer"
+        },
+        {
+          "path": "result.paging.nextCursor",
+          "type": "string"
+        }
+      ],
+      "unknownKeyCount": 10622,
+      "normalizedErrorCode": null
+    },
+    {
+      "operation": "getContacts",
+      "phase": "authenticated-first-page-3",
+      "endpoint": "/getContacts",
+      "status": 200,
+      "contentType": "application/json; charset=utf-8",
+      "bodyKind": "json",
+      "bodyBytes": 305819,
+      "shape": [
+        {
+          "path": "result",
+          "type": "object"
+        },
+        {
+          "path": "result.data",
+          "type": "array"
+        },
+        {
+          "path": "result.data.[]",
+          "type": "object"
+        },
+        {
+          "path": "result.data.[].*",
+          "type": "boolean"
+        },
+        {
+          "path": "result.data.[].*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.[].*",
+          "type": "null"
+        },
+        {
+          "path": "result.data.[].*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.[].*.*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.[].*.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.*.*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.[].*.*.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.*.contentType",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.*.height",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.[].*.*.name",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.*.url",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.*.width",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.[].*.contentType",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.height",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.[].*.id",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.name",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.source",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.startDate",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.title",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.url",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.width",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.[].id",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].name",
+          "type": "string"
+        },
+        {
+          "path": "result.paging",
+          "type": "object"
+        },
+        {
+          "path": "result.paging.*",
+          "type": "integer"
+        },
+        {
+          "path": "result.paging.nextCursor",
+          "type": "string"
+        }
+      ],
+      "unknownKeyCount": 4749,
+      "normalizedErrorCode": null
+    },
+    {
+      "operation": "getContacts",
+      "phase": "authenticated-first-page-4",
+      "endpoint": "/getContacts",
+      "status": 200,
+      "contentType": "application/json; charset=utf-8",
+      "bodyKind": "json",
+      "bodyBytes": 53,
+      "shape": [
+        {
+          "path": "result",
+          "type": "object"
+        },
+        {
+          "path": "result.data",
+          "type": "array"
+        },
+        {
+          "path": "result.paging",
+          "type": "object"
+        },
+        {
+          "path": "result.paging.*",
+          "type": "integer"
+        }
+      ],
+      "unknownKeyCount": 1,
+      "normalizedErrorCode": null
+    },
+    {
+      "operation": "getContacts",
+      "phase": "authenticated-repeat-page-1",
+      "endpoint": "/getContacts",
+      "status": 200,
+      "contentType": "application/json; charset=utf-8",
+      "bodyKind": "json",
+      "bodyBytes": 829708,
+      "shape": [
+        {
+          "path": "result",
+          "type": "object"
+        },
+        {
+          "path": "result.data",
+          "type": "array"
+        },
+        {
+          "path": "result.data.[]",
+          "type": "object"
+        },
+        {
+          "path": "result.data.[].*",
+          "type": "boolean"
+        },
+        {
+          "path": "result.data.[].*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.[].*",
+          "type": "null"
+        },
+        {
+          "path": "result.data.[].*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.[].*.*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.[].*.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.*.*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.[].*.*.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.*.contentType",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.*.height",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.[].*.*.name",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.*.url",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.*.width",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.[].*.contentType",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.height",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.[].*.id",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.name",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.source",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.startDate",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.title",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.url",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.width",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.[].id",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].name",
+          "type": "string"
+        },
+        {
+          "path": "result.paging",
+          "type": "object"
+        },
+        {
+          "path": "result.paging.*",
+          "type": "integer"
+        },
+        {
+          "path": "result.paging.nextCursor",
+          "type": "string"
+        }
+      ],
+      "unknownKeyCount": 12212,
+      "normalizedErrorCode": null
+    },
+    {
+      "operation": "getContacts",
+      "phase": "authenticated-repeat-page-2",
+      "endpoint": "/getContacts",
+      "status": 200,
+      "contentType": "application/json; charset=utf-8",
+      "bodyKind": "json",
+      "bodyBytes": 696727,
+      "shape": [
+        {
+          "path": "result",
+          "type": "object"
+        },
+        {
+          "path": "result.data",
+          "type": "array"
+        },
+        {
+          "path": "result.data.[]",
+          "type": "object"
+        },
+        {
+          "path": "result.data.[].*",
+          "type": "boolean"
+        },
+        {
+          "path": "result.data.[].*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.[].*",
+          "type": "null"
+        },
+        {
+          "path": "result.data.[].*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.[].*.*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.[].*.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.*.*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.[].*.*.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.*.contentType",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.*.height",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.[].*.*.name",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.*.url",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.*.width",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.[].*.contentType",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.height",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.[].*.id",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.name",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.source",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.startDate",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.title",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.url",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.width",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.[].id",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].name",
+          "type": "string"
+        },
+        {
+          "path": "result.paging",
+          "type": "object"
+        },
+        {
+          "path": "result.paging.*",
+          "type": "integer"
+        },
+        {
+          "path": "result.paging.nextCursor",
+          "type": "string"
+        }
+      ],
+      "unknownKeyCount": 10622,
+      "normalizedErrorCode": null
+    },
+    {
+      "operation": "getContacts",
+      "phase": "authenticated-repeat-page-3",
+      "endpoint": "/getContacts",
+      "status": 200,
+      "contentType": "application/json; charset=utf-8",
+      "bodyKind": "json",
+      "bodyBytes": 305819,
+      "shape": [
+        {
+          "path": "result",
+          "type": "object"
+        },
+        {
+          "path": "result.data",
+          "type": "array"
+        },
+        {
+          "path": "result.data.[]",
+          "type": "object"
+        },
+        {
+          "path": "result.data.[].*",
+          "type": "boolean"
+        },
+        {
+          "path": "result.data.[].*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.[].*",
+          "type": "null"
+        },
+        {
+          "path": "result.data.[].*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.[].*.*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.[].*.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.*.*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.[].*.*.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.*.contentType",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.*.height",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.[].*.*.name",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.*.url",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.*.width",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.[].*.contentType",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.height",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.[].*.id",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.name",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.source",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.startDate",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.title",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.url",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].*.width",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.[].id",
+          "type": "string"
+        },
+        {
+          "path": "result.data.[].name",
+          "type": "string"
+        },
+        {
+          "path": "result.paging",
+          "type": "object"
+        },
+        {
+          "path": "result.paging.*",
+          "type": "integer"
+        },
+        {
+          "path": "result.paging.nextCursor",
+          "type": "string"
+        }
+      ],
+      "unknownKeyCount": 4749,
+      "normalizedErrorCode": null
+    },
+    {
+      "operation": "getContacts",
+      "phase": "authenticated-repeat-page-4",
+      "endpoint": "/getContacts",
+      "status": 200,
+      "contentType": "application/json; charset=utf-8",
+      "bodyKind": "json",
+      "bodyBytes": 53,
+      "shape": [
+        {
+          "path": "result",
+          "type": "object"
+        },
+        {
+          "path": "result.data",
+          "type": "array"
+        },
+        {
+          "path": "result.paging",
+          "type": "object"
+        },
+        {
+          "path": "result.paging.*",
+          "type": "integer"
+        }
+      ],
+      "unknownKeyCount": 1,
+      "normalizedErrorCode": null
+    },
+    {
+      "operation": "getEventInfo",
+      "phase": "authenticated-selected-event",
+      "endpoint": "/getEventInfo",
+      "status": 200,
+      "contentType": "application/json; charset=utf-8",
+      "bodyKind": "json",
+      "bodyBytes": 4975,
+      "shape": [
+        {
+          "path": "result",
+          "type": "object"
+        },
+        {
+          "path": "result.data",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*",
+          "type": "boolean"
+        },
+        {
+          "path": "result.data.event",
+          "type": "object"
+        },
+        {
+          "path": "result.data.event.*",
+          "type": "array"
+        },
+        {
+          "path": "result.data.event.*",
+          "type": "boolean"
+        },
+        {
+          "path": "result.data.event.*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.event.*",
+          "type": "null"
+        },
+        {
+          "path": "result.data.event.*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.event.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.*.[]",
+          "type": "object"
+        },
+        {
+          "path": "result.data.event.*.[]",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.*.[].*",
+          "type": "array"
+        },
+        {
+          "path": "result.data.event.*.[].*.[]",
+          "type": "object"
+        },
+        {
+          "path": "result.data.event.*.[].*.[].*",
+          "type": "array"
+        },
+        {
+          "path": "result.data.event.*.[].*.[].*",
+          "type": "boolean"
+        },
+        {
+          "path": "result.data.event.*.[].*.[].*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.*.[].*.[].*.[]",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.*.[].*.[].id",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.*.[].*.[].text",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.*.[].createdAt",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.*.*",
+          "type": "boolean"
+        },
+        {
+          "path": "result.data.event.*.*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.event.*.*",
+          "type": "null"
+        },
+        {
+          "path": "result.data.event.*.*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.event.*.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.*.*.*",
+          "type": "array"
+        },
+        {
+          "path": "result.data.event.*.*.*",
+          "type": "null"
+        },
+        {
+          "path": "result.data.event.*.*.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.createdAt",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.description",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.displaySettings",
+          "type": "object"
+        },
+        {
+          "path": "result.data.event.displaySettings.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.endDate",
+          "type": "null"
+        },
+        {
+          "path": "result.data.event.id",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.image",
+          "type": "object"
+        },
+        {
+          "path": "result.data.event.image.*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.event.image.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.image.*.*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.event.image.*.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.image.*.contentType",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.image.*.height",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.event.image.*.name",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.image.*.url",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.image.*.width",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.event.image.blurHash",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.image.contentType",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.image.height",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.event.image.name",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.image.source",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.image.url",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.image.width",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.event.startDate",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.status",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.timezone",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.title",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.visibility",
+          "type": "string"
+        }
+      ],
+      "unknownKeyCount": 90,
+      "normalizedErrorCode": null
+    },
+    {
+      "operation": "getCurrentGuest",
+      "phase": "authenticated-selected-event",
+      "endpoint": "/getCurrentGuest",
+      "status": 200,
+      "contentType": "application/json; charset=utf-8",
+      "bodyKind": "json",
+      "bodyBytes": 323,
+      "shape": [
+        {
+          "path": "result",
+          "type": "object"
+        },
+        {
+          "path": "result.data",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*",
+          "type": "null"
+        },
+        {
+          "path": "result.data.*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.*",
+          "type": "array"
+        },
+        {
+          "path": "result.data.*.*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.*",
+          "type": "null"
+        },
+        {
+          "path": "result.data.*.*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*.*.id",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.count",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.*.id",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.name",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.plusOnes",
+          "type": "null"
+        },
+        {
+          "path": "result.data.*.status",
+          "type": "string"
+        },
+        {
+          "path": "result.data.*.userId",
+          "type": "string"
+        }
+      ],
+      "unknownKeyCount": 8,
+      "normalizedErrorCode": null
+    },
+    {
+      "operation": "firestoreGetEvent",
+      "phase": "authenticated-selected-event",
+      "endpoint": "/v1/projects/getpartiful/databases/(default)/documents/events/{eventId}",
+      "status": 403,
+      "contentType": "application/json; charset=utf-8",
+      "bodyKind": "json",
+      "bodyBytes": 127,
+      "shape": [
+        {
+          "path": "error",
+          "type": "object"
+        },
+        {
+          "path": "error.code",
+          "type": "integer"
+        },
+        {
+          "path": "error.message",
+          "type": "string"
+        },
+        {
+          "path": "error.status",
+          "type": "string"
+        }
+      ],
+      "unknownKeyCount": 0,
+      "normalizedErrorCode": "PERMISSION_DENIED"
+    },
+    {
+      "operation": "firestoreGetGuest",
+      "phase": "authenticated-selected-event",
+      "endpoint": "/v1/projects/getpartiful/databases/(default)/documents/events/{eventId}/guests/{guestId}",
+      "status": 200,
+      "contentType": "application/json; charset=utf-8",
+      "bodyKind": "json",
+      "bodyBytes": 1492,
+      "shape": [
+        {
+          "path": "createTime",
+          "type": "string"
+        },
+        {
+          "path": "fields",
+          "type": "object"
+        },
+        {
+          "path": "fields.*",
+          "type": "object"
+        },
+        {
+          "path": "fields.*.*",
+          "type": "boolean"
+        },
+        {
+          "path": "fields.*.*",
+          "type": "object"
+        },
+        {
+          "path": "fields.*.*",
+          "type": "string"
+        },
+        {
+          "path": "fields.*.*.*",
+          "type": "array"
+        },
+        {
+          "path": "fields.*.*.*.[]",
+          "type": "object"
+        },
+        {
+          "path": "fields.*.*.*.[].*",
+          "type": "string"
+        },
+        {
+          "path": "fields.*.*.fields",
+          "type": "object"
+        },
+        {
+          "path": "fields.*.*.fields.*",
+          "type": "object"
+        },
+        {
+          "path": "fields.*.*.fields.*.*",
+          "type": "string"
+        },
+        {
+          "path": "fields.count",
+          "type": "object"
+        },
+        {
+          "path": "fields.count.*",
+          "type": "string"
+        },
+        {
+          "path": "fields.createdAt",
+          "type": "object"
+        },
+        {
+          "path": "fields.createdAt.*",
+          "type": "string"
+        },
+        {
+          "path": "fields.name",
+          "type": "object"
+        },
+        {
+          "path": "fields.name.*",
+          "type": "string"
+        },
+        {
+          "path": "fields.status",
+          "type": "object"
+        },
+        {
+          "path": "fields.status.*",
+          "type": "string"
+        },
+        {
+          "path": "name",
+          "type": "string"
+        },
+        {
+          "path": "updateTime",
+          "type": "string"
+        }
+      ],
+      "unknownKeyCount": 24,
+      "normalizedErrorCode": null
+    },
+    {
+      "operation": "getEventInfo",
+      "phase": "authenticated-synthetic-not-found",
+      "endpoint": "/getEventInfo",
+      "status": 404,
+      "contentType": "application/json; charset=utf-8",
+      "bodyKind": "json",
+      "bodyBytes": 60,
+      "shape": [
+        {
+          "path": "error",
+          "type": "object"
+        },
+        {
+          "path": "error.message",
+          "type": "string"
+        },
+        {
+          "path": "error.status",
+          "type": "string"
+        }
+      ],
+      "unknownKeyCount": 0,
+      "normalizedErrorCode": "NOT_FOUND"
+    },
+    {
+      "operation": "firestoreGetEvent",
+      "phase": "authenticated-synthetic-not-found",
+      "endpoint": "/v1/projects/getpartiful/databases/(default)/documents/events/{eventId}",
+      "status": 403,
+      "contentType": "application/json; charset=utf-8",
+      "bodyKind": "json",
+      "bodyBytes": 127,
+      "shape": [
+        {
+          "path": "error",
+          "type": "object"
+        },
+        {
+          "path": "error.code",
+          "type": "integer"
+        },
+        {
+          "path": "error.message",
+          "type": "string"
+        },
+        {
+          "path": "error.status",
+          "type": "string"
+        }
+      ],
+      "unknownKeyCount": 0,
+      "normalizedErrorCode": "PERMISSION_DENIED"
+    },
+    {
+      "operation": "getEventInfo",
+      "phase": "signed-out-readable-event",
+      "endpoint": "/getEventInfo",
+      "status": 200,
+      "contentType": "application/json; charset=utf-8",
+      "bodyKind": "json",
+      "bodyBytes": 4975,
+      "shape": [
+        {
+          "path": "result",
+          "type": "object"
+        },
+        {
+          "path": "result.data",
+          "type": "object"
+        },
+        {
+          "path": "result.data.*",
+          "type": "boolean"
+        },
+        {
+          "path": "result.data.event",
+          "type": "object"
+        },
+        {
+          "path": "result.data.event.*",
+          "type": "array"
+        },
+        {
+          "path": "result.data.event.*",
+          "type": "boolean"
+        },
+        {
+          "path": "result.data.event.*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.event.*",
+          "type": "null"
+        },
+        {
+          "path": "result.data.event.*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.event.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.*.[]",
+          "type": "object"
+        },
+        {
+          "path": "result.data.event.*.[]",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.*.[].*",
+          "type": "array"
+        },
+        {
+          "path": "result.data.event.*.[].*.[]",
+          "type": "object"
+        },
+        {
+          "path": "result.data.event.*.[].*.[].*",
+          "type": "array"
+        },
+        {
+          "path": "result.data.event.*.[].*.[].*",
+          "type": "boolean"
+        },
+        {
+          "path": "result.data.event.*.[].*.[].*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.*.[].*.[].*.[]",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.*.[].*.[].id",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.*.[].*.[].text",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.*.[].createdAt",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.*.*",
+          "type": "boolean"
+        },
+        {
+          "path": "result.data.event.*.*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.event.*.*",
+          "type": "null"
+        },
+        {
+          "path": "result.data.event.*.*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.event.*.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.*.*.*",
+          "type": "array"
+        },
+        {
+          "path": "result.data.event.*.*.*",
+          "type": "null"
+        },
+        {
+          "path": "result.data.event.*.*.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.createdAt",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.description",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.displaySettings",
+          "type": "object"
+        },
+        {
+          "path": "result.data.event.displaySettings.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.endDate",
+          "type": "null"
+        },
+        {
+          "path": "result.data.event.id",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.image",
+          "type": "object"
+        },
+        {
+          "path": "result.data.event.image.*",
+          "type": "object"
+        },
+        {
+          "path": "result.data.event.image.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.image.*.*",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.event.image.*.*",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.image.*.contentType",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.image.*.height",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.event.image.*.name",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.image.*.url",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.image.*.width",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.event.image.blurHash",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.image.contentType",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.image.height",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.event.image.name",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.image.source",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.image.url",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.image.width",
+          "type": "integer"
+        },
+        {
+          "path": "result.data.event.startDate",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.status",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.timezone",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.title",
+          "type": "string"
+        },
+        {
+          "path": "result.data.event.visibility",
+          "type": "string"
+        }
+      ],
+      "unknownKeyCount": 90,
+      "normalizedErrorCode": null
+    },
+    {
+      "operation": "getContacts",
+      "phase": "signed-out",
+      "endpoint": "/getContacts",
+      "status": 401,
+      "contentType": "application/json; charset=utf-8",
+      "bodyKind": "json",
+      "bodyBytes": 68,
+      "shape": [
+        {
+          "path": "error",
+          "type": "object"
+        },
+        {
+          "path": "error.message",
+          "type": "string"
+        },
+        {
+          "path": "error.status",
+          "type": "string"
+        }
+      ],
+      "unknownKeyCount": 0,
+      "normalizedErrorCode": "UNAUTHENTICATED"
+    }
+  ],
+  "aggregates": {
+    "eventLists": {
+      "upcoming": {
+        "observed": true,
+        "firstCount": 35,
+        "secondCount": 35,
+        "identityFieldComplete": true,
+        "sameIdentitySequence": true,
+        "sameIdentitySet": true,
+        "duplicateIdentityCount": 0,
+        "rawPath": "result.data.upcomingEvents"
+      },
+      "past": {
+        "observed": true,
+        "firstCount": 294,
+        "secondCount": 294,
+        "identityFieldComplete": true,
+        "sameIdentitySequence": true,
+        "sameIdentitySet": true,
+        "duplicateIdentityCount": 0,
+        "rawPath": "result.data.pastEvents"
+      }
+    },
+    "contacts": {
+      "observed": true,
+      "firstCount": 2451,
+      "secondCount": 2451,
+      "identityFieldComplete": true,
+      "sameIdentitySequence": true,
+      "sameIdentitySet": true,
+      "duplicateIdentityCount": 0,
+      "sharedEventCountPresent": 2451,
+      "sharedEventCountsAreNonNegativeIntegers": true,
+      "namesAreStrings": true,
+      "pagination": {
+        "observed": true,
+        "requestedMaxResults": 1000,
+        "firstRunPageCount": 4,
+        "secondRunPageCount": 4,
+        "firstRunPageItemCounts": [
+          1000,
+          1000,
+          451,
+          0
+        ],
+        "secondRunPageItemCounts": [
+          1000,
+          1000,
+          451,
+          0
+        ],
+        "firstRunCursorTypes": [
+          "string",
+          "string",
+          "string",
+          "undefined"
+        ],
+        "secondRunCursorTypes": [
+          "string",
+          "string",
+          "string",
+          "undefined"
+        ],
+        "terminalPageObserved": true,
+        "terminalPageItemCount": 0,
+        "repeatedCursorObserved": false,
+        "unpagedResponseObserved": false
+      },
+      "remoteFiltering": {
+        "observed": false,
+        "reason": "Current first-party assets filter names locally after complete cursor traversal; no remote filtering parameter was sent."
+      }
+    },
+    "selectedEventProjection": {
+      "source": "authenticated-list",
+      "ownerMatchObserved": false,
+      "guestObjectPresent": true,
+      "guestStatusType": "string",
+      "guestStatusPath": "result.data.upcomingEvents.[].guest.status"
+    },
+    "crossSourceProjection": {
+      "eventIdMatchesCallable": true,
+      "eventIdMatchesFirestoreName": null,
+      "currentGuestObserved": true,
+      "guestDocumentIdObserved": true,
+      "guestIdMatchesFirestoreName": true,
+      "guestStatusType": "string",
+      "guestStatusMatchesFirestore": true,
+      "currentGuestPath": "result.data.currentGuest"
+    },
+    "failureDistinctions": {
+      "permissionProbeObserved": false,
+      "callablePermissionDiffersFromNotFound": null,
+      "firestorePermissionDiffersFromNotFound": null,
+      "signedOutEventObserved": true,
+      "signedOutContactsObserved": true,
+      "callableNotFoundObserved": true,
+      "firestoreNotFoundObserved": false,
+      "firestoreSyntheticIdProbeObserved": true
+    }
+  }
+}

--- a/tests/remote-api-contract.test.js
+++ b/tests/remote-api-contract.test.js
@@ -183,7 +183,7 @@ describe('remote API contract', () => {
       ...materialClaimPointers(spec.paths, '#/paths', 'paths'),
       ...materialClaimPointers(spec.components, '#/components', 'components'),
     ]);
-    expect(pointers).toHaveLength(1249);
+    expect(pointers).toHaveLength(1250);
     for (const pointer of pointers) {
       const claim = evidence.claims[pointer];
       expect(claim, pointer).toBeDefined();
@@ -636,11 +636,11 @@ describe('remote API contract', () => {
     expect(currentGuest).toEqual({ $ref: '#/components/schemas/GetCurrentGuestResponse' });
     const currentGuestProperty = spec.components.schemas.GetCurrentGuestResponse
       .properties.result.properties.data.properties.currentGuest;
-    expect(currentGuestProperty.anyOf)
-      .toContainEqual({ $ref: '#/components/schemas/CurrentGuest' });
+    expect(currentGuestProperty)
+      .toEqual({ $ref: '#/components/schemas/CurrentGuest' });
     expect(spec.components.schemas.GetCurrentGuestResponse.properties.result
-      .properties.data.required ?? [])
-      .not.toContain('currentGuest');
+      .properties.data.required)
+      .toEqual(['currentGuest']);
     expect(spec.components.schemas.CurrentGuest).toMatchObject({
       required: ['id', 'count', 'name', 'plusOnes', 'status', 'userId'],
       properties: {

--- a/tests/remote-api-contract.test.js
+++ b/tests/remote-api-contract.test.js
@@ -287,7 +287,7 @@ describe('remote API contract', () => {
       ...materialClaimPointers(spec.paths, '#/paths', 'paths'),
       ...materialClaimPointers(spec.components, '#/components', 'components'),
     ]);
-    expect(pointers).toHaveLength(1250);
+    expect(pointers).toHaveLength(1232);
     for (const pointer of pointers) {
       const claim = evidence.claims[pointer];
       expect(claim, pointer).toBeDefined();
@@ -345,6 +345,7 @@ describe('remote API contract', () => {
     expect(ledger).toMatch(
       /Eleven of those\s+operations have a typed `200` response body\./,
     );
+    expect(ledger.match(/The 1232 material claims/g)).toHaveLength(2);
   });
 
   it('contains remote transport facts rather than product or implementation policy', () => {
@@ -754,18 +755,22 @@ describe('remote API contract', () => {
       .toEqual({ $ref: '#/components/schemas/CallableNotFoundError' });
     expect(eventInfo.responses['200'].description).toContain('selected readable event');
     expect(eventInfo.responses['200'].description).not.toContain('signed out');
-    expect(spec.components.schemas.EventInfo.properties).toMatchObject({
+    const eventInfoSchema = spec.components.schemas.EventInfo;
+    expect(eventInfoSchema.required ?? []).toEqual([]);
+    expect(eventInfoSchema.properties).toMatchObject({
       id: { type: 'string' },
       title: { type: 'string' },
       startDate: { type: 'string' },
-      endDate: { type: 'null' },
+      endDate: { type: ['string', 'null'] },
       timezone: { type: 'string' },
       status: { type: 'string' },
-      description: { type: 'string' },
+      description: {},
       displaySettings: { type: 'object' },
-      image: { type: 'object' },
-      visibility: { type: 'string' },
+      image: { type: ['object', 'null'] },
+      visibility: {},
     });
+    expect(eventInfoSchema.properties.description).toEqual({});
+    expect(eventInfoSchema.properties.visibility).toEqual({});
     expect(evidence.readObservation.getEventInfo).toMatchObject({
       selectedAuthenticatedStatus: 200,
       selectedSignedOutStatus: 200,
@@ -774,7 +779,39 @@ describe('remote API contract', () => {
       syntheticMissingCode: 'NOT_FOUND',
       authenticatedPermission: 'not-observed',
       inaccessibleEvent: 'not-observed',
+      sampleScope: 'one-selected-event',
+      fieldPresence: 'selected-object-only',
+      fieldNullabilityAndAlternateVariants: 'explicit-unknown',
+      relatedEventRepresentationTypes: {
+        endDate: ['string', 'null'],
+        image: ['object', 'null'],
+      },
     });
+    const eventListCitation =
+      'docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations';
+    for (const field of ['id', 'startDate', 'timezone', 'status', 'displaySettings']) {
+      expect(evidence.claims[
+        `#/components/schemas/EventInfo/properties/${field}/type`
+      ]?.citation).toBe(eventListCitation);
+    }
+    for (const field of ['endDate', 'image']) {
+      for (const index of [0, 1]) {
+        expect(evidence.claims[
+          `#/components/schemas/EventInfo/properties/${field}/type/${index}`
+        ]?.citation).toBe(eventListCitation);
+      }
+      expect(evidence.claims[
+        `#/components/schemas/EventInfo/properties/${field}/type`
+      ]).toBeUndefined();
+    }
+    expect(evidence.claims[
+      '#/components/schemas/EventInfo/properties/visibility/type'
+    ]).toBeUndefined();
+    for (let index = 0; index < 10; index += 1) {
+      expect(evidence.claims[
+        `#/components/schemas/EventInfo/required/${index}`
+      ]).toBeUndefined();
+    }
 
     const currentGuest = spec.paths['/getCurrentGuest'].post.responses['200']
       .content['application/json'].schema;
@@ -787,20 +824,43 @@ describe('remote API contract', () => {
       .properties.data.required)
       .toEqual(['currentGuest']);
     expect(spec.components.schemas.CurrentGuest).toMatchObject({
-      required: ['id', 'count', 'name', 'plusOnes', 'status', 'userId'],
       properties: {
         id: { type: 'string' },
-        count: { type: 'integer' },
+        count: {},
         name: { type: 'string' },
-        plusOnes: { type: 'null' },
+        plusOnes: {},
         status: { type: 'string' },
-        userId: { type: 'string' },
+        userId: {},
       },
     });
+    expect(spec.components.schemas.CurrentGuest.properties.count).toEqual({});
+    expect(spec.components.schemas.CurrentGuest.properties.plusOnes).toEqual({});
+    expect(spec.components.schemas.CurrentGuest.properties.userId).toEqual({});
+    expect(spec.components.schemas.CurrentGuest.required ?? []).toEqual([]);
     expect(evidence.readObservation.getCurrentGuest.otherVariants)
       .toBe('explicit-unknown');
     expect(evidence.readObservation.getCurrentGuest.currentGuestNullability)
       .toBe('explicit-unknown');
+    expect(evidence.readObservation.getCurrentGuest).toMatchObject({
+      sampleScope: 'one-selected-event',
+      fieldPresence: 'selected-object-only',
+      fieldNullabilityAndAlternateVariants: 'explicit-unknown',
+      plusOnesVariants: 'explicit-unknown',
+    });
+    for (const field of ['count', 'plusOnes', 'userId']) {
+      expect(evidence.claims[
+        `#/components/schemas/CurrentGuest/properties/${field}/type`
+      ]).toBeUndefined();
+    }
+    for (let index = 0; index < 6; index += 1) {
+      expect(evidence.claims[
+        `#/components/schemas/CurrentGuest/required/${index}`
+      ]).toBeUndefined();
+    }
+    expect(evidence.unresolvedUncertainty).toEqual(expect.arrayContaining([
+      'Only one selected EventInfo object was observed; operation-wide field presence, nullability, and alternate variants remain unknown. Related event-list representations support only the optional endDate string/null and image object/null unions.',
+      'Only one CurrentGuest object was observed; operation-wide field presence, nullability, alternate variants, plus-one shape, unsupported statuses, and failure bodies remain unknown.',
+    ]));
   });
 
   it('distinguishes the observed Firestore guest success from event-document denial', () => {
@@ -1074,11 +1134,27 @@ describe('remote API contract', () => {
       'docs/CLI-PRODUCT-CONTRACT.md',
       'utf8',
     );
+    const appSource = fs.readFileSync('internal/app/app.go', 'utf8');
     const contactResearch = fs.readFileSync(
       'docs/research/2026-08-11-contacts-pagination-public-assets.md',
       'utf8',
     );
+    const shippedRevision = appSource.match(
+      /RemoteContractRevision\s*=\s*"([^"]+)"/,
+    )?.[1];
+    const documentedRevision = productContract.match(
+      /\*\*Remote API contract revision:\*\* `([^`]+)`/,
+    )?.[1];
+    const envelopeRevisions = [...productContract.matchAll(
+      /"remoteContractRevision": "([^"]+)"/g,
+    )].map((match) => match[1]);
 
+    expect(shippedRevision).toBe('2026-08-11.4');
+    expect(documentedRevision).toBe(shippedRevision);
+    expect(new Set(envelopeRevisions)).toEqual(new Set([shippedRevision]));
+    expect(spec.info.version).toBe('2026-08-11.5');
+    expect(evidence.status).toBe('proposed');
+    expect(spec.info.version).not.toBe(shippedRevision);
     expect(productContract)
       .not.toContain('currently leaves every operation response status and body unknown');
     expect(contactResearch)

--- a/tests/remote-api-contract.test.js
+++ b/tests/remote-api-contract.test.js
@@ -287,7 +287,7 @@ describe('remote API contract', () => {
       ...materialClaimPointers(spec.paths, '#/paths', 'paths'),
       ...materialClaimPointers(spec.components, '#/components', 'components'),
     ]);
-    expect(pointers).toHaveLength(1232);
+    expect(pointers).toHaveLength(1230);
     for (const pointer of pointers) {
       const claim = evidence.claims[pointer];
       expect(claim, pointer).toBeDefined();
@@ -345,7 +345,7 @@ describe('remote API contract', () => {
     expect(ledger).toMatch(
       /Eleven of those\s+operations have a typed `200` response body\./,
     );
-    expect(ledger.match(/The 1232 material claims/g)).toHaveLength(2);
+    expect(ledger.match(/The 1230 material claims/g)).toHaveLength(2);
   });
 
   it('contains remote transport facts rather than product or implementation policy', () => {
@@ -756,6 +756,8 @@ describe('remote API contract', () => {
     expect(eventInfo.responses['200'].description).toContain('selected readable event');
     expect(eventInfo.responses['200'].description).not.toContain('signed out');
     const eventInfoSchema = spec.components.schemas.EventInfo;
+    expect(eventInfoSchema).not.toHaveProperty('type');
+    expect(evidence.claims['#/components/schemas/EventInfo/type']).toBeUndefined();
     expect(eventInfoSchema.required ?? []).toEqual([]);
     expect(eventInfoSchema.properties).toMatchObject({
       id: { type: 'string' },
@@ -823,6 +825,8 @@ describe('remote API contract', () => {
     expect(spec.components.schemas.GetCurrentGuestResponse.properties.result
       .properties.data.required)
       .toEqual(['currentGuest']);
+    expect(spec.components.schemas.CurrentGuest).not.toHaveProperty('type');
+    expect(evidence.claims['#/components/schemas/CurrentGuest/type']).toBeUndefined();
     expect(spec.components.schemas.CurrentGuest).toMatchObject({
       properties: {
         id: { type: 'string' },

--- a/tests/remote-api-contract.test.js
+++ b/tests/remote-api-contract.test.js
@@ -43,6 +43,87 @@ const hosts = {
   upload: 'https://us-central1-getpartiful.cloudfunctions.net',
   posters: 'https://assets.getpartiful.com',
 };
+const expectedReadAggregates = {
+  eventLists: {
+    upcoming: {
+      observed: true,
+      firstCount: 35,
+      secondCount: 35,
+      identityFieldComplete: true,
+      sameIdentitySequence: true,
+      sameIdentitySet: true,
+      duplicateIdentityCount: 0,
+      rawPath: 'result.data.upcomingEvents',
+    },
+    past: {
+      observed: true,
+      firstCount: 294,
+      secondCount: 294,
+      identityFieldComplete: true,
+      sameIdentitySequence: true,
+      sameIdentitySet: true,
+      duplicateIdentityCount: 0,
+      rawPath: 'result.data.pastEvents',
+    },
+  },
+  contacts: {
+    observed: true,
+    firstCount: 2451,
+    secondCount: 2451,
+    identityFieldComplete: true,
+    sameIdentitySequence: true,
+    sameIdentitySet: true,
+    duplicateIdentityCount: 0,
+    sharedEventCountPresent: 2451,
+    sharedEventCountsAreNonNegativeIntegers: true,
+    namesAreStrings: true,
+    pagination: {
+      observed: true,
+      requestedMaxResults: 1000,
+      firstRunPageCount: 4,
+      secondRunPageCount: 4,
+      firstRunPageItemCounts: [1000, 1000, 451, 0],
+      secondRunPageItemCounts: [1000, 1000, 451, 0],
+      firstRunCursorTypes: ['string', 'string', 'string', 'undefined'],
+      secondRunCursorTypes: ['string', 'string', 'string', 'undefined'],
+      terminalPageObserved: true,
+      terminalPageItemCount: 0,
+      repeatedCursorObserved: false,
+      unpagedResponseObserved: false,
+    },
+    remoteFiltering: {
+      observed: false,
+      reason: 'Current first-party assets filter names locally after complete cursor traversal; no remote filtering parameter was sent.',
+    },
+  },
+  selectedEventProjection: {
+    source: 'authenticated-list',
+    ownerMatchObserved: false,
+    guestObjectPresent: true,
+    guestStatusType: 'string',
+    guestStatusPath: 'result.data.upcomingEvents.[].guest.status',
+  },
+  crossSourceProjection: {
+    eventIdMatchesCallable: true,
+    eventIdMatchesFirestoreName: null,
+    currentGuestObserved: true,
+    guestDocumentIdObserved: true,
+    guestIdMatchesFirestoreName: true,
+    guestStatusType: 'string',
+    guestStatusMatchesFirestore: true,
+    currentGuestPath: 'result.data.currentGuest',
+  },
+  failureDistinctions: {
+    permissionProbeObserved: false,
+    callablePermissionDiffersFromNotFound: null,
+    firestorePermissionDiffersFromNotFound: null,
+    signedOutEventObserved: true,
+    signedOutContactsObserved: true,
+    callableNotFoundObserved: true,
+    firestoreNotFoundObserved: false,
+    firestoreSyntheticIdProbeObserved: true,
+  },
+};
 
 function operations() {
   return Object.entries(spec.paths).flatMap(([path, item]) =>
@@ -72,7 +153,9 @@ function materialClaimPointers(value, pointer, parentKey = '') {
       materialClaimPointers(item, `${pointer}/${index}`, parentKey),
     );
   }
-  return Object.entries(value).flatMap(([key, child]) => {
+  const entries = Object.entries(value);
+  if (entries.length === 0 && parentKey === 'security') return [pointer];
+  return entries.flatMap(([key, child]) => {
     const childPointer = `${pointer}/${escapePointerSegment(key)}`;
     const namedClaim = materialMapKeys.has(parentKey) ? [childPointer] : [];
     return [
@@ -80,6 +163,27 @@ function materialClaimPointers(value, pointer, parentKey = '') {
       ...(ignoredKeys.has(key) ? [] : materialClaimPointers(child, childPointer, key)),
     ];
   });
+}
+
+function assertExactAllowlistedValue(actual, expected, pointer = 'aggregates') {
+  if (Array.isArray(expected)) {
+    expect(Array.isArray(actual), pointer).toBe(true);
+    expect(actual, pointer).toHaveLength(expected.length);
+    expected.forEach((item, index) =>
+      assertExactAllowlistedValue(actual[index], item, `${pointer}/${index}`));
+    return;
+  }
+  if (expected !== null && typeof expected === 'object') {
+    expect(actual !== null && typeof actual === 'object' && !Array.isArray(actual), pointer)
+      .toBe(true);
+    expect(Object.keys(actual).sort(), pointer)
+      .toEqual(Object.keys(expected).sort());
+    for (const [key, child] of Object.entries(expected)) {
+      assertExactAllowlistedValue(actual[key], child, `${pointer}/${key}`);
+    }
+    return;
+  }
+  expect(actual, pointer).toBe(expected);
 }
 
 function jsonPointerValue(value, pointer) {
@@ -200,6 +304,47 @@ describe('remote API contract', () => {
         expect(sourceValue, pointer).toEqual(canonicalValue);
       }
     }
+  });
+
+  it('keeps getEventInfo bearer-only and audits empty security alternatives', () => {
+    const security = spec.paths['/getEventInfo'].post.security;
+    expect(security).toEqual([{ firebaseBearer: [] }]);
+    const hypotheticalSecurity = [...security, {}];
+    expect(materialClaimPointers(
+      hypotheticalSecurity,
+      '#/paths/~1getEventInfo/post/security',
+      'security',
+    )).toContain('#/paths/~1getEventInfo/post/security/1');
+    expect(evidence.readObservation.getEventInfo).toMatchObject({
+      selectedSignedOutStatus: 200,
+      signedOutScope: 'selected-readable-event-only',
+    });
+  });
+
+  it('reports twelve observed 200 statuses and eleven typed 200 bodies', () => {
+    const withObserved200 = operations()
+      .filter(({ operation }) => operation.responses['200'])
+      .map(({ operation }) => operation.operationId)
+      .sort();
+    const withTyped200Body = operations()
+      .filter(({ operation }) => operation.responses['200']?.content)
+      .map(({ operation }) => operation.operationId)
+      .sort();
+    expect(withObserved200).toHaveLength(12);
+    expect(withTyped200Body).toHaveLength(11);
+    expect(withObserved200.filter((id) => !withTyped200Body.includes(id)))
+      .toEqual(['sendAuthCodeTrusted']);
+
+    const ledger = fs.readFileSync(
+      'docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md',
+      'utf8',
+    );
+    expect(ledger).toContain(
+      'Twelve operations have an observed HTTP `200` status.',
+    );
+    expect(ledger).toMatch(
+      /Eleven of those\s+operations have a typed `200` response body\./,
+    );
   });
 
   it('contains remote transport facts rather than product or implementation policy', () => {
@@ -402,10 +547,10 @@ describe('remote API contract', () => {
       const start = ledger.indexOf(marker);
       expect(start, heading).toBeGreaterThanOrEqual(0);
       const section = ledger.slice(start + marker.length).split(/\n#{2,6} /)[0];
-      return [...section.matchAll(/`([^`]+)`/g)]
+      const operationIds = [...section.matchAll(/`([^`]+)`/g)]
         .map((match) => match[1])
-        .filter((operationId) => knownOperationIds.has(operationId))
-        .sort();
+        .filter((operationId) => knownOperationIds.has(operationId));
+      return [...new Set(operationIds)].sort();
     };
     for (const [heading, classification] of [
       ['Dated-live operations', 'dated-live-observation'],
@@ -608,7 +753,7 @@ describe('remote API contract', () => {
     expect(eventInfo.responses['404'].content['application/json'].schema)
       .toEqual({ $ref: '#/components/schemas/CallableNotFoundError' });
     expect(eventInfo.responses['200'].description).toContain('selected readable event');
-    expect(eventInfo.responses['200'].description).toContain('signed out');
+    expect(eventInfo.responses['200'].description).not.toContain('signed out');
     expect(spec.components.schemas.EventInfo.properties).toMatchObject({
       id: { type: 'string' },
       title: { type: 'string' },
@@ -738,6 +883,8 @@ describe('remote API contract', () => {
 
     expect(evidence.operationClaims.getContacts.request)
       .toBe('reviewed-first-party-repository-research');
+    expect(citationResolves(evidence.sources.publicContactDeduplication20260811))
+      .toBe(true);
     expect(evidence.readObservation.contacts).toMatchObject({
       catalogCount: 2451,
       runPageItemCounts: [[1000, 1000, 451, 0], [1000, 1000, 451, 0]],
@@ -753,15 +900,30 @@ describe('remote API contract', () => {
       signedOutCode: 'UNAUTHENTICATED',
       normalParams: {},
       useAuthUserBehavior: 'explicit-unknown',
+      clientDeduplication: {
+        classification: 'reviewed-first-party-repository-research',
+        citation: evidence.sources.publicContactDeduplication20260811,
+        identityField: 'id',
+        duplicateResolution: 'first-occurrence-wins',
+      },
+      rateLimiting: 'explicit-unknown',
+      futureCatalogCompleteness: 'explicit-unknown',
+      serverDuplicateBehavior: 'explicit-unknown',
+      serverOrderingBehavior: 'explicit-unknown',
     });
-    expect(evidence.readObservation.contacts.unknowns).toEqual(expect.arrayContaining([
+    expect(evidence.readObservation.contacts.unknowns).toEqual([
       'invalid-cursor behavior',
       'cursor lifetime and reuse',
       'backend ordering key',
       'snapshot behavior',
       'useAuthUser behavior',
       'duplicates outside the two observations',
-    ]));
+      'rate limiting',
+      'future catalog completeness',
+    ]);
+    expect(evidence.unresolvedUncertainty).toContain(
+      'Contact invalid-cursor behavior, cursor lifetime and reuse, ordering key, snapshot behavior, useAuthUser, rate limiting, unsupported statuses, future catalog completeness, server duplicate behavior, and duplicates outside two traversals remain unknown.',
+    );
     const artifactContacts = readEvidence.aggregates.contacts;
     expect(artifactContacts.firstCount).toBe(evidence.readObservation.contacts.catalogCount);
     expect(artifactContacts.secondCount).toBe(evidence.readObservation.contacts.catalogCount);
@@ -859,6 +1021,26 @@ describe('remote API contract', () => {
           expect(safePathSegments.has(segment), shape.path).toBe(true);
         }
       }
+    }
+    assertExactAllowlistedValue(readEvidence.aggregates, expectedReadAggregates);
+    for (const mutate of [
+      (aggregates) => {
+        aggregates.contacts.rawContactName = 'synthetic-private-name';
+      },
+      (aggregates) => {
+        aggregates.contacts.rawContactId = 'synthetic-private-id';
+      },
+      (aggregates) => {
+        aggregates.selectedEventProjection.source = 'synthetic-private-id';
+      },
+      (aggregates) => {
+        aggregates.contacts.remoteFiltering.reason = 'synthetic-private-name';
+      },
+    ]) {
+      const mutated = structuredClone(readEvidence.aggregates);
+      mutate(mutated);
+      expect(() => assertExactAllowlistedValue(mutated, expectedReadAggregates))
+        .toThrow();
     }
 
     expect(readEvidence.aggregates.failureDistinctions).toMatchObject({

--- a/tests/remote-api-contract.test.js
+++ b/tests/remote-api-contract.test.js
@@ -241,7 +241,7 @@ describe('remote API contract', () => {
     expect(spec.openapi).toBe('3.1.0');
     expect(evidence.contractRevision).toBe('2026-08-11.5');
     expect(spec.info.version).toBe(evidence.contractRevision);
-    expect(evidence.status).toBe('proposed');
+    expect(evidence.status).toBe('owner-reviewed');
     const ids = operations().map(({ operation }) => operation.operationId);
     expect(ids).toHaveLength(27);
     expect(new Set(ids).size).toBe(ids.length);
@@ -1133,7 +1133,7 @@ describe('remote API contract', () => {
     expect(evidence.readObservation.artifactPath).toBe(readEvidencePath);
   });
 
-  it('keeps the proposed revision status aligned in human contract surfaces', () => {
+  it('keeps the approved remote revision separate from the shipped revision', () => {
     const productContract = fs.readFileSync(
       'docs/CLI-PRODUCT-CONTRACT.md',
       'utf8',
@@ -1157,7 +1157,7 @@ describe('remote API contract', () => {
     expect(documentedRevision).toBe(shippedRevision);
     expect(new Set(envelopeRevisions)).toEqual(new Set([shippedRevision]));
     expect(spec.info.version).toBe('2026-08-11.5');
-    expect(evidence.status).toBe('proposed');
+    expect(evidence.status).toBe('owner-reviewed');
     expect(spec.info.version).not.toBe(shippedRevision);
     expect(productContract)
       .not.toContain('currently leaves every operation response status and body unknown');

--- a/tests/remote-api-contract.test.js
+++ b/tests/remote-api-contract.test.js
@@ -6,7 +6,12 @@ import spec from '../spec/partiful.openapi.json';
 
 const historicalDraftPath = 'spec/research/historical-27-operation-draft.json';
 const historicalDraft = JSON.parse(fs.readFileSync(historicalDraftPath, 'utf8'));
-const sourceCache = new Map([[historicalDraftPath, historicalDraft]]);
+const readEvidencePath = 'spec/research/read-evidence-redacted-20260811.json';
+const readEvidence = JSON.parse(fs.readFileSync(readEvidencePath, 'utf8'));
+const sourceCache = new Map([
+  [historicalDraftPath, historicalDraft],
+  [readEvidencePath, readEvidence],
+]);
 const unsafeAuthSourcePath = 'docs/research/2026-03-24-auth-flow-endpoints.md';
 const safeFirebaseKeySource =
   'docs/research/2026-08-11-firebase-public-api-key-redacted.md#firebase-public-api-key';
@@ -130,9 +135,9 @@ function citationResolves(citation) {
 describe('remote API contract', () => {
   it('is a consistently versioned OpenAPI 3.1 document with unique operation IDs', () => {
     expect(spec.openapi).toBe('3.1.0');
-    expect(evidence.contractRevision).toBe('2026-08-11.4');
+    expect(evidence.contractRevision).toBe('2026-08-11.5');
     expect(spec.info.version).toBe(evidence.contractRevision);
-    expect(evidence.status).toBe('owner-reviewed');
+    expect(evidence.status).toBe('proposed');
     const ids = operations().map(({ operation }) => operation.operationId);
     expect(ids).toHaveLength(27);
     expect(new Set(ids).size).toBe(ids.length);
@@ -158,6 +163,13 @@ describe('remote API contract', () => {
         'signInWithCustomToken',
         'refreshToken',
         'lookupFirebaseUser',
+        'getMyUpcomingEventsForHomePage',
+        'getMyPastEventsForHomePage',
+        'getEventInfo',
+        'getCurrentGuest',
+        'firestoreGetEvent',
+        'firestoreGetGuest',
+        'getContacts',
       ]);
       expect(claim.status).toBe(
         observedStatusOps.has(operation.operationId)
@@ -171,7 +183,7 @@ describe('remote API contract', () => {
       ...materialClaimPointers(spec.paths, '#/paths', 'paths'),
       ...materialClaimPointers(spec.components, '#/components', 'components'),
     ]);
-    expect(pointers).toHaveLength(1008);
+    expect(pointers).toHaveLength(1249);
     for (const pointer of pointers) {
       const claim = evidence.claims[pointer];
       expect(claim, pointer).toBeDefined();
@@ -217,12 +229,26 @@ describe('remote API contract', () => {
       'signInWithCustomToken',
       'refreshToken',
       'lookupFirebaseUser',
+      'getMyUpcomingEventsForHomePage',
+      'getMyPastEventsForHomePage',
+      'getEventInfo',
+      'getCurrentGuest',
+      'firestoreGetEvent',
+      'firestoreGetGuest',
+      'getContacts',
     ]);
     const observedErrorOps = {
       getLoginToken: ['200', '403', 'default'],
       signInWithCustomToken: ['200', '400', 'default'],
       refreshToken: ['200', '400', 'default'],
       lookupFirebaseUser: ['200', '400', 'default'],
+      getMyUpcomingEventsForHomePage: ['200', 'default'],
+      getMyPastEventsForHomePage: ['200', 'default'],
+      getEventInfo: ['200', '404', 'default'],
+      getCurrentGuest: ['200', 'default'],
+      firestoreGetEvent: ['403', 'default'],
+      firestoreGetGuest: ['200', 'default'],
+      getContacts: ['200', '401', 'default'],
     };
     for (const { operation } of operations()) {
       if (observedStatusOps.has(operation.operationId)) {
@@ -257,6 +283,13 @@ describe('remote API contract', () => {
       'signInWithCustomToken',
       'refreshToken',
       'lookupFirebaseUser',
+      'getMyUpcomingEventsForHomePage',
+      'getMyPastEventsForHomePage',
+      'getEventInfo',
+      'getCurrentGuest',
+      'firestoreGetEvent',
+      'firestoreGetGuest',
+      'getContacts',
     ]);
     const observedResponseSources = new Map([
       ['getPosterCatalog', evidence.sources.posterCatalogObservation],
@@ -265,6 +298,13 @@ describe('remote API contract', () => {
       ['signInWithCustomToken', evidence.sources.authSignIn20260811],
       ['refreshToken', evidence.sources.authRefresh20260811],
       ['lookupFirebaseUser', evidence.sources.authLookup20260811],
+      ['getMyUpcomingEventsForHomePage', evidence.sources.readEventLists20260811],
+      ['getMyPastEventsForHomePage', evidence.sources.readEventLists20260811],
+      ['getEventInfo', evidence.sources.readEventInfo20260811],
+      ['getCurrentGuest', evidence.sources.readGuestFirestore20260811],
+      ['firestoreGetEvent', evidence.sources.readGuestFirestore20260811],
+      ['firestoreGetGuest', evidence.sources.readGuestFirestore20260811],
+      ['getContacts', evidence.sources.readContacts20260811],
     ]);
     for (const { path, method, operation } of operations()) {
       const base = `#/paths/${escapePointerSegment(path)}/${method}/responses/default`;
@@ -474,6 +514,267 @@ describe('remote API contract', () => {
       malformedSuccess: 'contract.protocol_changed',
       rateLimiting: 'not-claimed',
     });
+  });
+
+  it('formalizes the observed one-response event lists without inventing remote pagination', () => {
+    const cases = [
+      {
+        operationId: 'getMyUpcomingEventsForHomePage',
+        path: '/getMyUpcomingEventsForHomePage',
+        rawField: 'upcomingEvents',
+        count: 35,
+      },
+      {
+        operationId: 'getMyPastEventsForHomePage',
+        path: '/getMyPastEventsForHomePage',
+        rawField: 'pastEvents',
+        count: 294,
+      },
+    ];
+
+    for (const { operationId, path: operationPath, rawField, count } of cases) {
+      const operation = spec.paths[operationPath].post;
+      const response = operation.responses['200'].content['application/json'].schema;
+      const array = response.properties.result.properties.data.properties[rawField];
+      expect(array.type).toBe('array');
+      expect(array.items).toEqual({ $ref: '#/components/schemas/HomePageEvent' });
+      expect(response.properties.result.properties.data.properties)
+        .not.toHaveProperty('paging');
+      expect(operation.requestBody.content['application/json'].schema.properties.data.properties)
+        .not.toHaveProperty('paging');
+      expect(evidence.operationClaims[operationId]).toMatchObject({
+        request: 'typescript-derived-inference',
+        response: 'dated-live-observation',
+        status: 'dated-live-observation',
+      });
+      expect(evidence.readObservation.eventLists[rawField]).toMatchObject({
+        rawPath: `result.data.${rawField}`,
+        firstCount: count,
+        secondCount: count,
+        sameIdentitySequence: true,
+        duplicateIdentityCount: 0,
+        representation: 'one-response-observed-complete-array',
+        remotePagination: 'explicit-unknown',
+      });
+    }
+
+    expect(spec.components.schemas.HomePageEvent).toMatchObject({
+      type: 'object',
+      required: ['id'],
+      properties: {
+        id: { type: 'string' },
+        title: { type: 'string' },
+        startDate: { type: 'string' },
+        endDate: { type: ['string', 'null'] },
+        timezone: { type: 'string' },
+        status: { type: 'string' },
+        location: { type: ['string', 'null'] },
+        displaySettings: { type: 'object' },
+        image: { type: ['object', 'null'] },
+        guest: {
+          type: 'object',
+          properties: { status: { type: 'string' } },
+        },
+      },
+    });
+    expect(evidence.readObservation.productProjection).toMatchObject({
+      eventId: 'supported-by-complete-item-id',
+      titleStartEndTimezone: 'observed-types-only-presence-not-proven',
+      myRsvp: 'selected-item-guest-status-observed',
+      stateMapping: 'explicit-unknown',
+      userRoleMapping: 'explicit-unknown',
+    });
+  });
+
+  it('formalizes only the observed event-detail and guest read variants', () => {
+    const eventInfo = spec.paths['/getEventInfo'].post;
+    expect(Object.keys(eventInfo.responses).sort()).toEqual(['200', '404', 'default']);
+    expect(eventInfo.responses['200'].content['application/json'].schema)
+      .toEqual({ $ref: '#/components/schemas/GetEventInfoResponse' });
+    expect(eventInfo.responses['404'].content['application/json'].schema)
+      .toEqual({ $ref: '#/components/schemas/CallableNotFoundError' });
+    expect(eventInfo.responses['200'].description).toContain('selected readable event');
+    expect(eventInfo.responses['200'].description).toContain('signed out');
+    expect(spec.components.schemas.EventInfo.properties).toMatchObject({
+      id: { type: 'string' },
+      title: { type: 'string' },
+      startDate: { type: 'string' },
+      endDate: { type: 'null' },
+      timezone: { type: 'string' },
+      status: { type: 'string' },
+      description: { type: 'string' },
+      displaySettings: { type: 'object' },
+      image: { type: 'object' },
+      visibility: { type: 'string' },
+    });
+    expect(evidence.readObservation.getEventInfo).toMatchObject({
+      selectedAuthenticatedStatus: 200,
+      selectedSignedOutStatus: 200,
+      signedOutScope: 'selected-readable-event-only',
+      syntheticMissingStatus: 404,
+      syntheticMissingCode: 'NOT_FOUND',
+      authenticatedPermission: 'not-observed',
+      inaccessibleEvent: 'not-observed',
+    });
+
+    const currentGuest = spec.paths['/getCurrentGuest'].post.responses['200']
+      .content['application/json'].schema;
+    expect(currentGuest).toEqual({ $ref: '#/components/schemas/GetCurrentGuestResponse' });
+    const currentGuestProperty = spec.components.schemas.GetCurrentGuestResponse
+      .properties.result.properties.data.properties.currentGuest;
+    expect(currentGuestProperty.anyOf)
+      .toContainEqual({ $ref: '#/components/schemas/CurrentGuest' });
+    expect(spec.components.schemas.GetCurrentGuestResponse.properties.result
+      .properties.data.required ?? [])
+      .not.toContain('currentGuest');
+    expect(spec.components.schemas.CurrentGuest).toMatchObject({
+      required: ['id', 'count', 'name', 'plusOnes', 'status', 'userId'],
+      properties: {
+        id: { type: 'string' },
+        count: { type: 'integer' },
+        name: { type: 'string' },
+        plusOnes: { type: 'null' },
+        status: { type: 'string' },
+        userId: { type: 'string' },
+      },
+    });
+    expect(evidence.readObservation.getCurrentGuest.otherVariants)
+      .toBe('explicit-unknown');
+    expect(evidence.readObservation.getCurrentGuest.currentGuestNullability)
+      .toBe('explicit-unknown');
+  });
+
+  it('distinguishes the observed Firestore guest success from event-document denial', () => {
+    const guest = spec.paths[
+      '/v1/projects/getpartiful/databases/(default)/documents/events/{eventId}/guests/{guestId}'
+    ].get;
+    expect(guest.responses['200'].content['application/json'].schema)
+      .toEqual({ $ref: '#/components/schemas/FirestoreGuestDocument' });
+    expect(spec.components.schemas.FirestoreGuestDocument).toMatchObject({
+      required: ['name', 'fields', 'createTime', 'updateTime'],
+      properties: {
+        fields: {
+          type: 'object',
+          required: ['count', 'createdAt', 'name', 'status'],
+        },
+      },
+    });
+    expect(evidence.readObservation.firestoreGuest).toMatchObject({
+      status: 200,
+      documentIdMatchesCurrentGuestId: true,
+      statusMatchesCurrentGuest: true,
+    });
+
+    const event = spec.paths[
+      '/v1/projects/getpartiful/databases/(default)/documents/events/{eventId}'
+    ].get;
+    expect(Object.keys(event.responses).sort()).toEqual(['403', 'default']);
+    expect(event.responses['403'].content['application/json'].schema)
+      .toEqual({ $ref: '#/components/schemas/FirestorePermissionDeniedError' });
+    expect(evidence.readObservation.firestoreEvent).toMatchObject({
+      selectedReadableEventStatus: 403,
+      syntheticMissingIdStatus: 403,
+      normalizedCode: 'PERMISSION_DENIED',
+      attendeeDenial: 'not-claimed',
+      notFoundBehavior: 'explicit-unknown',
+    });
+  });
+
+  it('formalizes exact contact cursor traversal and keeps identity private', () => {
+    const operation = spec.paths['/getContacts'].post;
+    const requestData = operation.requestBody.content['application/json'].schema
+      .properties.data;
+    expect(requestData.required).toEqual(expect.arrayContaining(['params', 'paging']));
+    expect(requestData.properties.params).toEqual({
+      type: 'object',
+      properties: {
+        useAuthUser: { type: 'boolean' },
+      },
+      additionalProperties: false,
+    });
+    expect(requestData.properties.params.required ?? []).not.toContain('useAuthUser');
+    expect(requestData.properties.paging).toEqual({
+      type: 'object',
+      required: ['maxResults', 'cursor'],
+      properties: {
+        maxResults: { type: 'integer', const: 1000 },
+        cursor: { type: ['string', 'null'] },
+      },
+      additionalProperties: false,
+    });
+
+    expect(operation.responses['200'].content['application/json'].schema)
+      .toEqual({ $ref: '#/components/schemas/GetContactsResponse' });
+    expect(operation.responses['401'].content['application/json'].schema)
+      .toEqual({ $ref: '#/components/schemas/CallableUnauthenticatedError' });
+    expect(spec.components.schemas.GetContactsResponse.properties.result
+      .properties.paging.properties.nextCursor)
+      .toEqual({ type: 'string' });
+    expect(spec.components.schemas.GetContactsResponse.properties.result
+      .properties.paging.required ?? [])
+      .not.toContain('nextCursor');
+    expect(spec.components.schemas.Contact).toMatchObject({
+      required: ['id', 'name', 'sharedEventCount'],
+      properties: {
+        id: { type: 'string' },
+        name: { type: 'string' },
+        sharedEventCount: { type: 'integer', minimum: 0 },
+      },
+    });
+
+    expect(evidence.operationClaims.getContacts.request)
+      .toBe('reviewed-first-party-repository-research');
+    expect(evidence.readObservation.contacts).toMatchObject({
+      catalogCount: 2451,
+      runPageItemCounts: [[1000, 1000, 451, 0], [1000, 1000, 451, 0]],
+      dataPageNextCursorType: 'string',
+      terminalNextCursor: 'missing',
+      sameIdentitySequence: true,
+      sameIdentitySet: true,
+      duplicateIdentityCount: 0,
+      filtering: 'client-side-name-filter-over-complete-traversed-catalog',
+      publicProjection: ['displayName', 'sharedEventCount'],
+      privateIdentityField: 'id',
+      signedOutStatus: 401,
+      signedOutCode: 'UNAUTHENTICATED',
+      normalParams: {},
+      useAuthUserBehavior: 'explicit-unknown',
+    });
+    expect(evidence.readObservation.contacts.unknowns).toEqual(expect.arrayContaining([
+      'invalid-cursor behavior',
+      'cursor lifetime and reuse',
+      'backend ordering key',
+      'snapshot behavior',
+      'useAuthUser behavior',
+      'duplicates outside the two observations',
+    ]));
+  });
+
+  it('keeps the read artifact sanitized and corrects unsupported failure labels', () => {
+    expect(readEvidence.aggregates.failureDistinctions).toMatchObject({
+      permissionProbeObserved: false,
+      signedOutEventObserved: true,
+      signedOutContactsObserved: true,
+      callableNotFoundObserved: true,
+      firestoreNotFoundObserved: false,
+    });
+    expect(readEvidence.aggregates.failureDistinctions)
+      .not.toHaveProperty('callablePermissionDiffersFromNotFound', true);
+    expect(readEvidence.aggregates.failureDistinctions)
+      .not.toHaveProperty('firestorePermissionDiffersFromNotFound', true);
+
+    const serialized = JSON.stringify(readEvidence);
+    for (const unsafe of [
+      /(?<![\w])\+[1-9]\d{9,14}(?!\d)/,
+      /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/i,
+      /\beyJ[A-Za-z0-9_-]{12,}\.[A-Za-z0-9_-]{8,}\./,
+      /"(?:eventId|guestId|userId|id|name)"\s*:\s*"[^"]+"/,
+      /"(?:accessToken|refreshToken|authorization|credential)"\s*:/i,
+    ]) {
+      expect(serialized).not.toMatch(unsafe);
+    }
+    expect(readEvidence.redaction).toContain('No other body values');
+    expect(evidence.readObservation.artifactPath).toBe(readEvidencePath);
   });
 
   it('captures the observed authentication response shapes from the attended session', () => {

--- a/tests/remote-api-contract.test.js
+++ b/tests/remote-api-contract.test.js
@@ -556,6 +556,20 @@ describe('remote API contract', () => {
         representation: 'one-response-observed-complete-array',
         remotePagination: 'explicit-unknown',
       });
+      const artifactList = readEvidence.aggregates.eventLists[
+        rawField === 'upcomingEvents' ? 'upcoming' : 'past'
+      ];
+      expect(artifactList).toMatchObject({
+        firstCount: count,
+        secondCount: count,
+        sameIdentitySequence: true,
+        sameIdentitySet: true,
+        duplicateIdentityCount: 0,
+      });
+      expect(evidence.readObservation.eventLists[rawField].firstCount)
+        .toBe(artifactList.firstCount);
+      expect(evidence.readObservation.eventLists[rawField].secondCount)
+        .toBe(artifactList.secondCount);
     }
 
     expect(spec.components.schemas.HomePageEvent).toMatchObject({
@@ -748,9 +762,105 @@ describe('remote API contract', () => {
       'useAuthUser behavior',
       'duplicates outside the two observations',
     ]));
+    const artifactContacts = readEvidence.aggregates.contacts;
+    expect(artifactContacts.firstCount).toBe(evidence.readObservation.contacts.catalogCount);
+    expect(artifactContacts.secondCount).toBe(evidence.readObservation.contacts.catalogCount);
+    expect([
+      artifactContacts.pagination.firstRunPageItemCounts,
+      artifactContacts.pagination.secondRunPageItemCounts,
+    ]).toEqual(evidence.readObservation.contacts.runPageItemCounts);
+    expect(artifactContacts.pagination.firstRunPageItemCounts.reduce(
+      (total, pageCount) => total + pageCount,
+      0,
+    )).toBe(artifactContacts.firstCount);
   });
 
   it('keeps the read artifact sanitized and corrects unsupported failure labels', () => {
+    expect(Object.keys(readEvidence).sort()).toEqual([
+      'aggregates',
+      'observations',
+      'observedAt',
+      'probeMethod',
+      'purpose',
+      'redaction',
+    ]);
+    expect(readEvidence.observedAt).toBe(evidence.readObservation.observedAt);
+    expect(readEvidence.purpose)
+      .toBe('Privacy-safe Partiful event-read and contact remote-contract evidence');
+    expect(readEvidence.probeMethod)
+      .toBe('Owner-attended authenticated read-only calls. No mutation, retry, pagination guess, or rate-limit probe.');
+    expect(readEvidence.redaction)
+      .toBe('Only HTTP metadata, normalized JSON paths/types, allowlisted stable error codes, collection counts, and equality/projection facts are retained. No other body values, credentials, identities, names, event IDs, or contact details are written.');
+    const safeEndpoints = new Map([
+      ['getMyUpcomingEventsForHomePage', '/getMyUpcomingEventsForHomePage'],
+      ['getMyPastEventsForHomePage', '/getMyPastEventsForHomePage'],
+      ['getEventInfo', '/getEventInfo'],
+      ['getCurrentGuest', '/getCurrentGuest'],
+      ['getContacts', '/getContacts'],
+      [
+        'firestoreGetEvent',
+        '/v1/projects/getpartiful/databases/(default)/documents/events/{eventId}',
+      ],
+      [
+        'firestoreGetGuest',
+        '/v1/projects/getpartiful/databases/(default)/documents/events/{eventId}/guests/{guestId}',
+      ],
+    ]);
+    const safePhases = new Set([
+      'authenticated-first',
+      'authenticated-repeat',
+      'authenticated-first-page-1',
+      'authenticated-first-page-2',
+      'authenticated-first-page-3',
+      'authenticated-first-page-4',
+      'authenticated-repeat-page-1',
+      'authenticated-repeat-page-2',
+      'authenticated-repeat-page-3',
+      'authenticated-repeat-page-4',
+      'authenticated-selected-event',
+      'authenticated-synthetic-not-found',
+      'signed-out',
+      'signed-out-readable-event',
+    ]);
+    const safePathSegments = new Set([
+      '*', '[]', 'blurHash', 'code', 'contentType', 'count', 'createTime',
+      'createdAt', 'data', 'description', 'displaySettings', 'endDate', 'error',
+      'event', 'eventId', 'fields', 'height', 'id', 'image', 'images',
+      'location', 'message', 'name', 'nextCursor', 'paging', 'plusOnes',
+      'result', 'source', 'startDate', 'status', 'text', 'timezone', 'title',
+      'updateTime', 'url', 'userId', 'visibility', 'width',
+    ]);
+    const safeShapeTypes = new Set([
+      'array', 'boolean', 'integer', 'null', 'number', 'object', 'string',
+    ]);
+    for (const observation of readEvidence.observations) {
+      expect(Object.keys(observation).sort()).toEqual([
+        'bodyBytes',
+        'bodyKind',
+        'contentType',
+        'endpoint',
+        'normalizedErrorCode',
+        'operation',
+        'phase',
+        'shape',
+        'status',
+        'unknownKeyCount',
+      ]);
+      expect(observation.endpoint).toBe(safeEndpoints.get(observation.operation));
+      expect(safePhases.has(observation.phase)).toBe(true);
+      expect(observation.bodyKind).toBe('json');
+      expect(observation.contentType).toBe('application/json; charset=utf-8');
+      expect([null, 'NOT_FOUND', 'PERMISSION_DENIED', 'UNAUTHENTICATED'])
+        .toContain(observation.normalizedErrorCode);
+      for (const shape of observation.shape) {
+        expect(Object.keys(shape).sort()).toEqual(['path', 'type']);
+        expect(safeShapeTypes.has(shape.type)).toBe(true);
+        for (const segment of shape.path.split('.')) {
+          expect(safePathSegments.has(segment), shape.path).toBe(true);
+        }
+      }
+    }
+
     expect(readEvidence.aggregates.failureDistinctions).toMatchObject({
       permissionProbeObserved: false,
       signedOutEventObserved: true,
@@ -775,6 +885,28 @@ describe('remote API contract', () => {
     }
     expect(readEvidence.redaction).toContain('No other body values');
     expect(evidence.readObservation.artifactPath).toBe(readEvidencePath);
+  });
+
+  it('keeps the proposed revision status aligned in human contract surfaces', () => {
+    const productContract = fs.readFileSync(
+      'docs/CLI-PRODUCT-CONTRACT.md',
+      'utf8',
+    );
+    const contactResearch = fs.readFileSync(
+      'docs/research/2026-08-11-contacts-pagination-public-assets.md',
+      'utf8',
+    );
+
+    expect(productContract)
+      .not.toContain('currently leaves every operation response status and body unknown');
+    expect(contactResearch)
+      .not.toContain('The owner-reviewed remote contract still permits');
+    expect(contactResearch)
+      .not.toContain('Owner-attended authenticated observation is still required');
+    expect(contactResearch).toMatch(
+      /previous owner-reviewed remote contract[\s\S]+2026-08-11\.4/,
+    );
+    expect(contactResearch).toMatch(/Proposed revision `2026-08-11\.5`/);
   });
 
   it('captures the observed authentication response shapes from the attended session', () => {


### PR DESCRIPTION
## Summary

- Proposes remote contract revision `2026-08-11.5` for the read evidence needed by #164 and #165.
- Adds the sanitized owner-attended artifact and the public first-party contact paging research.
- Aligns the OpenAPI contract, evidence ledger, human contract surfaces, and semantic tests.
- Keeps the revision `proposed`; it is not owner-reviewed.

## Exact evidence

### Event and guest reads

- Upcoming and past event lists returned HTTP 200 at `result.data.upcomingEvents` and `result.data.pastEvents`, with 35 and 294 items.
- Immediate repeats had the same counts, identity sequences, and identity sets, with no observed duplicate identity.
- `getEventInfo` returned HTTP 200 for one selected readable event, including while signed out.
- A synthetic missing event returned HTTP 404 with `NOT_FOUND`.
- `getCurrentGuest` returned HTTP 200 for the selected event.
- The selected Firestore guest document returned HTTP 200, matched the callable guest identity, and had equal guest status.
- Firestore event reads returned HTTP 403 with `PERMISSION_DENIED` for both the selected readable ID and a synthetic ID.
- No inaccessible-event permission probe was available.

### Contact reads

- Two authenticated traversals each returned 2,451 contacts in pages of 1000, 1000, and 451, followed by an empty terminal sentinel.
- Data pages had string `nextCursor` values; the terminal response omitted `nextCursor`.
- Both traversals had the same identity sequence and set, with no observed duplicate identity.
- Every observed contact had string private identity and name fields plus a nonnegative integer shared-event count.
- Signed-out `getContacts` returned HTTP 401 with `UNAUTHENTICATED`.
- Current first-party public assets establish sibling `params`/`paging`, `maxResults: 1000`, sequential cursor traversal, and local name filtering.

## Remaining unknowns and implementation gates

- #164 still needs reviewed product mappings for event state, full role and RSVP projection, list-field completeness, list failure behavior, and a safe permission/not-found distinction for inaccessible events. List ordering, limits, pagination, and snapshot behavior remain unknown. Current-guest null/alternate variants and Firestore event success/not-found/attendee behavior also remain unknown.
- #165 still needs a reviewed safe bound for future complete-catalog traversal and mappings for unsupported failures. Invalid cursors, cursor lifetime/reuse, backend ordering, snapshot behavior, `useAuthUser`, rate limiting, future completeness, and duplicates outside the two traversals remain unknown. Local ambiguity behavior still needs synthetic fixture coverage during implementation.
- Owner review and merge of this proposed contract revision are required before either Go slice can use it as authority.

## Privacy

The committed artifact contains only allowlisted HTTP metadata, normalized paths and types, counts, equality facts, and stable error codes. It contains no raw private values, credentials, identities, names, event IDs, contact details, phone numbers, email addresses, or tokens.

## Validation

- `TZ=America/Los_Angeles npm test -- --run tests/remote-api-contract.test.js tests/drift.test.js` — 34 passed
- `TZ=America/Los_Angeles npm test -- --exclude='tests/*-integration.test.js' --exclude='tests/smoke-real-api.test.js'` — 290 passed; no live tests run
- `npm run typecheck` — passed
- `go test -race ./...` — passed
- `go vet ./...` — passed
- `go build ./...` — passed
- `go mod verify` — passed
- `git diff --check origin/main...HEAD` — passed
- Repository PII guard on the sanitized artifact, evidence notes, OpenAPI contract, and evidence ledger — passed

Related to #164 and #165. Do not merge until independent review is complete.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the remote API contract to proposed revision 2026-08-11.5.
  * Added evidence for event, guest, contact, and Firestore reads, including authentication, pagination, filtering, and known limitations.
  * Added research notes covering contact pagination and authenticated read behavior.
  * Clarified implementation-gate requirements for observed and unknown response mappings.

* **API Reference**
  * Expanded documented success and error responses and added structured schemas.
  * Documented contact paging requirements and authentication options.

* **Tests**
  * Added validation for response behavior, pagination, privacy redaction, and contract evidence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->