### PR TITLE
feat(contacts): add bounded private-safe listings

### DIFF
--- a/docs/CLI-PRODUCT-CONTRACT.md
+++ b/docs/CLI-PRODUCT-CONTRACT.md
@@ -2,7 +2,7 @@
 
 **Status:** Approved product contract  
 **Product contract revision:** `2026-08-10.1`  
-**Remote API contract revision:** `2026-08-11.4`
+**Remote API contract revision:** `2026-08-11.5`
 
 This document defines the public behavior of the greenfield Go `partiful` CLI.
 It is the authority for commands, inputs, JSON outputs, failures, and mutation
@@ -78,7 +78,7 @@ Every successful command returns:
     "command": "events.get",
     "cliVersion": "1.0.0",
     "productContractRevision": "2026-08-10.1",
-    "remoteContractRevision": "2026-08-11.4",
+    "remoteContractRevision": "2026-08-11.5",
     "warnings": []
   }
 }
@@ -102,7 +102,7 @@ Every failed command returns:
     "command": "guests.list",
     "cliVersion": "1.0.0",
     "productContractRevision": "2026-08-10.1",
-    "remoteContractRevision": "2026-08-11.4"
+    "remoteContractRevision": "2026-08-11.5"
   }
 }
 ```
@@ -150,7 +150,7 @@ Collection commands return:
     "command": "events.list",
     "cliVersion": "1.0.0",
     "productContractRevision": "2026-08-10.1",
-    "remoteContractRevision": "2026-08-11.4",
+    "remoteContractRevision": "2026-08-11.5",
     "warnings": [],
     "page": {
       "limit": 25,
@@ -203,7 +203,7 @@ remote mutation:
     "command": "events.update",
     "cliVersion": "1.0.0",
     "productContractRevision": "2026-08-10.1",
-    "remoteContractRevision": "2026-08-11.4",
+    "remoteContractRevision": "2026-08-11.5",
     "warnings": []
   }
 }
@@ -509,6 +509,17 @@ is:
 
 No command returns contact phone numbers, email addresses, or Partiful user
 IDs.
+
+The CLI traverses contact pages sequentially, keeps the first occurrence of
+each private contact identity, and then applies the name filter locally.
+Private identity remains internal.
+
+Contact traversal permits at most three nonempty pages and 3,000 transport
+items, then requires the empty terminal sentinel. This client execution bound
+uses the reviewed 1,000-item request size and observed traversal. It does not
+claim future remote completeness. A repeated remote cursor, data beyond the
+bound, or a missing empty sentinel fails with `contract.protocol_changed`; the
+CLI does not return a truncated collection as complete.
 
 ### Cohosts
 

--- a/docs/research/2026-08-11-contacts-pagination-public-assets.md
+++ b/docs/research/2026-08-11-contacts-pagination-public-assets.md
@@ -128,7 +128,7 @@ Sources:
 The previous owner-reviewed remote contract, revision `2026-08-11.4`, permits
 only empty request `params` and keeps response/status behavior unknown.
 Owner-reviewed revision `2026-08-11.5` incorporates this paging request research and
-the separate authenticated response observation. It remains proposed.
+the separate authenticated response observation.
 
 Sources:
 `spec/partiful.openapi.json#/paths/~1getContacts/post`;

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -202,12 +202,16 @@ var commandCatalog = []commandDefinition{
 		safety: readOnlySafety(),
 	},
 	{
-		path:          "contacts.list",
-		invocation:    []string{"contacts", "list"},
-		kind:          contactsListCommand,
-		positionals:   []positionalDefinition{},
-		flags:         collectionFlagDefinitions(),
-		inputSchema:   collectionInputSchema(false),
+		path:        "contacts.list",
+		invocation:  []string{"contacts", "list"},
+		kind:        contactsListCommand,
+		positionals: []positionalDefinition{},
+		flags: append([]flagDefinition{{
+			Name:        "--query",
+			Description: "Optional non-empty contact name filter.",
+			TakesValue:  true,
+		}}, collectionFlagDefinitions()...),
+		inputSchema:   contactCollectionInputSchema(),
 		successSchema: contactCollectionSuccessSchema(),
 		failureTypes: []string{
 			"auth.required",
@@ -405,6 +409,13 @@ func collectionInputSchema(search bool) jsonSchema {
 	schema.AllOf = []jsonSchema{{
 		Not: &jsonSchema{Required: []string{"all", "limit"}},
 	}}
+	return schema
+}
+
+func contactCollectionInputSchema() jsonSchema {
+	schema := collectionInputSchema(false)
+	one := 1
+	schema.Properties["query"] = jsonSchema{Type: "string", MinLength: &one, Pattern: `\S`}
 	return schema
 }
 
@@ -874,9 +885,10 @@ func Execute(ctx context.Context, request Request, dependencies Dependencies) Re
 					}
 					return contactsProtocolChangedFailure(definition.path, pretty)
 				}
-				end := min(options.limit, len(catalog.Contacts))
+				filteredContacts := filterContacts(catalog.Contacts, options.query)
+				end := min(options.limit, len(filteredContacts))
 				items := make([]contact, 0, end)
-				for _, remoteContact := range catalog.Contacts[:end] {
+				for _, remoteContact := range filteredContacts[:end] {
 					items = append(items, contact{
 						DisplayName:      remoteContact.Name,
 						SharedEventCount: remoteContact.SharedEventCount,

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -838,6 +838,21 @@ func Execute(ctx context.Context, request Request, dependencies Dependencies) Re
 				if inputError != nil {
 					return failure(definition.path, 2, *inputError, pretty)
 				}
+				filterHash := normalizedFilterHash(definition.path, options.query)
+				var decodedCursor cursorPayload
+				var cursorKey []byte
+				var err error
+				if options.cursorProvided {
+					cursorKey, err = loadCursorKey(dependencies)
+					if err != nil {
+						return internalFailure(definition.path, pretty)
+					}
+					var cursorFailure *cursorValidationFailure
+					decodedCursor, cursorFailure = decodeCursor(options.cursor, filterHash, cursorKey)
+					if cursorFailure != nil {
+						return failure(definition.path, cursorFailure.exitCode, cursorFailure.body, pretty)
+					}
+				}
 				clock := time.Now
 				if dependencies.Now != nil {
 					clock = dependencies.Now
@@ -886,18 +901,51 @@ func Execute(ctx context.Context, request Request, dependencies Dependencies) Re
 					return contactsProtocolChangedFailure(definition.path, pretty)
 				}
 				filteredContacts := filterContacts(catalog.Contacts, options.query)
-				end := min(options.limit, len(filteredContacts))
-				items := make([]contact, 0, end)
-				for _, remoteContact := range filteredContacts[:end] {
+				offset := 0
+				if options.cursorProvided {
+					var cursorFailure *cursorValidationFailure
+					offset, cursorFailure = cursorSnapshotOffset(
+						decodedCursor,
+						catalog.PayloadSHA256,
+						len(filteredContacts),
+					)
+					if cursorFailure != nil {
+						return failure(definition.path, cursorFailure.exitCode, cursorFailure.body, pretty)
+					}
+				}
+				end := min(offset+options.limit, len(filteredContacts))
+				items := make([]contact, 0, end-offset)
+				for _, remoteContact := range filteredContacts[offset:end] {
 					items = append(items, contact{
 						DisplayName:      remoteContact.Name,
 						SharedEventCount: remoteContact.SharedEventCount,
 					})
 				}
+				var cursor *string
+				hasMore := end < len(filteredContacts)
+				if hasMore {
+					if cursorKey == nil {
+						cursorKey, err = loadCursorKey(dependencies)
+						if err != nil {
+							return internalFailure(definition.path, pretty)
+						}
+					}
+					value, err := nextCursor(
+						catalog.PayloadSHA256,
+						filterHash,
+						end,
+						cursorKey,
+						dependencies.CursorRandom,
+					)
+					if err != nil {
+						return internalFailure(definition.path, pretty)
+					}
+					cursor = &value
+				}
 				return collectionSuccess(definition.path, contactData{Items: items}, pageMeta{
 					Limit:      options.limit,
-					NextCursor: nil,
-					HasMore:    false,
+					NextCursor: cursor,
+					HasMore:    hasMore,
 				}, pretty)
 			}
 		}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -898,6 +898,14 @@ func Execute(ctx context.Context, request Request, dependencies Dependencies) Re
 					if errors.Is(err, remote.ErrUnavailable) {
 						return contactsUnavailableFailure(definition.path, pretty)
 					}
+					if errors.Is(err, remote.ErrUnauthenticated) {
+						return authenticationExpiredFailure(
+							definition.path,
+							"REMOTE_SESSION_UNAUTHENTICATED",
+							"Stored authentication is no longer accepted. Log in again.",
+							pretty,
+						)
+					}
 					return contactsProtocolChangedFailure(definition.path, pretty)
 				}
 				filteredContacts := filterContacts(catalog.Contacts, options.query)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -216,6 +216,7 @@ var commandCatalog = []commandDefinition{
 		failureTypes: []string{
 			"auth.required",
 			"auth.expired",
+			"state.conflict",
 			"remote.unavailable",
 			"contract.protocol_changed",
 			"internal.failure",
@@ -788,6 +789,7 @@ func Execute(ctx context.Context, request Request, dependencies Dependencies) Re
 						decodedCursor,
 						catalog.PayloadSHA256,
 						len(filteredPosters),
+						"The poster catalog changed after this cursor was issued.",
 					)
 					if cursorFailure != nil {
 						return failure(definition.path, cursorFailure.exitCode, cursorFailure.body, pretty)
@@ -916,6 +918,7 @@ func Execute(ctx context.Context, request Request, dependencies Dependencies) Re
 						decodedCursor,
 						catalog.PayloadSHA256,
 						len(filteredContacts),
+						"The contact catalog changed after this cursor was issued.",
 					)
 					if cursorFailure != nil {
 						return failure(definition.path, cursorFailure.exitCode, cursorFailure.body, pretty)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -15,7 +15,7 @@ import (
 const (
 	Version                 = "1.0.0"
 	ProductContractRevision = "2026-08-10.1"
-	RemoteContractRevision  = "2026-08-11.4"
+	RemoteContractRevision  = "2026-08-11.5"
 )
 
 type Request struct {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -442,11 +442,12 @@ func posterCollectionSuccessSchema() jsonSchema {
 }
 
 func contactCollectionSuccessSchema() jsonSchema {
+	zero := 0
 	contact := objectSchema(
 		[]string{"displayName", "sharedEventCount"},
 		map[string]jsonSchema{
 			"displayName":      {Type: "string"},
-			"sharedEventCount": {Type: "integer"},
+			"sharedEventCount": {Type: "integer", Minimum: &zero},
 		},
 	)
 	items := jsonSchema{Type: "array", Items: &contact}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -856,6 +856,9 @@ func Execute(ctx context.Context, request Request, dependencies Dependencies) Re
 						return failure(definition.path, cursorFailure.exitCode, cursorFailure.body, pretty)
 					}
 				}
+				if dependencies.CredentialsPathError != nil {
+					return configurationDirectoryFailure(definition.path, pretty)
+				}
 				clock := time.Now
 				if dependencies.Now != nil {
 					clock = dependencies.Now

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -52,6 +52,7 @@ const (
 	doctorCommand
 	postersListCommand
 	postersSearchCommand
+	contactsListCommand
 )
 
 type commandDefinition struct {
@@ -194,6 +195,23 @@ var commandCatalog = []commandDefinition{
 		failureTypes: []string{
 			"input.invalid",
 			"state.conflict",
+			"remote.unavailable",
+			"contract.protocol_changed",
+			"internal.failure",
+		},
+		safety: readOnlySafety(),
+	},
+	{
+		path:          "contacts.list",
+		invocation:    []string{"contacts", "list"},
+		kind:          contactsListCommand,
+		positionals:   []positionalDefinition{},
+		flags:         collectionFlagDefinitions(),
+		inputSchema:   collectionInputSchema(false),
+		successSchema: contactCollectionSuccessSchema(),
+		failureTypes: []string{
+			"auth.required",
+			"auth.expired",
 			"remote.unavailable",
 			"contract.protocol_changed",
 			"internal.failure",
@@ -411,6 +429,18 @@ func posterCollectionSuccessSchema() jsonSchema {
 	return objectSchema([]string{"items"}, map[string]jsonSchema{"items": items})
 }
 
+func contactCollectionSuccessSchema() jsonSchema {
+	contact := objectSchema(
+		[]string{"displayName", "sharedEventCount"},
+		map[string]jsonSchema{
+			"displayName":      {Type: "string"},
+			"sharedEventCount": {Type: "integer"},
+		},
+	)
+	items := jsonSchema{Type: "array", Items: &contact}
+	return objectSchema([]string{"items"}, map[string]jsonSchema{"items": items})
+}
+
 func readOnlySafety() safetyDefinition {
 	return safetyDefinition{
 		Kind:                 "read-only",
@@ -453,6 +483,15 @@ type poster struct {
 	Height      *int     `json:"height"`
 	Tags        []string `json:"tags"`
 	Categories  []string `json:"categories"`
+}
+
+type contactData struct {
+	Items []contact `json:"items"`
+}
+
+type contact struct {
+	DisplayName      string `json:"displayName"`
+	SharedEventCount int    `json:"sharedEventCount"`
 }
 
 type versionData struct {
@@ -783,6 +822,71 @@ func Execute(ctx context.Context, request Request, dependencies Dependencies) Re
 					NextCursor: cursor,
 					HasMore:    hasMore,
 				}, pretty)
+			case contactsListCommand:
+				options, inputError := parseCollectionOptions(definition, argv)
+				if inputError != nil {
+					return failure(definition.path, 2, *inputError, pretty)
+				}
+				clock := time.Now
+				if dependencies.Now != nil {
+					clock = dependencies.Now
+				}
+				session, err := auth.AcquireSession(
+					ctx,
+					dependencies.Files,
+					dependencies.CredentialsPath,
+					clock,
+					remote.AuthClient{HTTP: dependencies.HTTP},
+				)
+				if err != nil {
+					if errors.Is(err, auth.ErrRequired) {
+						return authenticationRequiredFailure(definition.path, pretty)
+					}
+					if errors.Is(err, auth.ErrExpired) ||
+						errors.Is(err, auth.ErrRemoteTokenExpired) {
+						return authenticationExpiredFailure(
+							definition.path,
+							"SESSION_EXPIRED",
+							"Stored authentication has expired. Log in again.",
+							pretty,
+						)
+					}
+					if errors.Is(err, auth.ErrRemoteProtocolChanged) {
+						return authenticationProtocolChangedFailure(definition.path, pretty)
+					}
+					if errors.Is(err, auth.ErrRemoteUnavailable) {
+						return authenticationUnavailableFailure(definition.path, pretty)
+					}
+					return internalFailure(definition.path, pretty)
+				}
+				deviceID, err := randomDeviceID(dependencies.AuthRandom)
+				if err != nil {
+					return internalFailure(definition.path, pretty)
+				}
+				catalog, err := (remote.Client{HTTP: dependencies.HTTP}).GetContacts(
+					ctx,
+					session.AccessToken,
+					deviceID,
+				)
+				if err != nil {
+					if errors.Is(err, remote.ErrUnavailable) {
+						return contactsUnavailableFailure(definition.path, pretty)
+					}
+					return contactsProtocolChangedFailure(definition.path, pretty)
+				}
+				end := min(options.limit, len(catalog.Contacts))
+				items := make([]contact, 0, end)
+				for _, remoteContact := range catalog.Contacts[:end] {
+					items = append(items, contact{
+						DisplayName:      remoteContact.Name,
+						SharedEventCount: remoteContact.SharedEventCount,
+					})
+				}
+				return collectionSuccess(definition.path, contactData{Items: items}, pageMeta{
+					Limit:      options.limit,
+					NextCursor: nil,
+					HasMore:    false,
+				}, pretty)
 			}
 		}
 	}
@@ -810,7 +914,9 @@ func (definition commandDefinition) matches(argv []string) bool {
 	if definition.kind == schemaCommand && len(argv) == 2 {
 		return argv[0] == "schema"
 	}
-	if (definition.kind == postersListCommand || definition.kind == postersSearchCommand) &&
+	if (definition.kind == postersListCommand ||
+		definition.kind == postersSearchCommand ||
+		definition.kind == contactsListCommand) &&
 		len(argv) >= len(definition.invocation) {
 		return slices.Equal(argv[:len(definition.invocation)], definition.invocation)
 	}
@@ -1024,6 +1130,18 @@ func authenticationExpiredFailure(command, code, message string, pretty bool) Re
 	return result
 }
 
+func authenticationRequiredFailure(command string, pretty bool) Result {
+	result := failure(command, 3, errorBody{
+		Type:      "auth.required",
+		Code:      "AUTHENTICATION_REQUIRED",
+		Message:   "Authentication is required. Log in and try again.",
+		Retryable: false,
+		Details:   map[string]any{},
+	}, pretty)
+	result.Stderr = "partiful: authentication required\n"
+	return result
+}
+
 func authenticationProtocolChangedFailure(command string, pretty bool) Result {
 	result := failure(command, 9, errorBody{
 		Type:      "contract.protocol_changed",
@@ -1069,6 +1187,30 @@ func protocolChangedFailure(command string, pretty bool) Result {
 		Details:   map[string]any{},
 	}, pretty)
 	result.Stderr = "partiful: poster catalog protocol changed\n"
+	return result
+}
+
+func contactsUnavailableFailure(command string, pretty bool) Result {
+	result := failure(command, 8, errorBody{
+		Type:      "remote.unavailable",
+		Code:      "CONTACTS_UNAVAILABLE",
+		Message:   "Contacts are unavailable.",
+		Retryable: true,
+		Details:   map[string]any{},
+	}, pretty)
+	result.Stderr = "partiful: contacts unavailable\n"
+	return result
+}
+
+func contactsProtocolChangedFailure(command string, pretty bool) Result {
+	result := failure(command, 9, errorBody{
+		Type:      "contract.protocol_changed",
+		Code:      "CONTACTS_PROTOCOL_CHANGED",
+		Message:   "Contacts no longer match the reviewed remote contract.",
+		Retryable: false,
+		Details:   map[string]any{},
+	}, pretty)
+	result.Stderr = "partiful: contacts protocol changed\n"
 	return result
 }
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -870,8 +870,15 @@ func Execute(ctx context.Context, request Request, dependencies Dependencies) Re
 					if errors.Is(err, auth.ErrRequired) {
 						return authenticationRequiredFailure(definition.path, pretty)
 					}
-					if errors.Is(err, auth.ErrExpired) ||
-						errors.Is(err, auth.ErrRemoteTokenExpired) {
+					if errors.Is(err, auth.ErrRemoteTokenExpired) {
+						return authenticationExpiredFailure(
+							definition.path,
+							"INVALID_REFRESH_TOKEN",
+							"Stored authentication has expired. Log in again.",
+							pretty,
+						)
+					}
+					if errors.Is(err, auth.ErrExpired) {
 						return authenticationExpiredFailure(
 							definition.path,
 							"SESSION_EXPIRED",

--- a/internal/app/contacts.go
+++ b/internal/app/contacts.go
@@ -1,0 +1,18 @@
+package app
+
+import (
+	"encoding/base64"
+	"errors"
+	"io"
+)
+
+func randomDeviceID(random io.Reader) (string, error) {
+	if random == nil {
+		return "", errors.New("device identity random source is unavailable")
+	}
+	value := make([]byte, 16)
+	if _, err := io.ReadFull(random, value); err != nil {
+		return "", errors.New("device identity random source is unavailable")
+	}
+	return base64.RawURLEncoding.EncodeToString(value), nil
+}

--- a/internal/app/contacts.go
+++ b/internal/app/contacts.go
@@ -4,6 +4,8 @@ import (
 	"encoding/base64"
 	"errors"
 	"io"
+
+	"github.com/KalebCole/partiful-cli/internal/remote"
 )
 
 func randomDeviceID(random io.Reader) (string, error) {
@@ -15,4 +17,19 @@ func randomDeviceID(random io.Reader) (string, error) {
 		return "", errors.New("device identity random source is unavailable")
 	}
 	return base64.RawURLEncoding.EncodeToString(value), nil
+}
+
+func filterContacts(contacts []remote.Contact, query string) []remote.Contact {
+	seen := make(map[string]struct{}, len(contacts))
+	filtered := make([]remote.Contact, 0, len(contacts))
+	for _, contact := range contacts {
+		if _, exists := seen[contact.ID]; exists {
+			continue
+		}
+		seen[contact.ID] = struct{}{}
+		if query == "" || containsFold(contact.Name, query) {
+			filtered = append(filtered, contact)
+		}
+	}
+	return filtered
 }

--- a/internal/app/execute_test.go
+++ b/internal/app/execute_test.go
@@ -1116,7 +1116,7 @@ func TestExecuteSchemaListsOnlyCompletedCatalog(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":true,"data":{"commands":["auth.login","auth.logout","auth.status","doctor","posters.list","posters.search","schema","version"]},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"commands":["auth.login","auth.logout","auth.status","contacts.list","doctor","posters.list","posters.search","schema","version"]},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -2049,6 +2049,80 @@ func (filesystem fakeFilesystem) WithLock(path string, operation func()) error {
 	}
 	operation()
 	return nil
+}
+
+func TestExecuteContactsListTraversesReviewedPagesAndReturnsOnlyPublicFields(t *testing.T) {
+	const (
+		credentials   = `{"accessToken":"private-access-token","refreshToken":"private-refresh-token","expiresAt":"2026-08-11T02:00:00Z"}`
+		privateID     = "private-contact-identity"
+		privateCursor = "private-remote-cursor"
+	)
+	requestCount := 0
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"contacts", "list"},
+		Stdin: strings.NewReader(""),
+	}, app.Dependencies{
+		Files: fakeFilesystem{
+			readFile: func(string) ([]byte, error) {
+				return []byte(credentials), nil
+			},
+		},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+		AuthRandom: strings.NewReader("0123456789abcdef"),
+		HTTP: scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+			requestCount++
+			if request.Method != http.MethodPost ||
+				request.URL.String() != "https://api.partiful.com/getContacts" {
+				t.Fatalf("request = %s %s, want reviewed getContacts call", request.Method, request.URL)
+			}
+			if got := request.Header.Get("Authorization"); got != "Bearer private-access-token" {
+				t.Fatalf("authorization = %q, want bearer credential", got)
+			}
+			body, err := io.ReadAll(request.Body)
+			if err != nil {
+				t.Fatalf("read request body: %v", err)
+			}
+			if requestCount == 1 {
+				const want = `{"data":{"params":{},"amplitudeDeviceId":"MDEyMzQ1Njc4OWFiY2RlZg","paging":{"maxResults":1000,"cursor":null}}}`
+				if string(body) != want {
+					t.Fatalf("first request body = %s, want %s", body, want)
+				}
+				return jsonResponse(
+					http.StatusOK,
+					`{"result":{"data":[{"id":"`+privateID+`","name":"Alice Example","sharedEventCount":2}],"paging":{"nextCursor":"`+privateCursor+`"}}}`,
+				), nil
+			}
+			const want = `{"data":{"params":{},"amplitudeDeviceId":"MDEyMzQ1Njc4OWFiY2RlZg","paging":{"maxResults":1000,"cursor":"private-remote-cursor"}}}`
+			if string(body) != want {
+				t.Fatalf("terminal request body = %s, want %s", body, want)
+			}
+			return jsonResponse(
+				http.StatusOK,
+				`{"result":{"data":[],"paging":{}}}`,
+			), nil
+		}},
+	})
+
+	const want = `{"ok":true,"data":{"items":[{"displayName":"Alice Example","sharedEventCount":2}]},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
+	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
+		t.Fatalf("result = %#v, want reviewed public contact collection", result)
+	}
+	if requestCount != 2 {
+		t.Fatalf("request count = %d, want data page and terminal sentinel", requestCount)
+	}
+	for _, privateValue := range []string{
+		privateID,
+		privateCursor,
+		"private-access-token",
+		"private-refresh-token",
+	} {
+		if strings.Contains(result.Stdout+result.Stderr, privateValue) {
+			t.Fatalf("result exposed private value %q", privateValue)
+		}
+	}
 }
 
 func TestExecuteAuthStatusRedactsHealthyCredentials(t *testing.T) {

--- a/internal/app/execute_test.go
+++ b/internal/app/execute_test.go
@@ -2736,6 +2736,87 @@ func TestExecuteSchemaProjectsCompleteContactsListDefinition(t *testing.T) {
 	}
 }
 
+func TestExecuteContactsListMapsRejectedRefreshWithoutAttemptingRead(t *testing.T) {
+	const privateRefresh = "private-rejected-refresh"
+	call := 0
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"contacts", "list"},
+		Stdin: strings.NewReader(""),
+	}, app.Dependencies{
+		Files: fakeFilesystem{
+			readFile: func(string) ([]byte, error) {
+				return []byte(
+					`{"accessToken":"private-expired-access","refreshToken":"` +
+						privateRefresh +
+						`","expiresAt":"2026-08-10T23:59:00Z"}`,
+				), nil
+			},
+		},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+		AuthRandom: strings.NewReader("must-not-be-read"),
+		HTTP: scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+			call++
+			if request.URL.Host != "securetoken.googleapis.com" {
+				t.Fatalf("request host = %q, want only refresh attempt", request.URL.Host)
+			}
+			return jsonResponse(
+				http.StatusBadRequest,
+				`{"error":{"code":400,"message":"INVALID_REFRESH_TOKEN","status":"INVALID_ARGUMENT"}}`,
+			), nil
+		}},
+	})
+
+	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"INVALID_REFRESH_TOKEN","message":"Stored authentication has expired. Log in again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
+	if result.ExitCode != 3 || result.Stdout != wantStdout {
+		t.Fatalf("result = %#v, want rejected refresh failure", result)
+	}
+	if call != 1 {
+		t.Fatalf("request count = %d, want refresh only", call)
+	}
+	if strings.Contains(result.Stdout+result.Stderr, privateRefresh) {
+		t.Fatal("rejected refresh failure exposed private token")
+	}
+}
+
+func TestExecuteContactsListPreservesUnauthenticatedBodyReadFailureAsUnavailable(t *testing.T) {
+	const privateReadError = "private unauthenticated response read failure"
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"contacts", "list"},
+		Stdin: strings.NewReader(""),
+	}, app.Dependencies{
+		Files: fakeFilesystem{
+			readFile: func(string) ([]byte, error) {
+				return []byte(
+					`{"accessToken":"private-access-token","expiresAt":"2026-08-11T02:00:00Z"}`,
+				), nil
+			},
+		},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+		AuthRandom: strings.NewReader("0123456789abcdef"),
+		HTTP: scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusUnauthorized,
+				Header:     http.Header{"Content-Type": {"application/json"}},
+				Body:       failingReadCloser{err: errors.New(privateReadError)},
+			}, nil
+		}},
+	})
+
+	if result.ExitCode != 8 ||
+		!strings.Contains(result.Stdout, `"type":"remote.unavailable"`) {
+		t.Fatalf("result = %#v, want response read failure to remain unavailable", result)
+	}
+	if strings.Contains(result.Stdout+result.Stderr, privateReadError) {
+		t.Fatal("response read failure exposed private transport details")
+	}
+}
+
 func TestExecuteAuthStatusRedactsHealthyCredentials(t *testing.T) {
 	const credentials = `{"accessToken":"secret-token-value","refreshToken":"secret-refresh-value","userId":"private-user-value","expiresAt":"2026-08-11T02:00:00Z"}`
 	result := app.Execute(context.Background(), app.Request{

--- a/internal/app/execute_test.go
+++ b/internal/app/execute_test.go
@@ -2576,6 +2576,166 @@ func TestExecuteContactsListRefreshesExpiringSessionBeforeProtectedRead(t *testi
 	}
 }
 
+func TestExecuteContactsListRejectsCursorWhenContactCatalogChanges(t *testing.T) {
+	const credentials = `{"accessToken":"private-access-token","expiresAt":"2026-08-11T02:00:00Z"}`
+	call := 0
+	dependencies := withTestCursorCrypto(app.Dependencies{
+		Files: fakeFilesystem{
+			readFile: func(string) ([]byte, error) {
+				return []byte(credentials), nil
+			},
+		},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+		AuthRandom: strings.NewReader("0123456789abcdefFEDCBA9876543210"),
+		HTTP: scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
+			call++
+			switch call {
+			case 1:
+				return jsonResponse(
+					http.StatusOK,
+					`{"result":{"data":[{"id":"private-one","name":"One","sharedEventCount":1},{"id":"private-two","name":"Two","sharedEventCount":2}],"paging":{"nextCursor":"cursor-one"}}}`,
+				), nil
+			case 2, 4:
+				return jsonResponse(http.StatusOK, `{"result":{"data":[],"paging":{}}}`), nil
+			case 3:
+				return jsonResponse(
+					http.StatusOK,
+					`{"result":{"data":[{"id":"private-replacement","name":"Replacement","sharedEventCount":3}],"paging":{"nextCursor":"cursor-two"}}}`,
+				), nil
+			default:
+				return nil, errors.New("unexpected request")
+			}
+		}},
+	})
+	first := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"contacts", "list", "--limit", "1"},
+		Stdin: strings.NewReader(""),
+	}, dependencies)
+	var envelope struct {
+		Meta struct {
+			Page struct {
+				NextCursor string `json:"nextCursor"`
+			} `json:"page"`
+		} `json:"meta"`
+	}
+	if err := json.Unmarshal([]byte(first.Stdout), &envelope); err != nil {
+		t.Fatalf("decode first result: %v", err)
+	}
+
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"contacts", "list", "--cursor", envelope.Meta.Page.NextCursor},
+		Stdin: strings.NewReader(""),
+	}, dependencies)
+
+	const want = `{"ok":false,"error":{"type":"state.conflict","code":"CURSOR_SNAPSHOT_CHANGED","message":"The contact catalog changed after this cursor was issued.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
+	if result.ExitCode != 6 || result.Stdout != want || result.Stderr != "" {
+		t.Fatalf("result = %#v, want contact snapshot conflict", result)
+	}
+	for _, privateValue := range []string{"private-one", "private-two", "private-replacement"} {
+		if strings.Contains(result.Stdout+result.Stderr, privateValue) {
+			t.Fatalf("snapshot failure exposed private value %q", privateValue)
+		}
+	}
+}
+
+func TestExecuteSchemaProjectsCompleteContactsListDefinition(t *testing.T) {
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"schema", "contacts.list"},
+		Stdin: strings.NewReader(""),
+	}, app.Dependencies{})
+
+	var envelope struct {
+		Data struct {
+			Command string `json:"command"`
+			Flags   []struct {
+				Name     string `json:"name"`
+				Required bool   `json:"required"`
+			} `json:"flags"`
+			InputSchema struct {
+				Properties map[string]struct {
+					Minimum   *int   `json:"minimum"`
+					Maximum   *int   `json:"maximum"`
+					MinLength *int   `json:"minLength"`
+					Pattern   string `json:"pattern"`
+				} `json:"properties"`
+			} `json:"inputSchema"`
+			SuccessSchema struct {
+				Properties map[string]struct {
+					Items struct {
+						Required []string `json:"required"`
+					} `json:"items"`
+				} `json:"properties"`
+			} `json:"successSchema"`
+			FailureTypes []string `json:"failureTypes"`
+			Safety       struct {
+				Kind                 string `json:"kind"`
+				PlanRequired         bool   `json:"planRequired"`
+				ConfirmationRequired bool   `json:"confirmationRequired"`
+			} `json:"safety"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(result.Stdout), &envelope); err != nil {
+		t.Fatalf("decode schema: %v", err)
+	}
+	if result.ExitCode != 0 || envelope.Data.Command != "contacts.list" {
+		t.Fatalf("result = %#v, schema = %#v, want contacts definition", result, envelope.Data)
+	}
+	var flags []string
+	for _, flag := range envelope.Data.Flags {
+		flags = append(flags, fmt.Sprintf("%s:%t", flag.Name, flag.Required))
+	}
+	wantFlags := []string{
+		"--query:false",
+		"--limit:false",
+		"--cursor:false",
+		"--all:false",
+		"--max-items:false",
+	}
+	if !reflect.DeepEqual(flags, wantFlags) {
+		t.Fatalf("flags = %v, want %v", flags, wantFlags)
+	}
+	query := envelope.Data.InputSchema.Properties["query"]
+	limit := envelope.Data.InputSchema.Properties["limit"]
+	maxItems := envelope.Data.InputSchema.Properties["maxItems"]
+	if query.MinLength == nil || *query.MinLength != 1 || query.Pattern != `\S` ||
+		limit.Minimum == nil || *limit.Minimum != 1 ||
+		limit.Maximum == nil || *limit.Maximum != 100 ||
+		maxItems.Minimum == nil || *maxItems.Minimum != 1 ||
+		maxItems.Maximum == nil || *maxItems.Maximum != 1000 {
+		t.Fatalf("input constraints = %#v, want product collection bounds", envelope.Data.InputSchema.Properties)
+	}
+	wantFields := []string{"displayName", "sharedEventCount"}
+	if got := envelope.Data.SuccessSchema.Properties["items"].Items.Required; !reflect.DeepEqual(got, wantFields) {
+		t.Fatalf("contact fields = %v, want only %v", got, wantFields)
+	}
+	wantFailures := []string{
+		"usage.invalid",
+		"input.invalid",
+		"auth.required",
+		"auth.expired",
+		"state.conflict",
+		"remote.unavailable",
+		"contract.protocol_changed",
+		"internal.failure",
+	}
+	if !reflect.DeepEqual(envelope.Data.FailureTypes, wantFailures) {
+		t.Fatalf("failure types = %v, want %v", envelope.Data.FailureTypes, wantFailures)
+	}
+	if envelope.Data.Safety.Kind != "read-only" ||
+		envelope.Data.Safety.PlanRequired ||
+		envelope.Data.Safety.ConfirmationRequired {
+		t.Fatalf("safety = %#v, want read-only", envelope.Data.Safety)
+	}
+	if strings.Contains(result.Stdout, `"id"`) ||
+		strings.Contains(result.Stdout, `"phone"`) ||
+		strings.Contains(result.Stdout, `"email"`) {
+		t.Fatal("public contact schema exposed a private field")
+	}
+}
+
 func TestExecuteAuthStatusRedactsHealthyCredentials(t *testing.T) {
 	const credentials = `{"accessToken":"secret-token-value","refreshToken":"secret-refresh-value","userId":"private-user-value","expiresAt":"2026-08-11T02:00:00Z"}`
 	result := app.Execute(context.Background(), app.Request{

--- a/internal/app/execute_test.go
+++ b/internal/app/execute_test.go
@@ -529,7 +529,10 @@ func TestExecuteSchemaProjectsPosterSearchDefinition(t *testing.T) {
 			SuccessSchema struct {
 				Properties map[string]struct {
 					Items struct {
-						Required []string `json:"required"`
+						Required   []string `json:"required"`
+						Properties map[string]struct {
+							Minimum *int `json:"minimum"`
+						} `json:"properties"`
 					} `json:"items"`
 				} `json:"properties"`
 			} `json:"successSchema"`
@@ -2665,7 +2668,10 @@ func TestExecuteSchemaProjectsCompleteContactsListDefinition(t *testing.T) {
 			SuccessSchema struct {
 				Properties map[string]struct {
 					Items struct {
-						Required []string `json:"required"`
+						Required   []string `json:"required"`
+						Properties map[string]struct {
+							Minimum *int `json:"minimum"`
+						} `json:"properties"`
 					} `json:"items"`
 				} `json:"properties"`
 			} `json:"successSchema"`
@@ -2710,6 +2716,10 @@ func TestExecuteSchemaProjectsCompleteContactsListDefinition(t *testing.T) {
 	wantFields := []string{"displayName", "sharedEventCount"}
 	if got := envelope.Data.SuccessSchema.Properties["items"].Items.Required; !reflect.DeepEqual(got, wantFields) {
 		t.Fatalf("contact fields = %v, want only %v", got, wantFields)
+	}
+	sharedEventCount := envelope.Data.SuccessSchema.Properties["items"].Items.Properties["sharedEventCount"]
+	if sharedEventCount.Minimum == nil || *sharedEventCount.Minimum != 0 {
+		t.Fatalf("sharedEventCount schema = %#v, want nonnegative integer", sharedEventCount)
 	}
 	wantFailures := []string{
 		"usage.invalid",

--- a/internal/app/execute_test.go
+++ b/internal/app/execute_test.go
@@ -80,7 +80,7 @@ func TestExecutePostersListReturnsFirstLocalPage(t *testing.T) {
 		}},
 	}))
 
-	const want = `{"ok":true,"data":{"items":[{"posterId":"first","name":"First","url":"https://example.invalid/first.png","contentType":"image/png","width":1200,"height":630,"tags":["party"],"categories":["fun"]},{"posterId":"duplicate","name":"Duplicate","url":"https://example.invalid/duplicate.gif","contentType":"image/gif","width":null,"height":null,"tags":["dance"],"categories":[]},{"posterId":"duplicate","name":"Duplicate Again","url":"https://example.invalid/duplicate-2.gif","contentType":"image/gif","width":640,"height":480,"tags":[],"categories":["night"]}]},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
+	const want = `{"ok":true,"data":{"items":[{"posterId":"first","name":"First","url":"https://example.invalid/first.png","contentType":"image/png","width":1200,"height":630,"tags":["party"],"categories":["fun"]},{"posterId":"duplicate","name":"Duplicate","url":"https://example.invalid/duplicate.gif","contentType":"image/gif","width":null,"height":null,"tags":["dance"],"categories":[]},{"posterId":"duplicate","name":"Duplicate Again","url":"https://example.invalid/duplicate-2.gif","contentType":"image/gif","width":640,"height":480,"tags":[],"categories":["night"]}]},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -486,7 +486,7 @@ func TestExecutePostersListRejectsCursorWhenPayloadChanges(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, dependencies)
 
-	const want = `{"ok":false,"error":{"type":"state.conflict","code":"CURSOR_SNAPSHOT_CHANGED","message":"The poster catalog changed after this cursor was issued.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"state.conflict","code":"CURSOR_SNAPSHOT_CHANGED","message":"The poster catalog changed after this cursor was issued.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5"}}` + "\n"
 	if result.ExitCode != 6 {
 		t.Fatalf("exit code = %d, want 6", result.ExitCode)
 	}
@@ -631,7 +631,7 @@ func TestExecutePostersListRejectsUnexpectedSuccessContentType(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5"}}` + "\n"
 	const wantStderr = "partiful: poster catalog protocol changed\n"
 	if result.ExitCode != 9 {
 		t.Fatalf("exit code = %d, want 9", result.ExitCode)
@@ -657,7 +657,7 @@ func TestExecutePostersListRejectsMalformedCursorBeforeRemoteFailure(t *testing.
 		}},
 	}))
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_INVALID","message":"The cursor is malformed.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_INVALID","message":"The cursor is malformed.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -712,7 +712,7 @@ func TestExecutePostersSearchRejectsCursorWithDifferentNormalizedFilter(t *testi
 		Stdin: strings.NewReader(""),
 	}, dependencies)
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_FILTER_MISMATCH","message":"The cursor does not match this command and filters.","retryable":false,"details":{}},"meta":{"command":"posters.search","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_FILTER_MISMATCH","message":"The cursor does not match this command and filters.","retryable":false,"details":{}},"meta":{"command":"posters.search","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -735,7 +735,7 @@ func TestExecutePostersListMapsNetworkFailureToRemoteUnavailable(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"remote.unavailable","code":"POSTER_CATALOG_UNAVAILABLE","message":"The poster catalog is unavailable.","retryable":true,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"remote.unavailable","code":"POSTER_CATALOG_UNAVAILABLE","message":"The poster catalog is unavailable.","retryable":true,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5"}}` + "\n"
 	const wantStderr = "partiful: poster catalog unavailable\n"
 	if result.ExitCode != 8 {
 		t.Fatalf("exit code = %d, want 8", result.ExitCode)
@@ -765,7 +765,7 @@ func TestExecutePostersListFailsClosedOnReceivedNon200(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5"}}` + "\n"
 	const wantStderr = "partiful: poster catalog protocol changed\n"
 	if result.ExitCode != 9 {
 		t.Fatalf("exit code = %d, want 9", result.ExitCode)
@@ -843,7 +843,7 @@ func TestExecutePostersListFailsClosedOnMalformed200Body(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5"}}` + "\n"
 	if result.ExitCode != 9 {
 		t.Fatalf("exit code = %d, want 9", result.ExitCode)
 	}
@@ -908,7 +908,7 @@ func TestExecutePostersListRequiresMaxItemsWithAll(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"MAX_ITEMS_REQUIRED","message":"--all requires --max-items.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"MAX_ITEMS_REQUIRED","message":"--all requires --max-items.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -930,7 +930,7 @@ func TestExecutePostersListRejectsLimitWithAll(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"LIMIT_WITH_ALL","message":"--limit cannot be combined with --all.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"LIMIT_WITH_ALL","message":"--limit cannot be combined with --all.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -948,7 +948,7 @@ func TestExecutePostersListRejectsLimitAboveMaximum(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"LIMIT_INVALID","message":"Limit must be an integer from 1 to 100.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"LIMIT_INVALID","message":"Limit must be an integer from 1 to 100.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -963,7 +963,7 @@ func TestExecutePostersListRejectsEmptyCursor(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_INVALID","message":"The cursor is malformed.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_INVALID","message":"The cursor is malformed.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -981,7 +981,7 @@ func TestExecutePostersSearchRequiresNonEmptyQuery(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"QUERY_REQUIRED","message":"Search query must not be empty.","retryable":false,"details":{}},"meta":{"command":"posters.search","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"QUERY_REQUIRED","message":"Search query must not be empty.","retryable":false,"details":{}},"meta":{"command":"posters.search","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -996,7 +996,7 @@ func TestExecuteVersion(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":true,"data":{"version":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"},"meta":{"command":"version","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"version":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5"},"meta":{"command":"version","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -1014,7 +1014,7 @@ func TestExecuteRejectsUnknownCommand(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_NOT_FOUND","message":"Unknown command.","retryable":false,"details":{}},"meta":{"command":"unknown","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_NOT_FOUND","message":"Unknown command.","retryable":false,"details":{}},"meta":{"command":"unknown","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -1037,13 +1037,13 @@ func TestExecutePrettyPrintsOneCompleteEnvelope(t *testing.T) {
   "data": {
     "version": "1.0.0",
     "productContractRevision": "2026-08-10.1",
-    "remoteContractRevision": "2026-08-11.4"
+    "remoteContractRevision": "2026-08-11.5"
   },
   "meta": {
     "command": "version",
     "cliVersion": "1.0.0",
     "productContractRevision": "2026-08-10.1",
-    "remoteContractRevision": "2026-08-11.4",
+    "remoteContractRevision": "2026-08-11.5",
     "warnings": []
   }
 }
@@ -1065,7 +1065,7 @@ func TestExecuteAcceptsNonInteractiveGlobalFlag(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":true,"data":{"version":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"},"meta":{"command":"version","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"version":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5"},"meta":{"command":"version","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -1098,7 +1098,7 @@ func TestExecuteRejectsRepeatedScalarFlag(t *testing.T) {
     "command": "version",
     "cliVersion": "1.0.0",
     "productContractRevision": "2026-08-10.1",
-    "remoteContractRevision": "2026-08-11.4"
+    "remoteContractRevision": "2026-08-11.5"
   }
 }
 `
@@ -1119,7 +1119,7 @@ func TestExecuteSchemaListsOnlyCompletedCatalog(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":true,"data":{"commands":["auth.login","auth.logout","auth.status","contacts.list","doctor","posters.list","posters.search","schema","version"]},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"commands":["auth.login","auth.logout","auth.status","contacts.list","doctor","posters.list","posters.search","schema","version"]},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -1137,7 +1137,7 @@ func TestExecuteSchemaProjectsExecutableDefinition(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":true,"data":{"command":"auth.status","positionals":[],"flags":[],"inputSchema":{"type":"object","additionalProperties":false},"successSchema":{"type":"object","additionalProperties":false,"required":["authenticated","tokenState","expiresAt"],"properties":{"authenticated":{"type":"boolean"},"expiresAt":{"type":["string","null"],"format":"date-time"},"tokenState":{"type":"string","enum":["healthy","expiring","expired","missing"]}}},"failureTypes":["usage.invalid","input.invalid","auth.expired","remote.unavailable","contract.protocol_changed","internal.failure"],"safety":{"kind":"local-mutation","planRequired":false,"confirmationRequired":false}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"command":"auth.status","positionals":[],"flags":[],"inputSchema":{"type":"object","additionalProperties":false},"successSchema":{"type":"object","additionalProperties":false,"required":["authenticated","tokenState","expiresAt"],"properties":{"authenticated":{"type":"boolean"},"expiresAt":{"type":["string","null"],"format":"date-time"},"tokenState":{"type":"string","enum":["healthy","expiring","expired","missing"]}}},"failureTypes":["usage.invalid","input.invalid","auth.expired","remote.unavailable","contract.protocol_changed","internal.failure"],"safety":{"kind":"local-mutation","planRequired":false,"confirmationRequired":false}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -1195,7 +1195,7 @@ func TestExecuteRejectsUnknownSchemaPathWithoutEchoingInput(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_SCHEMA_NOT_FOUND","message":"No completed command has that schema path.","retryable":false,"details":{}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_SCHEMA_NOT_FOUND","message":"No completed command has that schema path.","retryable":false,"details":{}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -1226,7 +1226,7 @@ func TestExecuteAuthStatusWhenCredentialsAreMissing(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"missing","expiresAt":null},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"missing","expiresAt":null},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -1244,7 +1244,7 @@ func TestExecuteAuthLoginRequiresPrivateTerminal(t *testing.T) {
 		Stdin: strings.NewReader("private-stdin-value"),
 	}, app.Dependencies{})
 
-	const wantStdout = `{"ok":false,"error":{"type":"auth.human_required","code":"PRIVATE_TERMINAL_REQUIRED","message":"Authentication login requires a private terminal.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"auth.human_required","code":"PRIVATE_TERMINAL_REQUIRED","message":"Authentication login requires a private terminal.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5"}}` + "\n"
 	const wantStderr = "partiful: private terminal required\n"
 	if result.ExitCode != 3 {
 		t.Fatalf("exit code = %d, want 3", result.ExitCode)
@@ -1303,7 +1303,7 @@ func TestExecuteAuthLoginRejectsEmptyPrivateInputBeforeHTTP(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"input.invalid","code":"AUTH_INPUT_INVALID","message":"Authentication input is invalid.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"input.invalid","code":"AUTH_INPUT_INVALID","message":"Authentication input is invalid.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5"}}` + "\n"
 	if result.ExitCode != 2 || result.Stdout != wantStdout {
 		t.Fatalf("result = %#v, want invalid private input failure", result)
 	}
@@ -1445,7 +1445,7 @@ func TestExecuteAuthLoginPersistsReviewedSessionWithoutRevealingPrivateValues(t 
 		}},
 	})
 
-	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T01:10:00Z"},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T01:10:00Z"},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want redacted login success", result)
 	}
@@ -1518,7 +1518,7 @@ func TestExecuteAuthLoginMapsReviewedWrongCodeWithoutEchoingIt(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"input.invalid","code":"AUTH_CODE_REJECTED","message":"The verification code was rejected.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"input.invalid","code":"AUTH_CODE_REJECTED","message":"The verification code was rejected.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5"}}` + "\n"
 	const wantStderr = "partiful: authentication code rejected\n"
 	if result.ExitCode != 2 || result.Stdout != wantStdout || result.Stderr != wantStderr {
 		t.Fatalf("result = %#v, want reviewed wrong-code failure", result)
@@ -1659,7 +1659,7 @@ func TestExecuteAuthLoginMapsRejectedCustomTokenToExpired(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"INVALID_CUSTOM_TOKEN","message":"Authentication expired during login. Start login again.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"INVALID_CUSTOM_TOKEN","message":"Authentication expired during login. Start login again.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5"}}` + "\n"
 	const wantStderr = "partiful: authentication expired\n"
 	if result.ExitCode != 3 || result.Stdout != wantStdout || result.Stderr != wantStderr {
 		t.Fatalf("result = %#v, want reviewed custom-token failure", result)
@@ -1846,7 +1846,7 @@ func TestExecuteAuthLoginFailsClosedOnMalformedReviewedSuccess(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"AUTH_PROTOCOL_CHANGED","message":"Authentication no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"AUTH_PROTOCOL_CHANGED","message":"Authentication no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5"}}` + "\n"
 	const wantStderr = "partiful: authentication protocol changed\n"
 	if result.ExitCode != 9 || result.Stdout != wantStdout || result.Stderr != wantStderr {
 		t.Fatalf("result = %#v, want protocol drift failure", result)
@@ -1943,7 +1943,7 @@ func TestExecuteAuthLoginMapsNoResponseWithoutLeakingTransportError(t *testing.T
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"remote.unavailable","code":"AUTH_SERVICE_UNAVAILABLE","message":"The authentication service is unavailable.","retryable":true,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"remote.unavailable","code":"AUTH_SERVICE_UNAVAILABLE","message":"The authentication service is unavailable.","retryable":true,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5"}}` + "\n"
 	const wantStderr = "partiful: authentication service unavailable\n"
 	if result.ExitCode != 8 || result.Stdout != wantStdout || result.Stderr != wantStderr {
 		t.Fatalf("result = %#v, want auth unavailable failure", result)
@@ -1997,7 +1997,7 @@ func TestExecuteAuthLoginAtomicPersistenceFailurePreservesExistingCredentials(t 
 		Argv: []string{"auth", "login"},
 	}, dependencies)
 
-	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIAL_STORE_UNAVAILABLE","message":"Local credential storage is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIAL_STORE_UNAVAILABLE","message":"Local credential storage is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5"}}` + "\n"
 	if result.ExitCode != 10 || result.Stdout != wantStdout {
 		t.Fatalf("result = %#v, want atomic persistence failure", result)
 	}
@@ -2109,7 +2109,7 @@ func TestExecuteContactsListTraversesReviewedPagesAndReturnsOnlyPublicFields(t *
 		}},
 	})
 
-	const want = `{"ok":true,"data":{"items":[{"displayName":"Alice Example","sharedEventCount":2}]},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
+	const want = `{"ok":true,"data":{"items":[{"displayName":"Alice Example","sharedEventCount":2}]},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
 	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want reviewed public contact collection", result)
 	}
@@ -2164,7 +2164,7 @@ func TestExecuteContactsListFiltersLocallyAfterFirstIdentityOccurrenceWins(t *te
 		}},
 	})
 
-	const want = `{"ok":true,"data":{"items":[{"displayName":"Alice First","sharedEventCount":1},{"displayName":"Second ALICE","sharedEventCount":3}]},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
+	const want = `{"ok":true,"data":{"items":[{"displayName":"Alice First","sharedEventCount":1},{"displayName":"Second ALICE","sharedEventCount":3}]},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
 	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want locally filtered first-occurrence contacts", result)
 	}
@@ -2494,7 +2494,7 @@ func TestExecuteContactsListMapsReviewedUnauthenticatedResponseToExpired(t *test
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"REMOTE_SESSION_UNAUTHENTICATED","message":"Stored authentication is no longer accepted. Log in again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"REMOTE_SESSION_UNAUTHENTICATED","message":"Stored authentication is no longer accepted. Log in again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5"}}` + "\n"
 	if result.ExitCode != 3 || result.Stdout != wantStdout {
 		t.Fatalf("result = %#v, want reviewed unauthenticated mapping", result)
 	}
@@ -2633,7 +2633,7 @@ func TestExecuteContactsListRejectsCursorWhenContactCatalogChanges(t *testing.T)
 		Stdin: strings.NewReader(""),
 	}, dependencies)
 
-	const want = `{"ok":false,"error":{"type":"state.conflict","code":"CURSOR_SNAPSHOT_CHANGED","message":"The contact catalog changed after this cursor was issued.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"state.conflict","code":"CURSOR_SNAPSHOT_CHANGED","message":"The contact catalog changed after this cursor was issued.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5"}}` + "\n"
 	if result.ExitCode != 6 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want contact snapshot conflict", result)
 	}
@@ -2779,7 +2779,7 @@ func TestExecuteContactsListMapsRejectedRefreshWithoutAttemptingRead(t *testing.
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"INVALID_REFRESH_TOKEN","message":"Stored authentication has expired. Log in again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"INVALID_REFRESH_TOKEN","message":"Stored authentication has expired. Log in again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5"}}` + "\n"
 	if result.ExitCode != 3 || result.Stdout != wantStdout {
 		t.Fatalf("result = %#v, want rejected refresh failure", result)
 	}
@@ -2844,7 +2844,7 @@ func TestExecuteAuthStatusRedactsHealthyCredentials(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T02:00:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T02:00:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -2878,7 +2878,7 @@ func TestExecuteAuthStatusReportsExpiringToken(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"expiring","expiresAt":"2026-08-11T00:04:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"expiring","expiresAt":"2026-08-11T00:04:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -2953,7 +2953,7 @@ func TestExecuteAuthStatusDeterministicallyRefreshesExpiringSession(t *testing.T
 	first := app.Execute(context.Background(), app.Request{
 		Argv: []string{"auth", "status"},
 	}, dependencies)
-	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T01:10:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T01:10:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5","warnings":[]}}` + "\n"
 	if first.ExitCode != 0 || first.Stdout != want || first.Stderr != "" {
 		t.Fatalf("first status = %#v, want refreshed healthy session", first)
 	}
@@ -3127,7 +3127,7 @@ func TestExecuteAuthStatusMapsReviewedInvalidRefreshTokenToExpired(t *testing.T)
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"INVALID_REFRESH_TOKEN","message":"Stored authentication has expired. Log in again.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"INVALID_REFRESH_TOKEN","message":"Stored authentication has expired. Log in again.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5"}}` + "\n"
 	const wantStderr = "partiful: authentication expired\n"
 	if result.ExitCode != 3 || result.Stdout != wantStdout || result.Stderr != wantStderr {
 		t.Fatalf("result = %#v, want reviewed invalid-refresh failure", result)
@@ -3246,7 +3246,7 @@ func TestExecuteAuthStatusReportsExpiredToken(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"expired","expiresAt":"2026-08-10T23:59:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"expired","expiresAt":"2026-08-10T23:59:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -3275,7 +3275,7 @@ func TestExecuteAuthStatusFailureDoesNotRevealCredentialContents(t *testing.T) {
 		},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIALS_INVALID","message":"Local credentials are invalid.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIALS_INVALID","message":"Local credentials are invalid.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5"}}` + "\n"
 	const wantStderr = "partiful: local operation failed\n"
 	if result.ExitCode != 10 {
 		t.Fatalf("exit code = %d, want 10", result.ExitCode)
@@ -3311,7 +3311,7 @@ func TestExecuteAuthLogoutAtomicallyRemovesCredentials(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, dependencies)
 
-	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"missing","expiresAt":null},"meta":{"command":"auth.logout","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"missing","expiresAt":null},"meta":{"command":"auth.logout","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -3390,7 +3390,7 @@ func TestExecuteAuthLogoutFailureLeavesCredentialsAvailableAndRedactsError(t *te
 		Stdin: strings.NewReader(""),
 	}, dependencies)
 
-	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIAL_STORE_UNAVAILABLE","message":"Local credential storage is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.logout","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIAL_STORE_UNAVAILABLE","message":"Local credential storage is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.logout","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5"}}` + "\n"
 	if result.ExitCode != 10 {
 		t.Fatalf("exit code = %d, want 10", result.ExitCode)
 	}
@@ -3427,7 +3427,7 @@ func TestExecuteDoctorReportsHealthyCredentialsWithoutPrivateData(t *testing.T) 
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":true,"checks":[{"name":"credentials","status":"pass","message":"Authentication credentials are available.","remediation":null}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":true,"checks":[{"name":"credentials","status":"pass","message":"Authentication credentials are available.","remediation":null}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -3460,7 +3460,7 @@ func TestExecuteDoctorReportsMissingCredentialsAsARedactedCheck(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials are missing.","remediation":"Establish authentication before using commands that require it."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials are missing.","remediation":"Establish authentication before using commands that require it."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -3489,7 +3489,7 @@ func TestExecuteDoctorWarnsWhenCredentialsExpireSoon(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":true,"checks":[{"name":"credentials","status":"warn","message":"Authentication credentials expire soon.","remediation":"Refresh authentication before the credentials expire."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":true,"checks":[{"name":"credentials","status":"warn","message":"Authentication credentials expire soon.","remediation":"Refresh authentication before the credentials expire."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -3518,7 +3518,7 @@ func TestExecuteDoctorFailsExpiredCredentialsCheck(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials have expired.","remediation":"Re-establish authentication."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials have expired.","remediation":"Re-establish authentication."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -3547,7 +3547,7 @@ func TestExecuteDoctorRedactsInvalidCredentialFile(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials are invalid.","remediation":"Remove the invalid credentials and re-establish authentication."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials are invalid.","remediation":"Remove the invalid credentials and re-establish authentication."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -3579,7 +3579,7 @@ func TestExecuteDoctorRedactsCredentialStorageFailure(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Credential storage is unavailable.","remediation":"Check local credential file permissions."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Credential storage is unavailable.","remediation":"Check local credential file permissions."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -3687,7 +3687,7 @@ func TestExecuteUsesDefinitionForFlagFailureCommandMetadata(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"FLAG_REPEATED","message":"A scalar flag cannot be repeated.","retryable":false,"details":{"flag":"--non-interactive"}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"FLAG_REPEATED","message":"A scalar flag cannot be repeated.","retryable":false,"details":{"flag":"--non-interactive"}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -3731,7 +3731,7 @@ func TestExecuteUsesKnownCommandMetadataForInvalidArity(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_NOT_FOUND","message":"Unknown command.","retryable":false,"details":{}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_NOT_FOUND","message":"Unknown command.","retryable":false,"details":{}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -3756,7 +3756,7 @@ func TestExecuteAuthStatusReportsConfigurationDirectoryFailure(t *testing.T) {
 		},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CONFIG_DIRECTORY_UNAVAILABLE","message":"Local configuration directory is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CONFIG_DIRECTORY_UNAVAILABLE","message":"Local configuration directory is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5"}}` + "\n"
 	if result.ExitCode != 10 {
 		t.Fatalf("exit code = %d, want 10", result.ExitCode)
 	}
@@ -3781,7 +3781,7 @@ func TestExecuteDoctorDiagnosesConfigurationDirectoryFailure(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Configuration directory is unavailable.","remediation":"Set a usable user configuration directory."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Configuration directory is unavailable.","remediation":"Set a usable user configuration directory."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}

--- a/internal/app/execute_test.go
+++ b/internal/app/execute_test.go
@@ -2964,6 +2964,45 @@ func TestExecuteContactsListFailsClosedOnUnsupportedStatus(t *testing.T) {
 	}
 }
 
+func TestExecuteContactsListFailsClosedOnUnexpectedTerminalData(t *testing.T) {
+	const (
+		privateID   = "private-terminal-identity"
+		privateName = "Private Terminal Name"
+	)
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"contacts", "list"},
+		Stdin: strings.NewReader(""),
+	}, app.Dependencies{
+		Files: fakeFilesystem{
+			readFile: func(string) ([]byte, error) {
+				return []byte(
+					`{"accessToken":"private-access-token","expiresAt":"2026-08-11T02:00:00Z"}`,
+				), nil
+			},
+		},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+		AuthRandom: strings.NewReader("0123456789abcdef"),
+		HTTP: scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
+			return jsonResponse(
+				http.StatusOK,
+				`{"result":{"data":[{"id":"`+privateID+`","name":"`+privateName+`","sharedEventCount":1}],"paging":{}}}`,
+			), nil
+		}},
+	})
+
+	if result.ExitCode != 9 ||
+		!strings.Contains(result.Stdout, `"type":"contract.protocol_changed"`) {
+		t.Fatalf("result = %#v, want unexpected terminal data failure", result)
+	}
+	if strings.Contains(result.Stdout+result.Stderr, privateID) ||
+		strings.Contains(result.Stdout+result.Stderr, privateName) {
+		t.Fatal("terminal data failure exposed private contact content")
+	}
+}
+
 func TestExecuteAuthStatusRedactsHealthyCredentials(t *testing.T) {
 	const credentials = `{"accessToken":"secret-token-value","refreshToken":"secret-refresh-value","userId":"private-user-value","expiresAt":"2026-08-11T02:00:00Z"}`
 	result := app.Execute(context.Background(), app.Request{

--- a/internal/app/execute_test.go
+++ b/internal/app/execute_test.go
@@ -2363,6 +2363,107 @@ func TestExecuteContactsListFailsClosedBeyondReviewedTraversalBound(t *testing.T
 	}
 }
 
+func TestExecuteContactsListFailsClosedWhenPrivateIdentityIsMissing(t *testing.T) {
+	const (
+		credentials = `{"accessToken":"private-access-token","expiresAt":"2026-08-11T02:00:00Z"}`
+		privateName = "Private Name"
+	)
+	call := 0
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"contacts", "list"},
+		Stdin: strings.NewReader(""),
+	}, app.Dependencies{
+		Files: fakeFilesystem{
+			readFile: func(string) ([]byte, error) {
+				return []byte(credentials), nil
+			},
+		},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+		AuthRandom: strings.NewReader("0123456789abcdef"),
+		HTTP: scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
+			call++
+			if call > 1 {
+				return nil, errors.New("malformed contact was accepted")
+			}
+			return jsonResponse(
+				http.StatusOK,
+				`{"result":{"data":[{"name":"`+privateName+`","sharedEventCount":1}],"paging":{"nextCursor":"cursor"}}}`,
+			), nil
+		}},
+	})
+
+	if result.ExitCode != 9 ||
+		!strings.Contains(result.Stdout, `"type":"contract.protocol_changed"`) {
+		t.Fatalf("result = %#v, want required identity protocol failure", result)
+	}
+	if call != 1 {
+		t.Fatalf("request count = %d, want immediate shape failure", call)
+	}
+	if strings.Contains(result.Stdout+result.Stderr, privateName) {
+		t.Fatal("malformed contact failure exposed a private name")
+	}
+}
+
+func TestExecuteContactsListFailsClosedWhenTerminalPagingIsMissing(t *testing.T) {
+	const credentials = `{"accessToken":"private-access-token","expiresAt":"2026-08-11T02:00:00Z"}`
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"contacts", "list"},
+		Stdin: strings.NewReader(""),
+	}, app.Dependencies{
+		Files: fakeFilesystem{
+			readFile: func(string) ([]byte, error) {
+				return []byte(credentials), nil
+			},
+		},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+		AuthRandom: strings.NewReader("0123456789abcdef"),
+		HTTP: scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
+			return jsonResponse(http.StatusOK, `{"result":{"data":[]}}`), nil
+		}},
+	})
+
+	if result.ExitCode != 9 ||
+		!strings.Contains(result.Stdout, `"type":"contract.protocol_changed"`) {
+		t.Fatalf("result = %#v, want required paging protocol failure", result)
+	}
+}
+
+func TestExecuteContactsListFailsClosedOnNullRemoteCursor(t *testing.T) {
+	const credentials = `{"accessToken":"private-access-token","expiresAt":"2026-08-11T02:00:00Z"}`
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"contacts", "list"},
+		Stdin: strings.NewReader(""),
+	}, app.Dependencies{
+		Files: fakeFilesystem{
+			readFile: func(string) ([]byte, error) {
+				return []byte(credentials), nil
+			},
+		},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+		AuthRandom: strings.NewReader("0123456789abcdef"),
+		HTTP: scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
+			return jsonResponse(
+				http.StatusOK,
+				`{"result":{"data":[],"paging":{"nextCursor":null}}}`,
+			), nil
+		}},
+	})
+
+	if result.ExitCode != 9 ||
+		!strings.Contains(result.Stdout, `"type":"contract.protocol_changed"`) {
+		t.Fatalf("result = %#v, want invalid cursor shape protocol failure", result)
+	}
+}
+
 func TestExecuteAuthStatusRedactsHealthyCredentials(t *testing.T) {
 	const credentials = `{"accessToken":"secret-token-value","refreshToken":"secret-refresh-value","userId":"private-user-value","expiresAt":"2026-08-11T02:00:00Z"}`
 	result := app.Execute(context.Background(), app.Request{

--- a/internal/app/execute_test.go
+++ b/internal/app/execute_test.go
@@ -2437,6 +2437,86 @@ func TestExecuteContactsListFailsClosedWhenTerminalPagingIsMissing(t *testing.T)
 	}
 }
 
+func TestExecuteContactsListRejectsUnknownSuccessEnvelopeFields(t *testing.T) {
+	const (
+		credentials  = `{"accessToken":"private-access-token","expiresAt":"2026-08-11T02:00:00Z"}`
+		privateValue = "private-unknown-envelope-value"
+	)
+	call := 0
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"contacts", "list"},
+		Stdin: strings.NewReader(""),
+	}, app.Dependencies{
+		Files: fakeFilesystem{
+			readFile: func(string) ([]byte, error) {
+				return []byte(credentials), nil
+			},
+		},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+		AuthRandom: strings.NewReader("0123456789abcdef"),
+		HTTP: scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
+			call++
+			if call > 1 {
+				return nil, errors.New("unknown success field was accepted")
+			}
+			return jsonResponse(
+				http.StatusOK,
+				`{"result":{"data":[],"paging":{}},"unknown":"`+privateValue+`"}`,
+			), nil
+		}},
+	})
+
+	if result.ExitCode != 9 ||
+		!strings.Contains(result.Stdout, `"type":"contract.protocol_changed"`) {
+		t.Fatalf("result = %#v, want unknown success field protocol failure", result)
+	}
+	if call != 1 {
+		t.Fatalf("request count = %d, want immediate envelope failure", call)
+	}
+	if strings.Contains(result.Stdout+result.Stderr, privateValue) {
+		t.Fatal("unknown success field exposed private transport content")
+	}
+}
+
+func TestExecuteContactsListRejectsTrailingSuccessJSON(t *testing.T) {
+	const (
+		credentials  = `{"accessToken":"private-access-token","expiresAt":"2026-08-11T02:00:00Z"}`
+		privateValue = "private-trailing-json-value"
+	)
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"contacts", "list"},
+		Stdin: strings.NewReader(""),
+	}, app.Dependencies{
+		Files: fakeFilesystem{
+			readFile: func(string) ([]byte, error) {
+				return []byte(credentials), nil
+			},
+		},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+		AuthRandom: strings.NewReader("0123456789abcdef"),
+		HTTP: scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
+			return jsonResponse(
+				http.StatusOK,
+				`{"result":{"data":[],"paging":{}}}{"trailing":"`+privateValue+`"}`,
+			), nil
+		}},
+	})
+
+	if result.ExitCode != 9 ||
+		!strings.Contains(result.Stdout, `"type":"contract.protocol_changed"`) {
+		t.Fatalf("result = %#v, want trailing JSON protocol failure", result)
+	}
+	if strings.Contains(result.Stdout+result.Stderr, privateValue) {
+		t.Fatal("trailing JSON failure exposed private transport content")
+	}
+}
+
 func TestExecuteContactsListFailsClosedOnNullRemoteCursor(t *testing.T) {
 	const credentials = `{"accessToken":"private-access-token","expiresAt":"2026-08-11T02:00:00Z"}`
 	result := app.Execute(context.Background(), app.Request{
@@ -2500,6 +2580,36 @@ func TestExecuteContactsListRejectsUnknownUnauthenticatedErrorFields(t *testing.
 	}
 	if strings.Contains(result.Stdout+result.Stderr, privateValue) {
 		t.Fatal("unauthenticated failure exposed remote response content")
+	}
+}
+
+func TestExecuteContactsListMapsReviewedUnauthenticatedResponseToExpired(t *testing.T) {
+	const credentials = `{"accessToken":"private-access-token","expiresAt":"2026-08-11T02:00:00Z"}`
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"contacts", "list"},
+		Stdin: strings.NewReader(""),
+	}, app.Dependencies{
+		Files: fakeFilesystem{
+			readFile: func(string) ([]byte, error) {
+				return []byte(credentials), nil
+			},
+		},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+		AuthRandom: strings.NewReader("0123456789abcdef"),
+		HTTP: scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
+			return jsonResponse(
+				http.StatusUnauthorized,
+				`{"error":{"message":"Unauthenticated","status":"UNAUTHENTICATED"}}`,
+			), nil
+		}},
+	})
+
+	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"REMOTE_SESSION_UNAUTHENTICATED","message":"Stored authentication is no longer accepted. Log in again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5"}}` + "\n"
+	if result.ExitCode != 3 || result.Stdout != wantStdout {
+		t.Fatalf("result = %#v, want reviewed unauthenticated mapping", result)
 	}
 }
 

--- a/internal/app/execute_test.go
+++ b/internal/app/execute_test.go
@@ -2180,6 +2180,97 @@ func TestExecuteContactsListFiltersLocallyAfterFirstIdentityOccurrenceWins(t *te
 	}
 }
 
+func TestExecuteContactsListReturnsOpaqueResumableLocalCursor(t *testing.T) {
+	const (
+		credentials = `{"accessToken":"private-access-token","expiresAt":"2026-08-11T02:00:00Z"}`
+		dataPage    = `{"result":{"data":[{"id":"private-one","name":"One","sharedEventCount":1},{"id":"private-two","name":"Two","sharedEventCount":2},{"id":"private-three","name":"Three","sharedEventCount":3}],"paging":{"nextCursor":"private-remote-cursor"}}}`
+		terminal    = `{"result":{"data":[],"paging":{}}}`
+	)
+	call := 0
+	dependencies := withTestCursorCrypto(app.Dependencies{
+		Files: fakeFilesystem{
+			readFile: func(string) ([]byte, error) {
+				return []byte(credentials), nil
+			},
+		},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+		AuthRandom: strings.NewReader("0123456789abcdefFEDCBA9876543210"),
+		HTTP: scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
+			call++
+			if call%2 == 1 {
+				return jsonResponse(http.StatusOK, dataPage), nil
+			}
+			return jsonResponse(http.StatusOK, terminal), nil
+		}},
+	})
+	first := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"contacts", "list", "--limit", "2"},
+		Stdin: strings.NewReader(""),
+	}, dependencies)
+	var firstEnvelope struct {
+		Data struct {
+			Items []contactOutput `json:"items"`
+		} `json:"data"`
+		Meta struct {
+			Page struct {
+				NextCursor *string `json:"nextCursor"`
+				HasMore    bool    `json:"hasMore"`
+			} `json:"page"`
+		} `json:"meta"`
+	}
+	if err := json.Unmarshal([]byte(first.Stdout), &firstEnvelope); err != nil {
+		t.Fatalf("decode first result: %v", err)
+	}
+	if first.ExitCode != 0 ||
+		!reflect.DeepEqual(firstEnvelope.Data.Items, []contactOutput{{"One", 1}, {"Two", 2}}) ||
+		!firstEnvelope.Meta.Page.HasMore ||
+		firstEnvelope.Meta.Page.NextCursor == nil {
+		t.Fatalf("first result = %#v, envelope = %#v, want resumable first page", first, firstEnvelope)
+	}
+	cursor := *firstEnvelope.Meta.Page.NextCursor
+	for _, privateValue := range []string{"private-one", "private-two", "private-three"} {
+		if strings.Contains(cursor, privateValue) {
+			t.Fatalf("local cursor exposed private identity %q", privateValue)
+		}
+	}
+
+	second := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"contacts", "list", "--limit", "2", "--cursor", cursor},
+		Stdin: strings.NewReader(""),
+	}, dependencies)
+	var secondEnvelope struct {
+		Data struct {
+			Items []contactOutput `json:"items"`
+		} `json:"data"`
+		Meta struct {
+			Page struct {
+				NextCursor *string `json:"nextCursor"`
+				HasMore    bool    `json:"hasMore"`
+			} `json:"page"`
+		} `json:"meta"`
+	}
+	if err := json.Unmarshal([]byte(second.Stdout), &secondEnvelope); err != nil {
+		t.Fatalf("decode second result: %v", err)
+	}
+	if second.ExitCode != 0 ||
+		!reflect.DeepEqual(secondEnvelope.Data.Items, []contactOutput{{"Three", 3}}) ||
+		secondEnvelope.Meta.Page.HasMore ||
+		secondEnvelope.Meta.Page.NextCursor != nil {
+		t.Fatalf("second result = %#v, envelope = %#v, want completed second page", second, secondEnvelope)
+	}
+	if call != 4 {
+		t.Fatalf("request count = %d, want two complete traversals", call)
+	}
+}
+
+type contactOutput struct {
+	DisplayName      string `json:"displayName"`
+	SharedEventCount int    `json:"sharedEventCount"`
+}
+
 func TestExecuteAuthStatusRedactsHealthyCredentials(t *testing.T) {
 	const credentials = `{"accessToken":"secret-token-value","refreshToken":"secret-refresh-value","userId":"private-user-value","expiresAt":"2026-08-11T02:00:00Z"}`
 	result := app.Execute(context.Background(), app.Request{

--- a/internal/app/execute_test.go
+++ b/internal/app/execute_test.go
@@ -2437,10 +2437,12 @@ func TestExecuteContactsListFailsClosedWhenTerminalPagingIsMissing(t *testing.T)
 	}
 }
 
-func TestExecuteContactsListRejectsUnknownSuccessEnvelopeFields(t *testing.T) {
+func TestExecuteContactsListAcceptsOpenReviewedResponseFields(t *testing.T) {
 	const (
-		credentials  = `{"accessToken":"private-access-token","expiresAt":"2026-08-11T02:00:00Z"}`
-		privateValue = "private-unknown-envelope-value"
+		credentials          = `{"accessToken":"private-access-token","expiresAt":"2026-08-11T02:00:00Z"}`
+		privateContactValue  = "private-unknown-contact-value"
+		privateNestedValue   = "private-unknown-nested-value"
+		privateEnvelopeValue = "private-unknown-envelope-value"
 	)
 	call := 0
 	result := app.Execute(context.Background(), app.Request{
@@ -2459,25 +2461,36 @@ func TestExecuteContactsListRejectsUnknownSuccessEnvelopeFields(t *testing.T) {
 		AuthRandom: strings.NewReader("0123456789abcdef"),
 		HTTP: scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
 			call++
-			if call > 1 {
-				return nil, errors.New("unknown success field was accepted")
+			if call == 1 {
+				return jsonResponse(
+					http.StatusOK,
+					`{"result":{"data":[{"id":"private-contact-id","name":"Open Contact","sharedEventCount":4,"unknownContact":"`+privateContactValue+`","unknownObject":{"nested":"`+privateNestedValue+`"}}],"paging":{"nextCursor":"private-remote-cursor","unknownPageInteger":11},"unknownResult":true},"unknownEnvelope":"`+privateEnvelopeValue+`"}`,
+				), nil
 			}
 			return jsonResponse(
 				http.StatusOK,
-				`{"result":{"data":[],"paging":{}},"unknown":"`+privateValue+`"}`,
+				`{"result":{"data":[],"paging":{"unknownTerminalInteger":7}},"unknownEnvelopeInteger":9}`,
 			), nil
 		}},
 	})
 
-	if result.ExitCode != 9 ||
-		!strings.Contains(result.Stdout, `"type":"contract.protocol_changed"`) {
-		t.Fatalf("result = %#v, want unknown success field protocol failure", result)
+	const want = `{"ok":true,"data":{"items":[{"displayName":"Open Contact","sharedEventCount":4}]},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
+	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
+		t.Fatalf("result = %#v, want reviewed open response traversal", result)
 	}
-	if call != 1 {
-		t.Fatalf("request count = %d, want immediate envelope failure", call)
+	if call != 2 {
+		t.Fatalf("request count = %d, want data and terminal pages", call)
 	}
-	if strings.Contains(result.Stdout+result.Stderr, privateValue) {
-		t.Fatal("unknown success field exposed private transport content")
+	for _, privateValue := range []string{
+		"private-contact-id",
+		"private-remote-cursor",
+		privateContactValue,
+		privateNestedValue,
+		privateEnvelopeValue,
+	} {
+		if strings.Contains(result.Stdout+result.Stderr, privateValue) {
+			t.Fatalf("open response exposed private transport value %q", privateValue)
+		}
 	}
 }
 
@@ -2547,7 +2560,7 @@ func TestExecuteContactsListFailsClosedOnNullRemoteCursor(t *testing.T) {
 	}
 }
 
-func TestExecuteContactsListRejectsUnknownUnauthenticatedErrorFields(t *testing.T) {
+func TestExecuteContactsListAcceptsUnknownUnauthenticatedErrorFields(t *testing.T) {
 	const (
 		credentials  = `{"accessToken":"private-access-token","expiresAt":"2026-08-11T02:00:00Z"}`
 		privateValue = "private-remote-detail"
@@ -2574,9 +2587,9 @@ func TestExecuteContactsListRejectsUnknownUnauthenticatedErrorFields(t *testing.
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"CONTACTS_PROTOCOL_CHANGED","message":"Contacts no longer match the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5"}}` + "\n"
-	if result.ExitCode != 9 || result.Stdout != wantStdout {
-		t.Fatalf("result = %#v, want unknown error field protocol failure", result)
+	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"REMOTE_SESSION_UNAUTHENTICATED","message":"Stored authentication is no longer accepted. Log in again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5"}}` + "\n"
+	if result.ExitCode != 3 || result.Stdout != wantStdout {
+		t.Fatalf("result = %#v, want reviewed unauthenticated mapping", result)
 	}
 	if strings.Contains(result.Stdout+result.Stderr, privateValue) {
 		t.Fatal("unauthenticated failure exposed remote response content")

--- a/internal/app/execute_test.go
+++ b/internal/app/execute_test.go
@@ -2464,6 +2464,118 @@ func TestExecuteContactsListFailsClosedOnNullRemoteCursor(t *testing.T) {
 	}
 }
 
+func TestExecuteContactsListMapsReviewedUnauthenticatedResponseToExpired(t *testing.T) {
+	const (
+		credentials  = `{"accessToken":"private-access-token","expiresAt":"2026-08-11T02:00:00Z"}`
+		privateValue = "private-remote-detail"
+	)
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"contacts", "list"},
+		Stdin: strings.NewReader(""),
+	}, app.Dependencies{
+		Files: fakeFilesystem{
+			readFile: func(string) ([]byte, error) {
+				return []byte(credentials), nil
+			},
+		},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+		AuthRandom: strings.NewReader("0123456789abcdef"),
+		HTTP: scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
+			return jsonResponse(
+				http.StatusUnauthorized,
+				`{"error":{"message":"Unauthenticated","status":"UNAUTHENTICATED","detail":"`+privateValue+`"}}`,
+			), nil
+		}},
+	})
+
+	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"REMOTE_SESSION_UNAUTHENTICATED","message":"Stored authentication is no longer accepted. Log in again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4"}}` + "\n"
+	if result.ExitCode != 3 || result.Stdout != wantStdout {
+		t.Fatalf("result = %#v, want reviewed unauthenticated mapping", result)
+	}
+	if strings.Contains(result.Stdout+result.Stderr, privateValue) {
+		t.Fatal("unauthenticated failure exposed remote response content")
+	}
+}
+
+func TestExecuteContactsListRefreshesExpiringSessionBeforeProtectedRead(t *testing.T) {
+	const (
+		credentialsPath = "/config/partiful/credentials.json"
+		oldAccess       = "private-old-access"
+		newAccess       = "private-new-access"
+		newRefresh      = "private-new-refresh"
+	)
+	document := []byte(
+		`{"accessToken":"` + oldAccess +
+			`","refreshToken":"private-old-refresh","expiresAt":"2026-08-11T00:04:00Z"}`,
+	)
+	call := 0
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"contacts", "list"},
+		Stdin: strings.NewReader(""),
+	}, app.Dependencies{
+		Files: fakeFilesystem{
+			readFile: func(string) ([]byte, error) {
+				return append([]byte(nil), document...), nil
+			},
+			writeFileAtomic: func(_ string, replacement []byte) error {
+				document = append([]byte(nil), replacement...)
+				return nil
+			},
+		},
+		CredentialsPath: credentialsPath,
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+		AuthRandom: strings.NewReader("0123456789abcdef"),
+		HTTP: scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+			call++
+			switch call {
+			case 1:
+				if request.URL.Host != "securetoken.googleapis.com" {
+					t.Fatalf("first request host = %q, want session refresh", request.URL.Host)
+				}
+				return jsonResponse(
+					http.StatusOK,
+					`{"access_token":"private-alias","id_token":"`+newAccess+`","refresh_token":"`+newRefresh+`","expires_in":"3600","token_type":"Bearer"}`,
+				), nil
+			case 2:
+				if got := request.Header.Get("Authorization"); got != "Bearer "+newAccess {
+					t.Fatalf("contacts authorization = %q, want refreshed session", got)
+				}
+				return jsonResponse(
+					http.StatusOK,
+					`{"result":{"data":[{"id":"private-contact","name":"Refreshed Contact","sharedEventCount":4}],"paging":{"nextCursor":"remote-cursor"}}}`,
+				), nil
+			case 3:
+				return jsonResponse(
+					http.StatusOK,
+					`{"result":{"data":[],"paging":{}}}`,
+				), nil
+			default:
+				return nil, errors.New("unexpected request")
+			}
+		}},
+	})
+
+	if result.ExitCode != 0 ||
+		!strings.Contains(result.Stdout, `"displayName":"Refreshed Contact"`) {
+		t.Fatalf("result = %#v, want protected read after deterministic refresh", result)
+	}
+	if !bytes.Contains(document, []byte(newAccess)) ||
+		!bytes.Contains(document, []byte(newRefresh)) ||
+		bytes.Contains(document, []byte(oldAccess)) {
+		t.Fatal("credentials were not atomically replaced with refreshed session")
+	}
+	for _, privateValue := range []string{oldAccess, newAccess, newRefresh, "private-contact"} {
+		if strings.Contains(result.Stdout+result.Stderr, privateValue) {
+			t.Fatalf("result exposed private session value %q", privateValue)
+		}
+	}
+}
+
 func TestExecuteAuthStatusRedactsHealthyCredentials(t *testing.T) {
 	const credentials = `{"accessToken":"secret-token-value","refreshToken":"secret-refresh-value","userId":"private-user-value","expiresAt":"2026-08-11T02:00:00Z"}`
 	result := app.Execute(context.Background(), app.Request{

--- a/internal/app/execute_test.go
+++ b/internal/app/execute_test.go
@@ -2271,6 +2271,52 @@ type contactOutput struct {
 	SharedEventCount int    `json:"sharedEventCount"`
 }
 
+func TestExecuteContactsListFailsClosedOnRepeatedRemoteCursor(t *testing.T) {
+	const (
+		credentials = `{"accessToken":"private-access-token","expiresAt":"2026-08-11T02:00:00Z"}`
+		privateLoop = "private-repeated-cursor"
+	)
+	call := 0
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"contacts", "list"},
+		Stdin: strings.NewReader(""),
+	}, app.Dependencies{
+		Files: fakeFilesystem{
+			readFile: func(string) ([]byte, error) {
+				return []byte(credentials), nil
+			},
+		},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+		AuthRandom: strings.NewReader("0123456789abcdef"),
+		HTTP: scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
+			call++
+			if call > 2 {
+				return nil, errors.New("traversal continued after repeated cursor")
+			}
+			return jsonResponse(
+				http.StatusOK,
+				`{"result":{"data":[{"id":"private-id","name":"Private Name","sharedEventCount":1}],"paging":{"nextCursor":"`+privateLoop+`"}}}`,
+			), nil
+		}},
+	})
+
+	if result.ExitCode != 9 ||
+		!strings.Contains(result.Stdout, `"type":"contract.protocol_changed"`) ||
+		!strings.Contains(result.Stdout, `"code":"CONTACTS_PROTOCOL_CHANGED"`) {
+		t.Fatalf("result = %#v, want repeated cursor protocol failure", result)
+	}
+	if call != 2 {
+		t.Fatalf("request count = %d, want stop on repeated cursor", call)
+	}
+	if strings.Contains(result.Stdout+result.Stderr, privateLoop) ||
+		strings.Contains(result.Stdout+result.Stderr, "private-id") {
+		t.Fatal("repeated cursor failure exposed private transport data")
+	}
+}
+
 func TestExecuteAuthStatusRedactsHealthyCredentials(t *testing.T) {
 	const credentials = `{"accessToken":"secret-token-value","refreshToken":"secret-refresh-value","userId":"private-user-value","expiresAt":"2026-08-11T02:00:00Z"}`
 	result := app.Execute(context.Background(), app.Request{

--- a/internal/app/execute_test.go
+++ b/internal/app/execute_test.go
@@ -2317,6 +2317,52 @@ func TestExecuteContactsListFailsClosedOnRepeatedRemoteCursor(t *testing.T) {
 	}
 }
 
+func TestExecuteContactsListFailsClosedBeyondReviewedTraversalBound(t *testing.T) {
+	const credentials = `{"accessToken":"private-access-token","expiresAt":"2026-08-11T02:00:00Z"}`
+	call := 0
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"contacts", "list", "--all", "--max-items", "1000"},
+		Stdin: strings.NewReader(""),
+	}, app.Dependencies{
+		Files: fakeFilesystem{
+			readFile: func(string) ([]byte, error) {
+				return []byte(credentials), nil
+			},
+		},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+		AuthRandom: strings.NewReader("0123456789abcdef"),
+		HTTP: scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
+			call++
+			if call > 4 {
+				return nil, errors.New("traversal exceeded finite request bound")
+			}
+			return jsonResponse(
+				http.StatusOK,
+				fmt.Sprintf(
+					`{"result":{"data":[{"id":"private-%d","name":"Private","sharedEventCount":0}],"paging":{"nextCursor":"cursor-%d"}}}`,
+					call,
+					call,
+				),
+			), nil
+		}},
+	})
+
+	if result.ExitCode != 9 ||
+		!strings.Contains(result.Stdout, `"type":"contract.protocol_changed"`) {
+		t.Fatalf("result = %#v, want finite traversal failure", result)
+	}
+	if call != 4 {
+		t.Fatalf("request count = %d, want stop at first page beyond reviewed bound", call)
+	}
+	if strings.Contains(result.Stdout+result.Stderr, "private-") ||
+		strings.Contains(result.Stdout+result.Stderr, "cursor-") {
+		t.Fatal("traversal bound failure exposed private transport data")
+	}
+}
+
 func TestExecuteAuthStatusRedactsHealthyCredentials(t *testing.T) {
 	const credentials = `{"accessToken":"secret-token-value","refreshToken":"secret-refresh-value","userId":"private-user-value","expiresAt":"2026-08-11T02:00:00Z"}`
 	result := app.Execute(context.Background(), app.Request{

--- a/internal/app/execute_test.go
+++ b/internal/app/execute_test.go
@@ -2467,7 +2467,7 @@ func TestExecuteContactsListFailsClosedOnNullRemoteCursor(t *testing.T) {
 	}
 }
 
-func TestExecuteContactsListMapsReviewedUnauthenticatedResponseToExpired(t *testing.T) {
+func TestExecuteContactsListRejectsUnknownUnauthenticatedErrorFields(t *testing.T) {
 	const (
 		credentials  = `{"accessToken":"private-access-token","expiresAt":"2026-08-11T02:00:00Z"}`
 		privateValue = "private-remote-detail"
@@ -2494,9 +2494,9 @@ func TestExecuteContactsListMapsReviewedUnauthenticatedResponseToExpired(t *test
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"REMOTE_SESSION_UNAUTHENTICATED","message":"Stored authentication is no longer accepted. Log in again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5"}}` + "\n"
-	if result.ExitCode != 3 || result.Stdout != wantStdout {
-		t.Fatalf("result = %#v, want reviewed unauthenticated mapping", result)
+	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"CONTACTS_PROTOCOL_CHANGED","message":"Contacts no longer match the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5"}}` + "\n"
+	if result.ExitCode != 9 || result.Stdout != wantStdout {
+		t.Fatalf("result = %#v, want unknown error field protocol failure", result)
 	}
 	if strings.Contains(result.Stdout+result.Stderr, privateValue) {
 		t.Fatal("unauthenticated failure exposed remote response content")

--- a/internal/app/execute_test.go
+++ b/internal/app/execute_test.go
@@ -2827,6 +2827,143 @@ func TestExecuteContactsListPreservesUnauthenticatedBodyReadFailureAsUnavailable
 	}
 }
 
+func TestExecuteContactsListReportsUnavailableConfigurationBeforeProtectedRead(t *testing.T) {
+	const privateConfigurationError = "private configuration path failure"
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"contacts", "list"},
+		Stdin: strings.NewReader(""),
+	}, app.Dependencies{
+		CredentialsPathError: errors.New(privateConfigurationError),
+		AuthRandom:           strings.NewReader("must-not-be-read"),
+		HTTP: scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
+			return nil, errors.New("remote must not be called")
+		}},
+	})
+
+	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CONFIG_DIRECTORY_UNAVAILABLE","message":"Local configuration directory is unavailable.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5"}}` + "\n"
+	if result.ExitCode != 10 || result.Stdout != wantStdout {
+		t.Fatalf("result = %#v, want unavailable configuration failure", result)
+	}
+	if strings.Contains(result.Stdout+result.Stderr, privateConfigurationError) {
+		t.Fatal("configuration failure exposed private local details")
+	}
+}
+
+func TestExecuteContactsListRequiresAuthenticationWithoutRemoteCall(t *testing.T) {
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"contacts", "list"},
+		Stdin: strings.NewReader(""),
+	}, app.Dependencies{
+		Files: fakeFilesystem{
+			readFile: func(string) ([]byte, error) {
+				return nil, fs.ErrNotExist
+			},
+		},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+		AuthRandom: strings.NewReader("must-not-be-read"),
+		HTTP: scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
+			return nil, errors.New("remote must not be called")
+		}},
+	})
+
+	const wantStdout = `{"ok":false,"error":{"type":"auth.required","code":"AUTHENTICATION_REQUIRED","message":"Authentication is required. Log in and try again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.5"}}` + "\n"
+	if result.ExitCode != 3 || result.Stdout != wantStdout {
+		t.Fatalf("result = %#v, want authentication requirement", result)
+	}
+}
+
+func TestExecuteContactsListPreservesAmbiguousDisplayNamesWithoutIdentity(t *testing.T) {
+	const ambiguousName = "Same Display Name"
+	call := 0
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"contacts", "list", "--query", "same display"},
+		Stdin: strings.NewReader(""),
+	}, app.Dependencies{
+		Files: fakeFilesystem{
+			readFile: func(string) ([]byte, error) {
+				return []byte(
+					`{"accessToken":"private-access-token","expiresAt":"2026-08-11T02:00:00Z"}`,
+				), nil
+			},
+		},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+		AuthRandom: strings.NewReader("0123456789abcdef"),
+		HTTP: scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
+			call++
+			if call == 1 {
+				return jsonResponse(
+					http.StatusOK,
+					`{"result":{"data":[{"id":"private-first","name":"`+ambiguousName+`","sharedEventCount":1},{"id":"private-second","name":"`+ambiguousName+`","sharedEventCount":2}],"paging":{"nextCursor":"private-cursor"}}}`,
+				), nil
+			}
+			return jsonResponse(http.StatusOK, `{"result":{"data":[],"paging":{}}}`), nil
+		}},
+	})
+
+	var envelope struct {
+		Data struct {
+			Items []contactOutput `json:"items"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(result.Stdout), &envelope); err != nil {
+		t.Fatalf("decode result: %v", err)
+	}
+	want := []contactOutput{
+		{DisplayName: ambiguousName, SharedEventCount: 1},
+		{DisplayName: ambiguousName, SharedEventCount: 2},
+	}
+	if result.ExitCode != 0 || !reflect.DeepEqual(envelope.Data.Items, want) {
+		t.Fatalf("result = %#v, items = %#v, want both ambiguous public matches", result, envelope.Data.Items)
+	}
+	for _, privateValue := range []string{"private-first", "private-second", "private-cursor"} {
+		if strings.Contains(result.Stdout+result.Stderr, privateValue) {
+			t.Fatalf("ambiguous result exposed private identity %q", privateValue)
+		}
+	}
+}
+
+func TestExecuteContactsListFailsClosedOnUnsupportedStatus(t *testing.T) {
+	const privateBody = "private unsupported response"
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"contacts", "list"},
+		Stdin: strings.NewReader(""),
+	}, app.Dependencies{
+		Files: fakeFilesystem{
+			readFile: func(string) ([]byte, error) {
+				return []byte(
+					`{"accessToken":"private-access-token","expiresAt":"2026-08-11T02:00:00Z"}`,
+				), nil
+			},
+		},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+		AuthRandom: strings.NewReader("0123456789abcdef"),
+		HTTP: scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
+			return jsonResponse(
+				http.StatusTooManyRequests,
+				`{"error":"`+privateBody+`"}`,
+			), nil
+		}},
+	})
+
+	if result.ExitCode != 9 ||
+		!strings.Contains(result.Stdout, `"type":"contract.protocol_changed"`) ||
+		strings.Contains(result.Stdout, `"type":"remote.rate_limited"`) {
+		t.Fatalf("result = %#v, want unsupported status protocol failure", result)
+	}
+	if strings.Contains(result.Stdout+result.Stderr, privateBody) {
+		t.Fatal("unsupported status exposed remote response body")
+	}
+}
+
 func TestExecuteAuthStatusRedactsHealthyCredentials(t *testing.T) {
 	const credentials = `{"accessToken":"secret-token-value","refreshToken":"secret-refresh-value","userId":"private-user-value","expiresAt":"2026-08-11T02:00:00Z"}`
 	result := app.Execute(context.Background(), app.Request{

--- a/internal/app/execute_test.go
+++ b/internal/app/execute_test.go
@@ -2125,6 +2125,61 @@ func TestExecuteContactsListTraversesReviewedPagesAndReturnsOnlyPublicFields(t *
 	}
 }
 
+func TestExecuteContactsListFiltersLocallyAfterFirstIdentityOccurrenceWins(t *testing.T) {
+	const credentials = `{"accessToken":"private-access-token","expiresAt":"2026-08-11T02:00:00Z"}`
+	responses := []string{
+		`{"result":{"data":[{"id":"private-duplicate","name":"Alice First","sharedEventCount":1},{"id":"private-other","name":"Bob","sharedEventCount":2}],"paging":{"nextCursor":"cursor-one"}}}`,
+		`{"result":{"data":[{"id":"private-duplicate","name":"Alice Later","sharedEventCount":99},{"id":"private-second","name":"Second ALICE","sharedEventCount":3}],"paging":{"nextCursor":"cursor-two"}}}`,
+		`{"result":{"data":[],"paging":{}}}`,
+	}
+	call := 0
+	result := app.Execute(context.Background(), app.Request{
+		Argv:  []string{"contacts", "list", "--query", "  ALICE  "},
+		Stdin: strings.NewReader(""),
+	}, app.Dependencies{
+		Files: fakeFilesystem{
+			readFile: func(string) ([]byte, error) {
+				return []byte(credentials), nil
+			},
+		},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+		},
+		AuthRandom: strings.NewReader("0123456789abcdef"),
+		HTTP: scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+			body, err := io.ReadAll(request.Body)
+			if err != nil {
+				t.Fatalf("read request body: %v", err)
+			}
+			if bytes.Contains(body, []byte("ALICE")) || bytes.Contains(body, []byte("alice")) {
+				t.Fatalf("request sent local query to remote: %s", body)
+			}
+			response := jsonResponse(http.StatusOK, responses[call])
+			call++
+			return response, nil
+		}},
+	})
+
+	const want = `{"ok":true,"data":{"items":[{"displayName":"Alice First","sharedEventCount":1},{"displayName":"Second ALICE","sharedEventCount":3}]},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-10.1","remoteContractRevision":"2026-08-11.4","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
+	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
+		t.Fatalf("result = %#v, want locally filtered first-occurrence contacts", result)
+	}
+	if call != len(responses) {
+		t.Fatalf("request count = %d, want %d", call, len(responses))
+	}
+	for _, privateValue := range []string{
+		"private-duplicate",
+		"private-other",
+		"private-second",
+		"Alice Later",
+	} {
+		if strings.Contains(result.Stdout+result.Stderr, privateValue) {
+			t.Fatalf("result exposed non-public value %q", privateValue)
+		}
+	}
+}
+
 func TestExecuteAuthStatusRedactsHealthyCredentials(t *testing.T) {
 	const credentials = `{"accessToken":"secret-token-value","refreshToken":"secret-refresh-value","userId":"private-user-value","expiresAt":"2026-08-11T02:00:00Z"}`
 	result := app.Execute(context.Background(), app.Request{

--- a/internal/app/posters.go
+++ b/internal/app/posters.go
@@ -261,6 +261,7 @@ func cursorSnapshotOffset(
 	payload cursorPayload,
 	payloadDigest [sha256.Size]byte,
 	itemCount int,
+	changedMessage string,
 ) (int, *cursorValidationFailure) {
 	if payload.Digest != hex.EncodeToString(payloadDigest[:]) {
 		return 0, &cursorValidationFailure{
@@ -268,7 +269,7 @@ func cursorSnapshotOffset(
 			body: errorBody{
 				Type:      "state.conflict",
 				Code:      "CURSOR_SNAPSHOT_CHANGED",
-				Message:   "The poster catalog changed after this cursor was issued.",
+				Message:   changedMessage,
 				Retryable: false,
 				Details:   map[string]any{},
 			},

--- a/internal/app/posters.go
+++ b/internal/app/posters.go
@@ -68,13 +68,18 @@ func parseCollectionOptions(definition commandDefinition, argv []string) (collec
 		return collectionOptions{}, &failure.body
 	}
 	_, options.all = values["--all"]
-	if definition.kind == postersSearchCommand {
-		options.query = strings.ToLower(strings.TrimSpace(values["--query"]))
-		if options.query == "" {
+	if definition.kind == postersSearchCommand || definition.kind == contactsListCommand {
+		query, queryProvided := values["--query"]
+		options.query = strings.ToLower(strings.TrimSpace(query))
+		if (definition.kind == postersSearchCommand || queryProvided) && options.query == "" {
+			message := "Query must not be empty."
+			if definition.kind == postersSearchCommand {
+				message = "Search query must not be empty."
+			}
 			return collectionOptions{}, &errorBody{
 				Type:      "input.invalid",
 				Code:      "QUERY_REQUIRED",
-				Message:   "Search query must not be empty.",
+				Message:   message,
 				Retryable: false,
 				Details:   map[string]any{},
 			}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -189,8 +189,31 @@ func AcquireSession(
 			operationErr = err
 			return
 		}
-		if !credentials.ExpiresAt.After(now()) {
-			operationErr = ErrExpired
+		state := stateFromCredentials(credentials, now())
+		if state.TokenState == "healthy" {
+			session = Session{AccessToken: credentials.AccessToken}
+			return
+		}
+		if credentials.RefreshToken == "" {
+			if state.TokenState == "expired" {
+				operationErr = ErrExpired
+				return
+			}
+			session = Session{AccessToken: credentials.AccessToken}
+			return
+		}
+		refreshed, err := client.RefreshToken(ctx, credentials.RefreshToken)
+		if err != nil {
+			operationErr = err
+			return
+		}
+		credentials = credentialRecord{
+			AccessToken:  refreshed.IDToken,
+			RefreshToken: refreshed.RefreshToken,
+			ExpiresAt:    now().Add(refreshed.ExpiresIn).UTC(),
+		}
+		if err := saveCredentialsUnlocked(files, path, credentials); err != nil {
+			operationErr = ErrPersistence
 			return
 		}
 		session = Session{AccessToken: credentials.AccessToken}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -15,6 +15,8 @@ var (
 	ErrNotConfigured         = errors.New("credential storage is not configured")
 	ErrUnavailable           = errors.New("credential storage is unavailable")
 	ErrInvalid               = errors.New("credential record is invalid")
+	ErrRequired              = errors.New("authentication is required")
+	ErrExpired               = errors.New("authentication has expired")
 	ErrHumanRequired         = errors.New("a private terminal is required")
 	ErrInputInvalid          = errors.New("authentication input is invalid")
 	ErrPersistence           = errors.New("credential persistence failed")
@@ -39,6 +41,10 @@ type State struct {
 	Authenticated bool       `json:"authenticated"`
 	TokenState    string     `json:"tokenState"`
 	ExpiresAt     *time.Time `json:"expiresAt"`
+}
+
+type Session struct {
+	AccessToken string
 }
 
 type credentialRecord struct {
@@ -157,6 +163,44 @@ func StatusWithRefresh(
 ) (State, error) {
 	state, err := refreshCredentials(ctx, files, path, now, client)
 	return state, err
+}
+
+func AcquireSession(
+	ctx context.Context,
+	files FileSystem,
+	path string,
+	now func() time.Time,
+	client RemoteAuth,
+) (Session, error) {
+	if files == nil || path == "" || now == nil {
+		return Session{}, ErrNotConfigured
+	}
+	var (
+		session      Session
+		operationErr error
+	)
+	if err := files.WithLock(path, func() {
+		credentials, err := loadCredentials(files, path)
+		if errors.Is(err, fs.ErrNotExist) {
+			operationErr = ErrRequired
+			return
+		}
+		if err != nil {
+			operationErr = err
+			return
+		}
+		if !credentials.ExpiresAt.After(now()) {
+			operationErr = ErrExpired
+			return
+		}
+		session = Session{AccessToken: credentials.AccessToken}
+	}); err != nil {
+		return Session{}, ErrUnavailable
+	}
+	if operationErr != nil {
+		return Session{}, operationErr
+	}
+	return session, nil
 }
 
 func Logout(files FileSystem, path string) (State, error) {

--- a/internal/remote/contacts.go
+++ b/internal/remote/contacts.go
@@ -129,7 +129,7 @@ func decodeContactNextCursor(value json.RawMessage) (*string, error) {
 		return nil, nil
 	}
 	var cursor *string
-	if err := json.Unmarshal(value, &cursor); err != nil || cursor == nil {
+	if err := decodeStrictContactJSON(value, &cursor); err != nil || cursor == nil {
 		return nil, fmt.Errorf("%w: contacts cursor", ErrProtocolChanged)
 	}
 	return cursor, nil
@@ -191,7 +191,7 @@ func (client Client) getContactsPage(
 		return contactsResponse{}, fmt.Errorf("%w: contacts response body", ErrProtocolChanged)
 	}
 	var page contactsResponse
-	if err := json.Unmarshal(body, &page); err != nil ||
+	if err := decodeStrictContactJSON(body, &page); err != nil ||
 		page.Result.Data == nil ||
 		page.Result.Paging == nil {
 		return contactsResponse{}, fmt.Errorf("%w: contacts response body", ErrProtocolChanged)

--- a/internal/remote/contacts.go
+++ b/internal/remote/contacts.go
@@ -129,7 +129,7 @@ func decodeContactNextCursor(value json.RawMessage) (*string, error) {
 		return nil, nil
 	}
 	var cursor *string
-	if err := decodeStrictContactJSON(value, &cursor); err != nil || cursor == nil {
+	if err := decodeSingleContactJSON(value, &cursor); err != nil || cursor == nil {
 		return nil, fmt.Errorf("%w: contacts cursor", ErrProtocolChanged)
 	}
 	return cursor, nil
@@ -191,7 +191,7 @@ func (client Client) getContactsPage(
 		return contactsResponse{}, fmt.Errorf("%w: contacts response body", ErrProtocolChanged)
 	}
 	var page contactsResponse
-	if err := decodeStrictContactJSON(body, &page); err != nil ||
+	if err := decodeSingleContactJSON(body, &page); err != nil ||
 		page.Result.Data == nil ||
 		page.Result.Paging == nil {
 		return contactsResponse{}, fmt.Errorf("%w: contacts response body", ErrProtocolChanged)
@@ -217,7 +217,7 @@ func validateContactsUnauthenticated(response *http.Response) error {
 			Status  *string `json:"status"`
 		} `json:"error"`
 	}
-	if decodeStrictContactJSON(body, &failure) != nil ||
+	if decodeSingleContactJSON(body, &failure) != nil ||
 		failure.Error == nil ||
 		failure.Error.Message == nil ||
 		failure.Error.Status == nil ||
@@ -227,9 +227,8 @@ func validateContactsUnauthenticated(response *http.Response) error {
 	return nil
 }
 
-func decodeStrictContactJSON(body []byte, destination any) error {
+func decodeSingleContactJSON(body []byte, destination any) error {
 	decoder := json.NewDecoder(bytes.NewReader(body))
-	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(destination); err != nil {
 		return err
 	}

--- a/internal/remote/contacts.go
+++ b/internal/remote/contacts.go
@@ -217,12 +217,25 @@ func validateContactsUnauthenticated(response *http.Response) error {
 			Status  *string `json:"status"`
 		} `json:"error"`
 	}
-	if json.Unmarshal(body, &failure) != nil ||
+	if decodeStrictContactJSON(body, &failure) != nil ||
 		failure.Error == nil ||
 		failure.Error.Message == nil ||
 		failure.Error.Status == nil ||
 		*failure.Error.Status != "UNAUTHENTICATED" {
 		return fmt.Errorf("%w: contacts unauthenticated response body", ErrProtocolChanged)
+	}
+	return nil
+}
+
+func decodeStrictContactJSON(body []byte, destination any) error {
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(destination); err != nil {
+		return err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return errors.New("contact response has trailing JSON")
 	}
 	return nil
 }

--- a/internal/remote/contacts.go
+++ b/internal/remote/contacts.go
@@ -12,9 +12,14 @@ import (
 	"unicode/utf8"
 )
 
+// The reviewed traversal has three data pages of at most the requested 1,000
+// items, followed by one empty terminal page. Do not traverse beyond that
+// finite execution boundary until a larger bound is reviewed.
 const (
-	contactPageSize         = 1000
-	maximumContactPageBytes = 4 << 20
+	contactPageSize           = 1000
+	maximumContactDataPages   = 3
+	maximumContactCatalogSize = contactPageSize * maximumContactDataPages
+	maximumContactPageBytes   = 4 << 20
 )
 
 type Contact struct {
@@ -62,24 +67,15 @@ func (client Client) GetContacts(
 	amplitudeDeviceID string,
 ) (ContactCatalog, error) {
 	var (
-		cursor   *string
-		contacts []Contact
+		cursor        *string
+		contacts      []Contact
+		dataPageCount int
 	)
 	seenCursors := make(map[string]struct{})
 	for {
 		page, err := client.getContactsPage(ctx, accessToken, amplitudeDeviceID, cursor)
 		if err != nil {
 			return ContactCatalog{}, err
-		}
-		for _, item := range page.Result.Data {
-			if item.SharedEventCount < 0 {
-				return ContactCatalog{}, fmt.Errorf("%w: contact", ErrProtocolChanged)
-			}
-			contacts = append(contacts, Contact{
-				ID:               item.ID,
-				Name:             item.Name,
-				SharedEventCount: item.SharedEventCount,
-			})
 		}
 		if page.Result.Paging.NextCursor == nil {
 			if len(page.Result.Data) != 0 {
@@ -93,6 +89,21 @@ func (client Client) GetContacts(
 		}
 		if len(page.Result.Data) == 0 {
 			return ContactCatalog{}, fmt.Errorf("%w: empty data page", ErrProtocolChanged)
+		}
+		dataPageCount++
+		if dataPageCount > maximumContactDataPages ||
+			len(page.Result.Data) > maximumContactCatalogSize-len(contacts) {
+			return ContactCatalog{}, fmt.Errorf("%w: contacts traversal bound", ErrProtocolChanged)
+		}
+		for _, item := range page.Result.Data {
+			if item.SharedEventCount < 0 {
+				return ContactCatalog{}, fmt.Errorf("%w: contact", ErrProtocolChanged)
+			}
+			contacts = append(contacts, Contact{
+				ID:               item.ID,
+				Name:             item.Name,
+				SharedEventCount: item.SharedEventCount,
+			})
 		}
 		if _, repeated := seenCursors[*page.Result.Paging.NextCursor]; repeated {
 			return ContactCatalog{}, fmt.Errorf("%w: repeated contacts cursor", ErrProtocolChanged)

--- a/internal/remote/contacts.go
+++ b/internal/remote/contacts.go
@@ -65,6 +65,7 @@ func (client Client) GetContacts(
 		cursor   *string
 		contacts []Contact
 	)
+	seenCursors := make(map[string]struct{})
 	for {
 		page, err := client.getContactsPage(ctx, accessToken, amplitudeDeviceID, cursor)
 		if err != nil {
@@ -93,6 +94,10 @@ func (client Client) GetContacts(
 		if len(page.Result.Data) == 0 {
 			return ContactCatalog{}, fmt.Errorf("%w: empty data page", ErrProtocolChanged)
 		}
+		if _, repeated := seenCursors[*page.Result.Paging.NextCursor]; repeated {
+			return ContactCatalog{}, fmt.Errorf("%w: repeated contacts cursor", ErrProtocolChanged)
+		}
+		seenCursors[*page.Result.Paging.NextCursor] = struct{}{}
 		cursor = page.Result.Paging.NextCursor
 	}
 }

--- a/internal/remote/contacts.go
+++ b/internal/remote/contacts.go
@@ -13,14 +13,15 @@ import (
 	"unicode/utf8"
 )
 
-// The reviewed traversal has three data pages of at most the requested 1,000
-// items, followed by one empty terminal page. Do not traverse beyond that
-// finite execution boundary until a larger bound is reviewed.
+// The reviewed traversal used three data pages with a requested maximum of
+// 1,000 items, followed by one empty terminal page. Do not exceed three data
+// pages or 3,000 retained items until a larger boundary is reviewed.
 const (
 	contactPageSize           = 1000
 	maximumContactDataPages   = 3
 	maximumContactCatalogSize = contactPageSize * maximumContactDataPages
-	maximumContactPageBytes   = 4 << 20
+	// The observed full page was below 1 MiB; this is a local memory ceiling.
+	maximumContactPageBytes = 4 << 20
 )
 
 var ErrUnauthenticated = errors.New("remote authentication is required")

--- a/internal/remote/contacts.go
+++ b/internal/remote/contacts.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime"
@@ -21,6 +22,8 @@ const (
 	maximumContactCatalogSize = contactPageSize * maximumContactDataPages
 	maximumContactPageBytes   = 4 << 20
 )
+
+var ErrUnauthenticated = errors.New("remote authentication is required")
 
 type Contact struct {
 	ID               string
@@ -166,6 +169,12 @@ func (client Client) getContactsPage(
 		return contactsResponse{}, fmt.Errorf("%w: contacts response", ErrProtocolChanged)
 	}
 	defer response.Body.Close()
+	if response.StatusCode == http.StatusUnauthorized {
+		if !validContactsUnauthenticated(response) {
+			return contactsResponse{}, fmt.Errorf("%w: contacts unauthenticated response", ErrProtocolChanged)
+		}
+		return contactsResponse{}, ErrUnauthenticated
+	}
 	if response.StatusCode != http.StatusOK {
 		return contactsResponse{}, fmt.Errorf("%w: contacts status", ErrProtocolChanged)
 	}
@@ -187,4 +196,28 @@ func (client Client) getContactsPage(
 		return contactsResponse{}, fmt.Errorf("%w: contacts response body", ErrProtocolChanged)
 	}
 	return page, nil
+}
+
+func validContactsUnauthenticated(response *http.Response) bool {
+	mediaType, _, err := mime.ParseMediaType(response.Header.Get("Content-Type"))
+	if err != nil || mediaType != "application/json" {
+		return false
+	}
+	body, err := io.ReadAll(io.LimitReader(response.Body, maximumContactPageBytes+1))
+	if err != nil ||
+		len(body) > maximumContactPageBytes ||
+		!utf8.Valid(body) {
+		return false
+	}
+	var failure struct {
+		Error *struct {
+			Message *string `json:"message"`
+			Status  *string `json:"status"`
+		} `json:"error"`
+	}
+	return json.Unmarshal(body, &failure) == nil &&
+		failure.Error != nil &&
+		failure.Error.Message != nil &&
+		failure.Error.Status != nil &&
+		*failure.Error.Status == "UNAUTHENTICATED"
 }

--- a/internal/remote/contacts.go
+++ b/internal/remote/contacts.go
@@ -1,0 +1,148 @@
+package remote
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"unicode/utf8"
+)
+
+const (
+	contactPageSize         = 1000
+	maximumContactPageBytes = 4 << 20
+)
+
+type Contact struct {
+	ID               string
+	Name             string
+	SharedEventCount int
+}
+
+type ContactCatalog struct {
+	Contacts []Contact
+}
+
+type contactsRequest struct {
+	Data contactsRequestData `json:"data"`
+}
+
+type contactsRequestData struct {
+	Params            struct{}       `json:"params"`
+	AmplitudeDeviceID string         `json:"amplitudeDeviceId"`
+	Paging            contactsPaging `json:"paging"`
+}
+
+type contactsPaging struct {
+	MaxResults int     `json:"maxResults"`
+	Cursor     *string `json:"cursor"`
+}
+
+type contactsResponse struct {
+	Result struct {
+		Data []struct {
+			ID               string `json:"id"`
+			Name             string `json:"name"`
+			SharedEventCount int    `json:"sharedEventCount"`
+		} `json:"data"`
+		Paging struct {
+			NextCursor *string `json:"nextCursor"`
+		} `json:"paging"`
+	} `json:"result"`
+}
+
+func (client Client) GetContacts(
+	ctx context.Context,
+	accessToken string,
+	amplitudeDeviceID string,
+) (ContactCatalog, error) {
+	var (
+		cursor   *string
+		contacts []Contact
+	)
+	for {
+		page, err := client.getContactsPage(ctx, accessToken, amplitudeDeviceID, cursor)
+		if err != nil {
+			return ContactCatalog{}, err
+		}
+		for _, item := range page.Result.Data {
+			if item.SharedEventCount < 0 {
+				return ContactCatalog{}, fmt.Errorf("%w: contact", ErrProtocolChanged)
+			}
+			contacts = append(contacts, Contact{
+				ID:               item.ID,
+				Name:             item.Name,
+				SharedEventCount: item.SharedEventCount,
+			})
+		}
+		if page.Result.Paging.NextCursor == nil {
+			if len(page.Result.Data) != 0 {
+				return ContactCatalog{}, fmt.Errorf("%w: terminal page", ErrProtocolChanged)
+			}
+			return ContactCatalog{Contacts: contacts}, nil
+		}
+		if len(page.Result.Data) == 0 {
+			return ContactCatalog{}, fmt.Errorf("%w: empty data page", ErrProtocolChanged)
+		}
+		cursor = page.Result.Paging.NextCursor
+	}
+}
+
+func (client Client) getContactsPage(
+	ctx context.Context,
+	accessToken string,
+	amplitudeDeviceID string,
+	cursor *string,
+) (contactsResponse, error) {
+	if client.HTTP == nil {
+		return contactsResponse{}, fmt.Errorf("%w: contacts transport", ErrUnavailable)
+	}
+	payload, _ := json.Marshal(contactsRequest{Data: contactsRequestData{
+		AmplitudeDeviceID: amplitudeDeviceID,
+		Paging: contactsPaging{
+			MaxResults: contactPageSize,
+			Cursor:     cursor,
+		},
+	}})
+	request, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		partifulCallableHost+"/getContacts",
+		bytes.NewReader(payload),
+	)
+	if err != nil {
+		return contactsResponse{}, fmt.Errorf("%w: contacts request", ErrUnavailable)
+	}
+	request.Header.Set("Authorization", "Bearer "+accessToken)
+	request.Header.Set("Content-Type", "application/json")
+	response, err := client.HTTP.Do(request)
+	if err != nil {
+		return contactsResponse{}, fmt.Errorf("%w: contacts request failed", ErrUnavailable)
+	}
+	if response == nil || response.Body == nil {
+		return contactsResponse{}, fmt.Errorf("%w: contacts response", ErrProtocolChanged)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return contactsResponse{}, fmt.Errorf("%w: contacts status", ErrProtocolChanged)
+	}
+	mediaType, _, err := mime.ParseMediaType(response.Header.Get("Content-Type"))
+	if err != nil || mediaType != "application/json" {
+		return contactsResponse{}, fmt.Errorf("%w: contacts content type", ErrProtocolChanged)
+	}
+	body, err := io.ReadAll(io.LimitReader(response.Body, maximumContactPageBytes+1))
+	if err != nil {
+		return contactsResponse{}, fmt.Errorf("%w: contacts response read", ErrUnavailable)
+	}
+	if len(body) > maximumContactPageBytes || !utf8.Valid(body) {
+		return contactsResponse{}, fmt.Errorf("%w: contacts response body", ErrProtocolChanged)
+	}
+	var page contactsResponse
+	if err := json.Unmarshal(body, &page); err != nil || page.Result.Data == nil {
+		return contactsResponse{}, fmt.Errorf("%w: contacts response body", ErrProtocolChanged)
+	}
+	return page, nil
+}

--- a/internal/remote/contacts.go
+++ b/internal/remote/contacts.go
@@ -170,8 +170,8 @@ func (client Client) getContactsPage(
 	}
 	defer response.Body.Close()
 	if response.StatusCode == http.StatusUnauthorized {
-		if !validContactsUnauthenticated(response) {
-			return contactsResponse{}, fmt.Errorf("%w: contacts unauthenticated response", ErrProtocolChanged)
+		if err := validateContactsUnauthenticated(response); err != nil {
+			return contactsResponse{}, err
 		}
 		return contactsResponse{}, ErrUnauthenticated
 	}
@@ -198,16 +198,17 @@ func (client Client) getContactsPage(
 	return page, nil
 }
 
-func validContactsUnauthenticated(response *http.Response) bool {
+func validateContactsUnauthenticated(response *http.Response) error {
 	mediaType, _, err := mime.ParseMediaType(response.Header.Get("Content-Type"))
 	if err != nil || mediaType != "application/json" {
-		return false
+		return fmt.Errorf("%w: contacts unauthenticated content type", ErrProtocolChanged)
 	}
 	body, err := io.ReadAll(io.LimitReader(response.Body, maximumContactPageBytes+1))
-	if err != nil ||
-		len(body) > maximumContactPageBytes ||
-		!utf8.Valid(body) {
-		return false
+	if err != nil {
+		return fmt.Errorf("%w: contacts unauthenticated response read", ErrUnavailable)
+	}
+	if len(body) > maximumContactPageBytes || !utf8.Valid(body) {
+		return fmt.Errorf("%w: contacts unauthenticated response body", ErrProtocolChanged)
 	}
 	var failure struct {
 		Error *struct {
@@ -215,9 +216,12 @@ func validContactsUnauthenticated(response *http.Response) bool {
 			Status  *string `json:"status"`
 		} `json:"error"`
 	}
-	return json.Unmarshal(body, &failure) == nil &&
-		failure.Error != nil &&
-		failure.Error.Message != nil &&
-		failure.Error.Status != nil &&
-		*failure.Error.Status == "UNAUTHENTICATED"
+	if json.Unmarshal(body, &failure) != nil ||
+		failure.Error == nil ||
+		failure.Error.Message == nil ||
+		failure.Error.Status == nil ||
+		*failure.Error.Status != "UNAUTHENTICATED" {
+		return fmt.Errorf("%w: contacts unauthenticated response body", ErrProtocolChanged)
+	}
+	return nil
 }

--- a/internal/remote/contacts.go
+++ b/internal/remote/contacts.go
@@ -3,6 +3,7 @@ package remote
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -23,7 +24,8 @@ type Contact struct {
 }
 
 type ContactCatalog struct {
-	Contacts []Contact
+	Contacts      []Contact
+	PayloadSHA256 [sha256.Size]byte
 }
 
 type contactsRequest struct {
@@ -82,7 +84,11 @@ func (client Client) GetContacts(
 			if len(page.Result.Data) != 0 {
 				return ContactCatalog{}, fmt.Errorf("%w: terminal page", ErrProtocolChanged)
 			}
-			return ContactCatalog{Contacts: contacts}, nil
+			document, _ := json.Marshal(contacts)
+			return ContactCatalog{
+				Contacts:      contacts,
+				PayloadSHA256: sha256.Sum256(document),
+			}, nil
 		}
 		if len(page.Result.Data) == 0 {
 			return ContactCatalog{}, fmt.Errorf("%w: empty data page", ErrProtocolChanged)

--- a/internal/remote/contacts.go
+++ b/internal/remote/contacts.go
@@ -51,12 +51,12 @@ type contactsPaging struct {
 type contactsResponse struct {
 	Result struct {
 		Data []struct {
-			ID               string `json:"id"`
-			Name             string `json:"name"`
-			SharedEventCount int    `json:"sharedEventCount"`
+			ID               *string `json:"id"`
+			Name             *string `json:"name"`
+			SharedEventCount *int    `json:"sharedEventCount"`
 		} `json:"data"`
-		Paging struct {
-			NextCursor *string `json:"nextCursor"`
+		Paging *struct {
+			NextCursor json.RawMessage `json:"nextCursor"`
 		} `json:"paging"`
 	} `json:"result"`
 }
@@ -77,7 +77,11 @@ func (client Client) GetContacts(
 		if err != nil {
 			return ContactCatalog{}, err
 		}
-		if page.Result.Paging.NextCursor == nil {
+		nextCursor, err := decodeContactNextCursor(page.Result.Paging.NextCursor)
+		if err != nil {
+			return ContactCatalog{}, err
+		}
+		if nextCursor == nil {
 			if len(page.Result.Data) != 0 {
 				return ContactCatalog{}, fmt.Errorf("%w: terminal page", ErrProtocolChanged)
 			}
@@ -96,21 +100,35 @@ func (client Client) GetContacts(
 			return ContactCatalog{}, fmt.Errorf("%w: contacts traversal bound", ErrProtocolChanged)
 		}
 		for _, item := range page.Result.Data {
-			if item.SharedEventCount < 0 {
+			if item.ID == nil ||
+				item.Name == nil ||
+				item.SharedEventCount == nil ||
+				*item.SharedEventCount < 0 {
 				return ContactCatalog{}, fmt.Errorf("%w: contact", ErrProtocolChanged)
 			}
 			contacts = append(contacts, Contact{
-				ID:               item.ID,
-				Name:             item.Name,
-				SharedEventCount: item.SharedEventCount,
+				ID:               *item.ID,
+				Name:             *item.Name,
+				SharedEventCount: *item.SharedEventCount,
 			})
 		}
-		if _, repeated := seenCursors[*page.Result.Paging.NextCursor]; repeated {
+		if _, repeated := seenCursors[*nextCursor]; repeated {
 			return ContactCatalog{}, fmt.Errorf("%w: repeated contacts cursor", ErrProtocolChanged)
 		}
-		seenCursors[*page.Result.Paging.NextCursor] = struct{}{}
-		cursor = page.Result.Paging.NextCursor
+		seenCursors[*nextCursor] = struct{}{}
+		cursor = nextCursor
 	}
+}
+
+func decodeContactNextCursor(value json.RawMessage) (*string, error) {
+	if len(value) == 0 {
+		return nil, nil
+	}
+	var cursor *string
+	if err := json.Unmarshal(value, &cursor); err != nil || cursor == nil {
+		return nil, fmt.Errorf("%w: contacts cursor", ErrProtocolChanged)
+	}
+	return cursor, nil
 }
 
 func (client Client) getContactsPage(
@@ -163,7 +181,9 @@ func (client Client) getContactsPage(
 		return contactsResponse{}, fmt.Errorf("%w: contacts response body", ErrProtocolChanged)
 	}
 	var page contactsResponse
-	if err := json.Unmarshal(body, &page); err != nil || page.Result.Data == nil {
+	if err := json.Unmarshal(body, &page); err != nil ||
+		page.Result.Data == nil ||
+		page.Result.Paging == nil {
 		return contactsResponse{}, fmt.Errorf("%w: contacts response body", ErrProtocolChanged)
 	}
 	return page, nil

--- a/tests/remote-api-contract.test.js
+++ b/tests/remote-api-contract.test.js
@@ -1133,7 +1133,7 @@ describe('remote API contract', () => {
     expect(evidence.readObservation.artifactPath).toBe(readEvidencePath);
   });
 
-  it('keeps the approved remote revision separate from the shipped revision', () => {
+  it('ships the owner-reviewed contact remote revision', () => {
     const productContract = fs.readFileSync(
       'docs/CLI-PRODUCT-CONTRACT.md',
       'utf8',
@@ -1153,12 +1153,12 @@ describe('remote API contract', () => {
       /"remoteContractRevision": "([^"]+)"/g,
     )].map((match) => match[1]);
 
-    expect(shippedRevision).toBe('2026-08-11.4');
+    expect(shippedRevision).toBe('2026-08-11.5');
     expect(documentedRevision).toBe(shippedRevision);
     expect(new Set(envelopeRevisions)).toEqual(new Set([shippedRevision]));
     expect(spec.info.version).toBe('2026-08-11.5');
     expect(evidence.status).toBe('owner-reviewed');
-    expect(spec.info.version).not.toBe(shippedRevision);
+    expect(spec.info.version).toBe(shippedRevision);
     expect(productContract)
       .not.toContain('currently leaves every operation response status and body unknown');
     expect(contactResearch)
@@ -1168,7 +1168,7 @@ describe('remote API contract', () => {
     expect(contactResearch).toMatch(
       /previous owner-reviewed remote contract[\s\S]+2026-08-11\.4/,
     );
-    expect(contactResearch).toMatch(/Proposed revision `2026-08-11\.5`/);
+    expect(contactResearch).toMatch(/Owner-reviewed revision `2026-08-11\.5`/);
   });
 
   it('captures the observed authentication response shapes from the attended session', () => {


### PR DESCRIPTION
## Summary

- Adds `contacts list [--query]` to the Go command catalog and schema.
- Acquires or refreshes a protected session without prompting, then sends the reviewed `.5` `getContacts` request shape.
- Traverses pages sequentially with a three-page/3,000-item client bound and required empty sentinel; repeated cursors, excess data, malformed bodies, and unsupported statuses fail closed.
- Deduplicates by private identity with first occurrence winning, filters names locally, and provides digest-bound opaque local pagination.
- Returns only `displayName` and `sharedEventCount`; private identity and raw transport values stay out of envelopes, errors, and diagnostics.
- Advances the shipped Remote API revision to owner-reviewed `2026-08-11.5`.

## Private resolver boundary

No standalone exact-match resolver is exported in this slice. The accepted application seam has no current guest/cohost plan consumer, and S7/S8 are future slices. Adding an unused resolver now would create the dead speculative seam prohibited by ADR 0001. The internal catalog retains stable identity only for current deduplication and cursor binding; exact resolution will materialize with its first mutation-plan consumer.

## Validation

- `go test -race ./...`
- `go vet ./...`
- `go build ./...`
- `go mod tidy && go mod verify`
- `npm test -- tests/remote-api-contract.test.js tests/drift.test.js` (36 passed)
- `TZ=America/Los_Angeles PARTIFUL_SMOKE=0 npm test` (349 passed, 6 live smoke tests skipped)
- `npm run typecheck`
- Go format, diff, public-schema, commit-trailer, and production privacy scans

No live API, credential, SMS, mutation, or real-person data was used.

Closes #165