### PR TITLE
docs(contract): propose event-read mapping for #164

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -23,6 +23,11 @@ until it is reviewed into the remote API contract.
 A remote-evidence condition that must be satisfied before a public command can
 ship. A command does not use an implementation gate as a runtime fallback.
 
+**Unavailable-not-claimed**:
+A documented nullable product field that the current implementation
+intentionally does not project because no reviewed remote mapping exists.
+Null does not claim that the remote field is absent and is not protocol drift.
+
 **Protocol change**:  
 A difference between current Partiful behavior and the remote API contract
 that a released command was built against.

--- a/docs/CLI-PRODUCT-CONTRACT.md
+++ b/docs/CLI-PRODUCT-CONTRACT.md
@@ -1,8 +1,13 @@
 # CLI product contract
 
-**Status:** Approved product contract  
-**Product contract revision:** `2026-08-10.1`  
-**Remote API contract revision:** `2026-08-11.5`
+**Status:** Proposed product contract pending delegated review
+
+**Product contract revision:** `2026-08-12.1`
+
+**Remote API contract revision:** `2026-08-12.1` (proposed)
+
+**Currently shipped Go revisions:** product `2026-08-10.1`; remote
+`2026-08-11.5`
 
 This document defines the public behavior of the greenfield Go `partiful` CLI.
 It is the authority for commands, inputs, JSON outputs, failures, and mutation
@@ -77,8 +82,8 @@ Every successful command returns:
   "meta": {
     "command": "events.get",
     "cliVersion": "1.0.0",
-    "productContractRevision": "2026-08-10.1",
-    "remoteContractRevision": "2026-08-11.5",
+    "productContractRevision": "2026-08-12.1",
+    "remoteContractRevision": "2026-08-12.1",
     "warnings": []
   }
 }
@@ -101,8 +106,8 @@ Every failed command returns:
   "meta": {
     "command": "guests.list",
     "cliVersion": "1.0.0",
-    "productContractRevision": "2026-08-10.1",
-    "remoteContractRevision": "2026-08-11.5"
+    "productContractRevision": "2026-08-12.1",
+    "remoteContractRevision": "2026-08-12.1"
   }
 }
 ```
@@ -149,8 +154,8 @@ Collection commands return:
   "meta": {
     "command": "events.list",
     "cliVersion": "1.0.0",
-    "productContractRevision": "2026-08-10.1",
-    "remoteContractRevision": "2026-08-11.5",
+    "productContractRevision": "2026-08-12.1",
+    "remoteContractRevision": "2026-08-12.1",
     "warnings": [],
     "page": {
       "limit": 25,
@@ -175,6 +180,26 @@ different filters. If the remote capability cannot support this contract
 safely, the collection command remains behind its implementation gate.
 When `--all` reaches `--max-items` before the collection ends, `hasMore` is
 `true` and `nextCursor` lets the caller resume from that exact point.
+
+### Event-list local snapshots
+
+`events list` has no remote paging contract. One invocation fetches exactly
+one reviewed upcoming or past one-response representation and paginates that
+array locally. The CLI preserves the received sequence without claiming what
+the remote order means.
+
+The local safety ceiling is 1,000 items and 8 MiB for the complete response.
+If either ceiling is exceeded, the CLI returns
+`contract.protocol_changed` / `EVENT_LIST_BOUND_EXCEEDED`; it does not
+truncate a successful result.
+
+An event-list cursor is digest-bound to the complete response representation,
+the `events.list` command, the normalized `--when` value, and the next array
+offset. Resumption refetches the same one-response representation once. If
+its digest changed, the CLI returns `state.conflict` /
+`CURSOR_SNAPSHOT_CHANGED` rather than skip, repeat, merge, or guess items.
+This is local snapshot pagination. It does not claim a remote cursor, limit,
+ordering key, snapshot, or future completeness.
 
 ## Mutation safety
 
@@ -202,8 +227,8 @@ remote mutation:
   "meta": {
     "command": "events.update",
     "cliVersion": "1.0.0",
-    "productContractRevision": "2026-08-10.1",
-    "remoteContractRevision": "2026-08-11.5",
+    "productContractRevision": "2026-08-12.1",
+    "remoteContractRevision": "2026-08-12.1",
     "warnings": []
   }
 }
@@ -343,8 +368,67 @@ Each `data.items` entry is an `EventSummary`:
 }
 ```
 
-`state` is `active` or `cancelled`. `userRole` is `host`, `cohost`,
-`attendee`, or `none`.
+For S3 reads, `eventId` is the only non-null event-read field. It comes from
+the reviewed list item `id`. All other documented event-read fields are
+nullable because the reviewed remote representation does not establish their
+universal presence. A missing optional property produces JSON `null`; it does
+not make an otherwise reviewed response protocol drift. A present property
+that violates its reviewed type or closed enum is
+`contract.protocol_changed`.
+
+The conditional scalar projection is:
+
+| Product field | Reviewed remote property | Null meaning |
+| --- | --- | --- |
+| `title` | string `title` | The property is unavailable. |
+| `start` | string `startDate` | The property is unavailable. |
+| `end` | string or null `endDate` | The property is absent or explicitly null. |
+| `timezone` | string `timezone` | The property is unavailable. |
+| `state` | `status` mapping below | The property is unavailable. |
+
+Event state is an exact closed mapping:
+
+- `PUBLISHED` → `active`;
+- `CANCELED` → `cancelled`.
+
+Role projection uses private current-user identity only for comparison. It
+never emits an owner ID:
+
+- `ownerIds` contains the current user → `host`;
+- `ownerIds` is present, does not contain the current user, and `guest` is present → `attendee`;
+- `ownerIds` is present, does not contain the current user, and `guest` is absent → `none`;
+- `ownerIds` is absent → `null`.
+
+Owner membership takes precedence if a representation also has `guest`.
+`cohost` is reserved in the product enum, but S3 does not emit it. Current
+first-party assets do not distinguish a primary host from a cohost, so every
+owner membership maps to `host` until a distinct reviewed field exists.
+
+`myRsvp` uses the read-only `EventReadRsvp` enum. It is a lossless,
+one-to-one normalization and is separate from S5's narrower writable RSVP
+intent:
+
+| Remote guest status | `EventReadRsvp` |
+| --- | --- |
+| `READY_TO_SEND` | `ready-to-send` |
+| `SENDING` | `sending` |
+| `SEND_ERROR` | `send-error` |
+| `DELIVERY_ERROR` | `delivery-error` |
+| `SENT` | `sent` |
+| `INTERESTED` | `interested` |
+| `WAITLIST` | `waitlist` |
+| `MAYBE` | `maybe` |
+| `DECLINED` | `declined` |
+| `GOING` | `going` |
+| `PENDING_APPROVAL` | `pending-approval` |
+| `APPROVED` | `approved` |
+| `WITHDRAWN` | `withdrawn` |
+| `WAITLISTED_FOR_APPROVAL` | `waitlisted-for-approval` |
+| `REJECTED` | `rejected` |
+| `RESPONDED_TO_FIND_A_TIME` | `responded-to-find-a-time` |
+
+Null `myRsvp` means that no current guest object or status is available. An
+unknown present guest status is `contract.protocol_changed`, not null.
 
 #### `partiful events get <event-id>`
 
@@ -353,22 +437,56 @@ Returns an `Event`:
 ```json
 {
   "eventId": "evt_example",
-  "title": "Example event",
-  "start": "2026-09-12T19:00:00-07:00",
+  "title": null,
+  "start": null,
   "end": null,
-  "timezone": "America/Los_Angeles",
-  "state": "active",
-  "userRole": "host",
+  "timezone": null,
+  "state": null,
+  "userRole": null,
   "myRsvp": null,
   "description": null,
   "location": null,
   "address": null,
-  "visibility": "private",
+  "visibility": null,
   "guestLimit": null,
   "poster": null,
-  "links": []
+  "links": null
 }
 ```
+
+The positional input supplies `eventId`. Reviewed conditional `title`,
+`startDate`, `endDate`, `timezone`, and `status` properties use the same
+nullable scalar and state mappings as `EventSummary`. The current
+`getEventInfo` contract does not map owner or guest properties, so
+`userRole` and `myRsvp` are null for this command.
+
+`description`, `location`, `address`, `visibility`, `guestLimit`, `poster`,
+and `links` are unavailable-not-claimed in S3. They are null even if an
+unreviewed remote property has a similar name. In particular, `links` is
+`null`, not an empty array; this does not mean that the remote event has no
+links. A later contract revision can add a field only after its transport
+shape and product projection are reviewed.
+
+`getEventInfo` has this read failure boundary:
+
+- `200` uses the nullable projection above;
+- `404 NOT_FOUND` → `resource.not_found` / `EVENT_NOT_FOUND`;
+- no response → `remote.unavailable`;
+- every other unrecognized received status or malformed reviewed property →
+  `contract.protocol_changed`.
+
+An unobserved `403` is not `permission.denied`. The permission mapping is deferred
+until an inaccessible-event response is reviewed. S3 does not call `firestoreGetEvent`;
+`.5` returned the same `403 PERMISSION_DENIED` for a
+selected readable event and a synthetic ID, so that operation cannot
+distinguish permission or existence. S3 also does not call
+`getCurrentGuest` or `firestoreGetGuest`; the list's conditional inline
+`guest.status` is the only reviewed guest projection used here.
+
+The two list operations accept only their reviewed `200` bodies. No response
+is `remote.unavailable`; every unrecognized received status is
+`contract.protocol_changed`. Their remote permission and failure mappings
+remain unclaimed.
 
 #### `partiful events create`
 

--- a/docs/CLI-PRODUCT-CONTRACT.md
+++ b/docs/CLI-PRODUCT-CONTRACT.md
@@ -1,10 +1,10 @@
 # CLI product contract
 
-**Status:** Proposed product contract pending delegated review
+**Status:** Approved product contract
 
 **Product contract revision:** `2026-08-12.1`
 
-**Remote API contract revision:** `2026-08-12.1` (proposed)
+**Remote API contract revision:** `2026-08-12.1`
 
 **Currently shipped Go revisions:** product `2026-08-10.1`; remote
 `2026-08-11.5`

--- a/docs/CLI-PRODUCT-CONTRACT.md
+++ b/docs/CLI-PRODUCT-CONTRACT.md
@@ -342,6 +342,12 @@ A successful token lifetime must exceed the five-minute refresh window so
 login and refresh can return `healthy`. A shorter lifetime fails closed as
 `contract.protocol_changed` rather than creating a refresh loop.
 
+Protected commands never start login and never receive a private terminal.
+Missing credentials return `auth.required`. Stored credentials that are
+expired without a usable refresh token return `auth.expired`. A refresh rejected by the reviewed remote mapping also returns `auth.expired`.
+Unavailable refresh transport returns `remote.unavailable`; an unrecognized
+released refresh response returns `contract.protocol_changed`.
+
 ## Public commands
 
 ### Events
@@ -390,6 +396,10 @@ Event state is an exact closed mapping:
 
 - `PUBLISHED` → `active`;
 - `CANCELED` → `cancelled`.
+
+`UNSAVED` exists in the current first-party client vocabulary but has no
+reviewed S3 product mapping. If it appears in a released event-read response,
+the command returns `contract.protocol_changed`.
 
 Role projection uses private current-user identity only for comparison. It
 never emits an owner ID:
@@ -459,6 +469,12 @@ The positional input supplies `eventId`. Reviewed conditional `title`,
 nullable scalar and state mappings as `EventSummary`. The current
 `getEventInfo` contract does not map owner or guest properties, so
 `userRole` and `myRsvp` are null for this command.
+
+The product boundary requires `result.data.event` to be an object before any
+nullable field projection occurs. A null, scalar, or array event value returns
+`contract.protocol_changed`; it is not converted into an all-null successful
+event. This is a CLI output invariant and does not claim that the remote
+operation accepts only one top-level variant.
 
 `description`, `location`, `address`, `visibility`, `guestLimit`, `poster`,
 and `links` are unavailable-not-claimed in S3. They are null even if an

--- a/docs/REMOTE-API-CONTRACT.md
+++ b/docs/REMOTE-API-CONTRACT.md
@@ -1,9 +1,9 @@
 # Remote API contract
 
-`spec/partiful.openapi.json` is proposed revision `2026-08-12.1` of the remote
-transport snapshot, pending delegated review. It is based on owner-reviewed
-revision `2026-08-11.5`. It describes only network operations and wire shapes.
-It does not prescribe commands, output, credentials, mutation safeguards, or
+`spec/partiful.openapi.json` is owner-reviewed revision `2026-08-12.1` of the
+remote transport snapshot. It is based on owner-reviewed revision
+`2026-08-11.5`. It describes only network operations and wire shapes. It does
+not prescribe commands, output, credentials, mutation safeguards, or
 implementation architecture.
 
 ## Authority and change process
@@ -66,9 +66,9 @@ Unsupported statuses, ordering, snapshots, invalid cursors, cursor lifetime,
 `useAuthUser`, rate limiting, future catalog completeness, inaccessible-event
 permission behavior, and other unobserved variants remain explicit unknowns.
 
-## Proposed event mapping correction
+## Event mapping correction
 
-Proposed revision `2026-08-12.1` adds current first-party public-asset
+Revision `2026-08-12.1` adds current first-party public-asset
 research from
 `docs/research/2026-08-12-event-read-mapping-public-assets.md`. It promotes
 only facts used directly by the current `/events` build:

--- a/docs/REMOTE-API-CONTRACT.md
+++ b/docs/REMOTE-API-CONTRACT.md
@@ -1,9 +1,10 @@
 # Remote API contract
 
-`spec/partiful.openapi.json` is owner-reviewed revision `2026-08-11.5` of the
-remote transport snapshot. It describes only network operations and wire
-shapes. It does not prescribe commands, output, credentials, mutation
-safeguards, or implementation architecture.
+`spec/partiful.openapi.json` is proposed revision `2026-08-12.1` of the remote
+transport snapshot, pending delegated review. It is based on owner-reviewed
+revision `2026-08-11.5`. It describes only network operations and wire shapes.
+It does not prescribe commands, output, credentials, mutation safeguards, or
+implementation architecture.
 
 ## Authority and change process
 
@@ -23,7 +24,7 @@ with guessed fields, captured credentials, real identifiers, or personal data.
 `docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md` is the
 human-readable companion to the machine-readable ledger.
 
-## Read evidence revision
+## Owner-reviewed read evidence baseline
 
 Revision `2026-08-11.5` records dated response and status evidence for
 `getMyUpcomingEventsForHomePage`, `getMyPastEventsForHomePage`,
@@ -64,6 +65,37 @@ output remains display name and shared-event count. Signed-out access returned
 Unsupported statuses, ordering, snapshots, invalid cursors, cursor lifetime,
 `useAuthUser`, rate limiting, future catalog completeness, inaccessible-event
 permission behavior, and other unobserved variants remain explicit unknowns.
+
+## Proposed event mapping correction
+
+Proposed revision `2026-08-12.1` adds current first-party public-asset
+research from
+`docs/research/2026-08-12-event-read-mapping-public-assets.md`. It promotes
+only facts used directly by the current `/events` build:
+
+- symbolic event status `LIVE` has wire value `PUBLISHED`, and `CANCELED` has
+  wire value `CANCELED`;
+- homepage event `ownerIds` is the private identity collection used by
+  `event.ownerIds.includes(userId)` for host membership; and
+- module `54257` defines the closed 16-value guest-status enum.
+
+The `HomePageEvent.status` and conditional `EventInfo.status` properties now
+reference the closed `EventStatus` schema. `HomePageEvent.ownerIds` remains
+optional. The inline homepage guest status references the closed
+`GuestStatus` schema. No new field is required, and the single-sample
+`EventInfo` and `CurrentGuest` top-level uncertainty is unchanged.
+
+The public assets send no paging argument for the two homepage list calls.
+This agrees with the observed one-response arrays but does not establish
+remote order, limits, snapshots, paging, or future completeness. Digest-bound
+pagination and local item/body ceilings are CLI product behavior, not remote
+claims.
+
+No response status changed in this proposal. `getEventInfo` retains only
+reviewed `200` and `404 NOT_FOUND`; an unobserved `403` remains protocol drift.
+`firestoreGetEvent` remains unusable as an S3 success or permission path
+because its selected and synthetic requests both returned
+`403 PERMISSION_DENIED`.
 
 ## Historical provenance
 

--- a/docs/REMOTE-API-CONTRACT.md
+++ b/docs/REMOTE-API-CONTRACT.md
@@ -73,14 +73,15 @@ research from
 `docs/research/2026-08-12-event-read-mapping-public-assets.md`. It promotes
 only facts used directly by the current `/events` build:
 
-- symbolic event status `LIVE` has wire value `PUBLISHED`, and `CANCELED` has
-  wire value `CANCELED`;
+- module `18539` defines the client event-status vocabulary `UNSAVED`,
+  `PUBLISHED`, and `CANCELED`; only `PUBLISHED` and `CANCELED` have S3 product
+  mappings;
 - homepage event `ownerIds` is the private identity collection used by
   `event.ownerIds.includes(userId)` for host membership; and
 - module `54257` defines the closed 16-value guest-status enum.
 
 The `HomePageEvent.status` and conditional `EventInfo.status` properties now
-reference the closed `EventStatus` schema. `HomePageEvent.ownerIds` remains
+reference that three-value client vocabulary. `HomePageEvent.ownerIds` remains
 optional. The inline homepage guest status references the closed
 `GuestStatus` schema. No new field is required, and the single-sample
 `EventInfo` and `CurrentGuest` top-level uncertainty is unchanged.

--- a/docs/research/2026-08-10-contract-evidence-sources.md
+++ b/docs/research/2026-08-10-contract-evidence-sources.md
@@ -149,3 +149,14 @@ deduplication by contact `id` with the first occurrence winning. These client
 behaviors do not establish server ordering or duplicate behavior. This is
 reviewed first-party repository research, not a live-server request-shape
 observation.
+
+## Current public event mapping assets
+
+The unauthenticated first-party asset research in
+`docs/research/2026-08-12-event-read-mapping-public-assets.md`, under “Scope and
+provenance,” records the current `/events` build, exact module IDs, asset
+digests, event-status wire values, owner-membership host check, and closed
+guest-status enum. It contains no account-scoped response values or private
+identifiers. Public assets establish current client field and enum behavior;
+they do not establish server statuses, field presence, remote pagination,
+ordering, limits, or inaccessible-event behavior.

--- a/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
+++ b/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
@@ -1,8 +1,8 @@
 # Partiful remote API contract evidence ledger
 
-**Proposed contract revision:** `2026-08-12.1`
+**Owner-reviewed contract revision:** `2026-08-12.1`
 **Owner-reviewed baseline:** `2026-08-11.5`
-**Status:** Proposed; pending delegated review
+**Status:** Owner-reviewed under the issue #114 delegation
 **Contract:** `spec/partiful.openapi.json`
 **Machine-readable ledger:** `spec/partiful.api-evidence.json`
 **Stable citation sources:** `docs/research/2026-08-10-contract-evidence-sources.md`

--- a/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
+++ b/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
@@ -58,7 +58,7 @@ rules, and limits are **explicit unknown**. Eleven operations with an observed
 HTTP `200` status have typed response bodies. The schema-free
 send-code `200` and OpenAPI `default` responses do not claim a body.
 
-The 1253 material claims are audited by
+The 1254 material claims are audited by
 `tests/remote-api-contract.test.js`. Each ledger citation resolves either to a
 JSON Pointer in the committed non-authoritative historical artifact or to a
 heading in the committed stable source index. This keeps the audit independent
@@ -150,8 +150,9 @@ No remote paging field was observed for either list. Revision
 remote pagination, limits, ordering, snapshot behavior, and list failures
 unknown. Event ID projection is supported. One selected guest status supports
 an RSVP projection for that item. Current public assets close the S3
-event-state, owner-membership, and guest-status vocabulary. The two wire event
-states are `PUBLISHED` and `CANCELED`. Owner membership uses
+event-state, owner-membership, and guest-status vocabulary. The client
+event-status vocabulary is `UNSAVED`, `PUBLISHED`, and `CANCELED`; only the
+latter two have S3 product mappings. Owner membership uses
 `event.ownerIds.includes(userId)`. The events UI treats any owner membership
 as hosting and does not expose a primary-host/cohost distinction. The 16
 current guest statuses remain lossless in the read projection.
@@ -243,7 +244,7 @@ by the Go implementation's Firebase requests:
 Origin is unmodelled and remains unknown because the reviewed evidence
 establishes no Origin request fact.
 
-The 1253 material claims are audited by `tests/remote-api-contract.test.js`.
+The 1254 material claims are audited by `tests/remote-api-contract.test.js`.
 
 ## Resolved conflict
 

--- a/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
+++ b/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
@@ -1,7 +1,8 @@
 # Partiful remote API contract evidence ledger
 
-**Owner-reviewed contract revision:** `2026-08-11.5`
-**Status:** Owner-reviewed under the issue #114 delegation
+**Proposed contract revision:** `2026-08-12.1`
+**Owner-reviewed baseline:** `2026-08-11.5`
+**Status:** Proposed; pending delegated review
 **Contract:** `spec/partiful.openapi.json`
 **Machine-readable ledger:** `spec/partiful.api-evidence.json`
 **Stable citation sources:** `docs/research/2026-08-10-contract-evidence-sources.md`
@@ -11,6 +12,8 @@
 - **Dated live observation:** the March 24 browser-interception research, the
   August 11 public poster-catalog observation, and the August 11
   owner-attended authentication and read-only event/contact observations.
+- **Current first-party public-asset research:** immutable assets from the
+  current Partiful deployment, without authentication or account-scoped data.
 - **Reviewed first-party repository research:** reviewed repository source,
   without claiming it proves current server behavior.
 - **TypeScript-derived inference:** historical draft or TypeScript transport
@@ -55,7 +58,7 @@ rules, and limits are **explicit unknown**. Eleven operations with an observed
 HTTP `200` status have typed response bodies. The schema-free
 send-code `200` and OpenAPI `default` responses do not claim a body.
 
-The 1230 material claims are audited by
+The 1253 material claims are audited by
 `tests/remote-api-contract.test.js`. Each ledger citation resolves either to a
 JSON Pointer in the committed non-authoritative historical artifact or to a
 heading in the committed stable source index. This keeps the audit independent
@@ -146,8 +149,12 @@ No remote paging field was observed for either list. Revision
 `2026-08-11.5` records the observed complete array representations but keeps
 remote pagination, limits, ordering, snapshot behavior, and list failures
 unknown. Event ID projection is supported. One selected guest status supports
-an RSVP projection for that item. Product state and full role mappings remain
-implementation gates.
+an RSVP projection for that item. Current public assets close the S3
+event-state, owner-membership, and guest-status vocabulary. The two wire event
+states are `PUBLISHED` and `CANCELED`. Owner membership uses
+`event.ownerIds.includes(userId)`. The events UI treats any owner membership
+as hosting and does not expose a primary-host/cohost distinction. The 16
+current guest statuses remain lossless in the read projection.
 
 `getEventInfo` returned `200` at `result.data.event` for one selected readable
 event and returned `404 NOT_FOUND` for a synthetic missing ID. The selected
@@ -236,7 +243,7 @@ by the Go implementation's Firebase requests:
 Origin is unmodelled and remains unknown because the reviewed evidence
 establishes no Origin request fact.
 
-The 1230 material claims are audited by `tests/remote-api-contract.test.js`.
+The 1253 material claims are audited by `tests/remote-api-contract.test.js`.
 
 ## Resolved conflict
 

--- a/docs/research/2026-08-11-event-contacts-read-observation.md
+++ b/docs/research/2026-08-11-event-contacts-read-observation.md
@@ -10,8 +10,9 @@ live request was made.
 The sanitized source is
 `spec/research/read-evidence-redacted-20260811.json`. It contains only HTTP
 metadata, normalized paths and types, counts, equality facts, and allowlisted
-error codes. Revision `2026-08-11.5` is a proposal. This observation does not
-make it owner-reviewed.
+error codes. This evidence was proposed when captured and was subsequently
+owner-reviewed in revision `2026-08-11.5`; the observation alone did not confer
+that review.
 
 ## Event list observations
 
@@ -26,7 +27,7 @@ set for each operation. No duplicate identity occurred in either observed
 sequence. This is stability evidence for two observations only. It does not
 establish an ordering key or snapshot behavior.
 
-The observations establish the named item fields and types in the proposed
+The observations establish the named item fields and types in the reviewed
 schemas. Only `id` was present on every item by an explicit aggregate check.
 The selected upcoming item also had a guest object with a string status. This
 supports the event ID projection and one selected RSVP-status projection. It
@@ -62,7 +63,7 @@ path was `result.data.currentGuest`. It was an object with string `id`,
 `name`, `status`, and `userId`, integer `count`, and null `plusOnes`.
 This one object does not establish operation-wide field presence,
 nullability, or alternate variants, so `CurrentGuest` has no operation-wide
-top-level type and no required field list. The proposed schema leaves `count`,
+top-level type and no required field list. The schema leaves `count`,
 `plusOnes`, and `userId` unconstrained. In particular, the shape of an
 ordinary non-null plus-one value is unknown. No null `currentGuest` or other
 variant was observed.

--- a/docs/research/2026-08-12-event-read-mapping-public-assets.md
+++ b/docs/research/2026-08-12-event-read-mapping-public-assets.md
@@ -1,0 +1,239 @@
+# Event-read mappings in current public web assets
+
+## Scope and provenance
+
+This note records privacy-safe research from Partiful's current first-party
+public web assets. The assets were fetched without authentication on
+August 12, 2026. No credential, account-scoped request, response containing
+event or user data, or mutation was used.
+
+The public login page supplied build ID `z1npyrEHkwRMn_JlKXQXR` and deployment
+query `dpl_4w28tFBmSUwoToDpQB8CU8gt16sL`. Its build manifest assigns
+`pages/events-16d5030ecfa4fd91.js` to `/events`.
+
+Exact sources:
+
+- [login page](https://partiful.com/login)
+- [build manifest](https://partiful.com/_next/static/z1npyrEHkwRMn_JlKXQXR/_buildManifest.js?dpl=dpl_4w28tFBmSUwoToDpQB8CU8gt16sL)
+- [`/events` page asset](https://partiful.com/_next/static/chunks/pages/events-16d5030ecfa4fd91.js?dpl=dpl_4w28tFBmSUwoToDpQB8CU8gt16sL)
+- [shared `_app` asset](https://partiful.com/_next/static/chunks/pages/_app-05be110884cfdc20.js?dpl=dpl_4w28tFBmSUwoToDpQB8CU8gt16sL)
+- [shared chunk containing the past-operation name](https://partiful.com/_next/static/chunks/8733-cef914451f66c66d.js?dpl=dpl_4w28tFBmSUwoToDpQB8CU8gt16sL)
+
+The immutable asset responses reported `Last-Modified: Tue, 11 Aug 2026
+21:17:57 GMT`. The build manifest, events asset, and `_app` asset were 11,476,
+65,476, and 2,369,333 bytes. Their SHA-256 digests were, respectively:
+
+```text
+6014233108449ef82cd4066e6f29476845e3a637e0adfceb79b7cb17fd7d0159
+f06c1b0d78258ebb02ad6a95152ef4f9628c25c7ab54720180ed43db97e9f1fa
+46a2fe543a4aa17f2cd5d5f8d0547b8f8e692b43b9d7b7061d78f1a01228c9fe
+```
+
+Public assets are research evidence. They do not establish unobserved server
+statuses, ordering, limits, pagination, or response-field presence.
+
+## One-response event-list calls
+
+The `/events` asset names the two callable operations and sends empty
+`params`. It reads `response.data`, then reads `upcomingEvents` or
+`pastEvents`; it sends no paging member.
+
+Faithfully deminified modules `48666`, `17350`, `35932`, and `22920`:
+
+```js
+const upcomingOperation = "getMyUpcomingEventsForHomePage";
+
+async function getUpcomingHomePageData() {
+  return (await call(upcomingOperation, { params: EMPTY_OBJECT })).data ??
+    {
+      upcomingEvents: EMPTY_ARRAY,
+      initialPastEvents: EMPTY_ARRAY,
+      eventCategoryCounts: EMPTY_CATEGORY_COUNTS,
+    };
+}
+
+const pastOperation = "getMyPastEventsForHomePage";
+
+async function getPastHomePageData() {
+  return (await call(pastOperation, { params: EMPTY_OBJECT })).data ??
+    { pastEvents: EMPTY_ARRAY };
+}
+```
+
+The names, empty `params`, and absence of a paging argument agree with the
+owner-reviewed `.5` request and one-response observations. The fallback
+objects are client behavior and do not describe a successful remote body.
+
+## Event status
+
+Shared module `18539` contains this exact minified enum construction:
+
+```js
+let d=((r={}).UNSAVED="UNSAVED",r.LIVE="PUBLISHED",
+  r.CANCELED="CANCELED",r)
+```
+
+Faithfully deminified:
+
+```js
+const EventStatus = {
+  UNSAVED: "UNSAVED",
+  LIVE: "PUBLISHED",
+  CANCELED: "CANCELED",
+};
+```
+
+Thus the current client symbolic cases `LIVE` and `CANCELED` correspond to the
+wire values `PUBLISHED` and `CANCELED`. The `/events` page checks
+`event.status === EventStatus.CANCELED` for the canceled label and checks
+`event.status === EventStatus.LIVE` when selecting live invited and attended
+events. For S3 reads, the lossless product mapping is:
+
+```text
+PUBLISHED -> active
+CANCELED  -> cancelled
+```
+
+`UNSAVED` is a client draft state. The reviewed homepage list observations do
+not establish it as a returned value, so it is not promoted for S3.
+
+## Owner membership and hosting
+
+Shared module `50218` exports `Ro`. Its exact minified body is:
+
+```js
+function Z(e,t){
+  return t.status===l.fb.UNSAVED||null!=e&&t.ownerIds.includes(e)
+}
+```
+
+Faithfully deminified for non-draft event reads:
+
+```js
+function isHost(userId, event) {
+  return userId != null && event.ownerIds.includes(userId);
+}
+```
+
+Equivalently, the product rule is
+`event.ownerIds.includes(userId)`. The `/events` page uses this helper to
+build `hostedEvents`. It also independently computes:
+
+```js
+const isHost = event.ownerIds.some(ownerId => ownerId === currentUserId);
+const guest = "guest" in event ? event.guest : undefined;
+```
+
+It supplies that boolean as the event card's `isHost` value. Owner membership
+therefore means hosting in the current first-party events UI. The asset does
+not distinguish a primary host from a cohost. S3 can map any current-user
+owner membership to product `host`; product `cohost` stays reserved until a
+distinct reviewed field exists.
+
+The route separates non-host records by guest presence:
+
+```js
+const hostedEvents = events.filter(event => isHost(currentUserId, event));
+const guestEvents = events.filter(
+  event => hasGuest(event) || !isHost(currentUserId, event),
+);
+```
+
+For a reviewed representation with `ownerIds`, S3 can therefore emit
+`attendee` when the current user is not an owner and a `guest` object is
+present, and `none` when neither condition applies. If `ownerIds` is absent,
+the role is unavailable rather than guessed.
+
+## Guest statuses
+
+Shared module `54257` defines this closed current enum:
+
+```js
+const GuestStatus = {
+  READY_TO_SEND: "READY_TO_SEND",
+  SENDING: "SENDING",
+  SEND_ERROR: "SEND_ERROR",
+  DELIVERY_ERROR: "DELIVERY_ERROR",
+  SENT: "SENT",
+  INTERESTED: "INTERESTED",
+  WAITLIST: "WAITLIST",
+  MAYBE: "MAYBE",
+  DECLINED: "DECLINED",
+  GOING: "GOING",
+  PENDING_APPROVAL: "PENDING_APPROVAL",
+  APPROVED: "APPROVED",
+  WITHDRAWN: "WITHDRAWN",
+  WAITLISTED_FOR_APPROVAL: "WAITLISTED_FOR_APPROVAL",
+  REJECTED: "REJECTED",
+  RESPONDED_TO_FIND_A_TIME: "RESPONDED_TO_FIND_A_TIME",
+};
+```
+
+The same module's `VO` helper recognizes all 16 values for current event-card
+status display. Other helpers form narrower groups for invite delivery,
+attendance, application, and response behavior. None supplies one
+semantically lossless grouping for a general read result.
+
+S3 therefore uses a separate lossless read enum. It lowercases each exact
+value and replaces underscores with hyphens:
+
+| Remote | Product read value |
+| --- | --- |
+| `READY_TO_SEND` | `ready-to-send` |
+| `SENDING` | `sending` |
+| `SEND_ERROR` | `send-error` |
+| `DELIVERY_ERROR` | `delivery-error` |
+| `SENT` | `sent` |
+| `INTERESTED` | `interested` |
+| `WAITLIST` | `waitlist` |
+| `MAYBE` | `maybe` |
+| `DECLINED` | `declined` |
+| `GOING` | `going` |
+| `PENDING_APPROVAL` | `pending-approval` |
+| `APPROVED` | `approved` |
+| `WITHDRAWN` | `withdrawn` |
+| `WAITLISTED_FOR_APPROVAL` | `waitlisted-for-approval` |
+| `REJECTED` | `rejected` |
+| `RESPONDED_TO_FIND_A_TIME` | `responded-to-find-a-time` |
+
+This read enum does not redefine S5's narrower writable RSVP intent. A null
+read value means that no current guest object or status is available. An
+unknown present status is protocol drift, not null.
+
+## Pagination boundary
+
+The public assets make one call for each selected homepage representation and
+do not supply or consume remote paging for these arrays. The `.5` observation
+establishes complete one-response representations of 35 and 294 items,
+repeated with identical identity sequences. Their largest observed body was
+773,455 bytes.
+
+These facts support local snapshot pagination only. They do not establish
+remote order meaning, remote limits, server snapshots, or future completeness.
+The product can preserve the received sequence, bind its existing opaque
+cursor to a digest of the complete response plus command/filter and next
+offset, refetch once on resume, and reject a digest change as a snapshot
+conflict.
+
+A local ceiling is product safety, not a remote claim. S3 limits the
+one-response representation to 1,000 items (the existing product
+`--max-items` ceiling) and 8 MiB. It rejects an exceeded bound without
+returning a truncated success.
+
+## Facts not established
+
+These assets do not establish:
+
+- operation-wide presence of optional event fields;
+- a primary-host/cohost distinction inside `ownerIds`;
+- a universal signed-out event-read policy;
+- inaccessible-event behavior or a callable permission response;
+- remote paging, ordering keys, limits, snapshot behavior, or future
+  completeness;
+- null or alternate `getCurrentGuest` variants;
+- Firestore event success or not-found behavior; or
+- mappings for event address, guest limit, poster, links, or other fields not
+  named above.
+
+S3 must not call Firestore event GET: `.5` records `403 PERMISSION_DENIED` for
+both selected and synthetic IDs with the observed credential context.

--- a/spec/partiful.api-evidence.json
+++ b/spec/partiful.api-evidence.json
@@ -400,7 +400,7 @@
     "Firestore event GET returned PERMISSION_DENIED for selected readable and synthetic IDs with one credential; success, not-found, attendee-denial, and other credential behavior remain unknown.",
     "Contact invalid-cursor behavior, cursor lifetime and reuse, ordering key, snapshot behavior, useAuthUser, rate limiting, unsupported statuses, future catalog completeness, server duplicate behavior, and duplicates outside two traversals remain unknown."
   ],
-  "status": "proposed-pending-delegated-review",
+  "status": "owner-reviewed",
   "claims": {
     "#/servers/0/url": {
       "classification": "typescript-derived-inference",

--- a/spec/partiful.api-evidence.json
+++ b/spec/partiful.api-evidence.json
@@ -4690,6 +4690,10 @@
       "classification": "current-first-party-public-asset-research",
       "citation": "docs/research/2026-08-12-event-read-mapping-public-assets.md#event-status"
     },
+    "#/components/schemas/EventStatus/enum/2": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-read-mapping-public-assets.md#event-status"
+    },
     "#/components/schemas/GuestStatus/type": {
       "classification": "current-first-party-public-asset-research",
       "citation": "docs/research/2026-08-12-event-read-mapping-public-assets.md#guest-statuses"

--- a/spec/partiful.api-evidence.json
+++ b/spec/partiful.api-evidence.json
@@ -1,8 +1,9 @@
 {
-  "contractRevision": "2026-08-11.5",
+  "contractRevision": "2026-08-12.1",
   "contractPath": "spec/partiful.openapi.json",
   "allowedClassifications": [
     "dated-live-observation",
+    "current-first-party-public-asset-research",
     "reviewed-first-party-repository-research",
     "typescript-derived-inference",
     "explicit-unknown"
@@ -32,7 +33,12 @@
     "readPrivacy20260811": "docs/research/2026-08-11-event-contacts-read-observation.md#privacy-boundary",
     "readUnknowns20260811": "docs/research/2026-08-11-event-contacts-read-observation.md#remaining-unknowns",
     "publicContactPaging20260811": "docs/research/2026-08-11-contacts-pagination-public-assets.md#exact-callable-argument",
-    "publicContactDeduplication20260811": "docs/research/2026-08-11-contacts-pagination-public-assets.md#ordering-duplicates-and-filtering"
+    "publicContactDeduplication20260811": "docs/research/2026-08-11-contacts-pagination-public-assets.md#ordering-duplicates-and-filtering",
+    "publicEventMapping20260812": "docs/research/2026-08-12-event-read-mapping-public-assets.md#scope-and-provenance",
+    "publicEventStatus20260812": "docs/research/2026-08-12-event-read-mapping-public-assets.md#event-status",
+    "publicEventOwnership20260812": "docs/research/2026-08-12-event-read-mapping-public-assets.md#owner-membership-and-hosting",
+    "publicGuestStatus20260812": "docs/research/2026-08-12-event-read-mapping-public-assets.md#guest-statuses",
+    "publicEventPagination20260812": "docs/research/2026-08-12-event-read-mapping-public-assets.md#pagination-boundary"
   },
   "operations": {
     "createEvent": {
@@ -394,7 +400,7 @@
     "Firestore event GET returned PERMISSION_DENIED for selected readable and synthetic IDs with one credential; success, not-found, attendee-denial, and other credential behavior remain unknown.",
     "Contact invalid-cursor behavior, cursor lifetime and reuse, ordering key, snapshot behavior, useAuthUser, rate limiting, unsupported statuses, future catalog completeness, server duplicate behavior, and duplicates outside two traversals remain unknown."
   ],
-  "status": "owner-reviewed",
+  "status": "proposed-pending-delegated-review",
   "claims": {
     "#/servers/0/url": {
       "classification": "typescript-derived-inference",
@@ -4672,6 +4678,86 @@
       "classification": "typescript-derived-inference",
       "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
     },
+    "#/components/schemas/EventStatus/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-read-mapping-public-assets.md#event-status"
+    },
+    "#/components/schemas/EventStatus/enum/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-read-mapping-public-assets.md#event-status"
+    },
+    "#/components/schemas/EventStatus/enum/1": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-read-mapping-public-assets.md#event-status"
+    },
+    "#/components/schemas/GuestStatus/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-read-mapping-public-assets.md#guest-statuses"
+    },
+    "#/components/schemas/GuestStatus/enum/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-read-mapping-public-assets.md#guest-statuses"
+    },
+    "#/components/schemas/GuestStatus/enum/1": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-read-mapping-public-assets.md#guest-statuses"
+    },
+    "#/components/schemas/GuestStatus/enum/2": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-read-mapping-public-assets.md#guest-statuses"
+    },
+    "#/components/schemas/GuestStatus/enum/3": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-read-mapping-public-assets.md#guest-statuses"
+    },
+    "#/components/schemas/GuestStatus/enum/4": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-read-mapping-public-assets.md#guest-statuses"
+    },
+    "#/components/schemas/GuestStatus/enum/5": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-read-mapping-public-assets.md#guest-statuses"
+    },
+    "#/components/schemas/GuestStatus/enum/6": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-read-mapping-public-assets.md#guest-statuses"
+    },
+    "#/components/schemas/GuestStatus/enum/7": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-read-mapping-public-assets.md#guest-statuses"
+    },
+    "#/components/schemas/GuestStatus/enum/8": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-read-mapping-public-assets.md#guest-statuses"
+    },
+    "#/components/schemas/GuestStatus/enum/9": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-read-mapping-public-assets.md#guest-statuses"
+    },
+    "#/components/schemas/GuestStatus/enum/10": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-read-mapping-public-assets.md#guest-statuses"
+    },
+    "#/components/schemas/GuestStatus/enum/11": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-read-mapping-public-assets.md#guest-statuses"
+    },
+    "#/components/schemas/GuestStatus/enum/12": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-read-mapping-public-assets.md#guest-statuses"
+    },
+    "#/components/schemas/GuestStatus/enum/13": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-read-mapping-public-assets.md#guest-statuses"
+    },
+    "#/components/schemas/GuestStatus/enum/14": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-read-mapping-public-assets.md#guest-statuses"
+    },
+    "#/components/schemas/GuestStatus/enum/15": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-read-mapping-public-assets.md#guest-statuses"
+    },
     "#/components/schemas/HomePageEvent/type": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
@@ -4724,9 +4810,21 @@
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
     },
-    "#/components/schemas/HomePageEvent/properties/status/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    "#/components/schemas/HomePageEvent/properties/status/$ref": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-read-mapping-public-assets.md#event-status"
+    },
+    "#/components/schemas/HomePageEvent/properties/ownerIds": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-read-mapping-public-assets.md#owner-membership-and-hosting"
+    },
+    "#/components/schemas/HomePageEvent/properties/ownerIds/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-read-mapping-public-assets.md#owner-membership-and-hosting"
+    },
+    "#/components/schemas/HomePageEvent/properties/ownerIds/items/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-read-mapping-public-assets.md#owner-membership-and-hosting"
     },
     "#/components/schemas/HomePageEvent/properties/location": {
       "classification": "dated-live-observation",
@@ -4772,9 +4870,9 @@
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
     },
-    "#/components/schemas/HomePageEvent/properties/guest/properties/status/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    "#/components/schemas/HomePageEvent/properties/guest/properties/status/$ref": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-read-mapping-public-assets.md#guest-statuses"
     },
     "#/components/schemas/EventInfo/properties/id": {
       "classification": "dated-live-observation",
@@ -4820,9 +4918,9 @@
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
     },
-    "#/components/schemas/EventInfo/properties/status/type": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations"
+    "#/components/schemas/EventInfo/properties/status/$ref": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-read-mapping-public-assets.md#event-status"
     },
     "#/components/schemas/EventInfo/properties/description": {
       "classification": "dated-live-observation",
@@ -5354,6 +5452,73 @@
       "rateLimiting": "not-claimed"
     }
   },
+  "publicEventAssetResearch": {
+    "classification": "current-first-party-public-asset-research",
+    "sourceCitation": "docs/research/2026-08-12-event-read-mapping-public-assets.md#scope-and-provenance",
+    "observedAt": "2026-08-12T02:03:29Z",
+    "buildId": "z1npyrEHkwRMn_JlKXQXR",
+    "assets": {
+      "buildManifest": {
+        "url": "https://partiful.com/_next/static/z1npyrEHkwRMn_JlKXQXR/_buildManifest.js",
+        "bytes": 11476,
+        "sha256": "6014233108449ef82cd4066e6f29476845e3a637e0adfceb79b7cb17fd7d0159"
+      },
+      "eventsPage": {
+        "url": "https://partiful.com/_next/static/chunks/pages/events-16d5030ecfa4fd91.js",
+        "bytes": 65476,
+        "sha256": "f06c1b0d78258ebb02ad6a95152ef4f9628c25c7ab54720180ed43db97e9f1fa"
+      },
+      "sharedApp": {
+        "url": "https://partiful.com/_next/static/chunks/pages/_app-05be110884cfdc20.js",
+        "bytes": 2369333,
+        "sha256": "46a2fe543a4aa17f2cd5d5f8d0547b8f8e692b43b9d7b7061d78f1a01228c9fe"
+      }
+    },
+    "modules": {
+      "eventStatus": 18539,
+      "eventOwnership": 50218,
+      "guestStatus": 54257,
+      "upcomingOperation": 48666,
+      "upcomingQuery": 17350,
+      "pastOperation": 35932,
+      "pastQuery": 22920
+    },
+    "eventStatus": {
+      "LIVE": "PUBLISHED",
+      "CANCELED": "CANCELED"
+    },
+    "ownership": {
+      "field": "ownerIds",
+      "comparison": "event.ownerIds.includes(userId)",
+      "ownerProductRole": "host",
+      "cohostDistinction": "not-present"
+    },
+    "guestStatuses": [
+      "READY_TO_SEND",
+      "SENDING",
+      "SEND_ERROR",
+      "DELIVERY_ERROR",
+      "SENT",
+      "INTERESTED",
+      "WAITLIST",
+      "MAYBE",
+      "DECLINED",
+      "GOING",
+      "PENDING_APPROVAL",
+      "APPROVED",
+      "WITHDRAWN",
+      "WAITLISTED_FOR_APPROVAL",
+      "REJECTED",
+      "RESPONDED_TO_FIND_A_TIME"
+    ],
+    "listTransport": {
+      "requestPaging": "absent",
+      "responsePaging": "absent-in-reviewed-observation",
+      "remoteOrdering": "explicit-unknown",
+      "remoteLimits": "explicit-unknown",
+      "remoteSnapshot": "explicit-unknown"
+    }
+  },
   "authObservation": {
     "sourceCitation": "docs/research/2026-08-11-auth-observation.md#scope-and-provenance",
     "observedAt": "2026-08-11T02:30:19Z",
@@ -5444,9 +5609,19 @@
     "productProjection": {
       "eventId": "supported-by-complete-item-id",
       "titleStartEndTimezone": "observed-types-only-presence-not-proven",
-      "myRsvp": "selected-item-guest-status-observed",
-      "stateMapping": "explicit-unknown",
-      "userRoleMapping": "explicit-unknown"
+      "optionalScalars": "null-when-reviewed-property-is-unavailable",
+      "myRsvp": "lossless-closed-guest-status-normalization-or-null",
+      "stateMapping": {
+        "PUBLISHED": "active",
+        "CANCELED": "cancelled"
+      },
+      "userRoleMapping": {
+        "ownerMembership": "host",
+        "nonOwnerWithGuest": "attendee",
+        "nonOwnerWithoutGuest": "none",
+        "ownerIdsUnavailable": null,
+        "cohost": "reserved-not-emitted"
+      }
     },
     "getEventInfo": {
       "selectedAuthenticatedStatus": 200,

--- a/spec/partiful.openapi.json
+++ b/spec/partiful.openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Partiful remote API contract",
     "version": "2026-08-12.1",
-    "description": "Proposed, versioned remote-only transport snapshot pending delegated review. Evidence classifications and uncertainty are recorded in spec/partiful.api-evidence.json."
+    "description": "Owner-reviewed, versioned remote-only transport snapshot. Evidence classifications and uncertainty are recorded in spec/partiful.api-evidence.json."
   },
   "servers": [
     {

--- a/spec/partiful.openapi.json
+++ b/spec/partiful.openapi.json
@@ -2,8 +2,8 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Partiful remote API contract",
-    "version": "2026-08-11.5",
-    "description": "Owner-reviewed, versioned remote-only transport snapshot. Evidence classifications and uncertainty are recorded in spec/partiful.api-evidence.json."
+    "version": "2026-08-12.1",
+    "description": "Proposed, versioned remote-only transport snapshot pending delegated review. Evidence classifications and uncertainty are recorded in spec/partiful.api-evidence.json."
   },
   "servers": [
     {
@@ -2508,6 +2508,34 @@
         },
         "additionalProperties": true
       },
+      "EventStatus": {
+        "type": "string",
+        "enum": [
+          "PUBLISHED",
+          "CANCELED"
+        ]
+      },
+      "GuestStatus": {
+        "type": "string",
+        "enum": [
+          "READY_TO_SEND",
+          "SENDING",
+          "SEND_ERROR",
+          "DELIVERY_ERROR",
+          "SENT",
+          "INTERESTED",
+          "WAITLIST",
+          "MAYBE",
+          "DECLINED",
+          "GOING",
+          "PENDING_APPROVAL",
+          "APPROVED",
+          "WITHDRAWN",
+          "WAITLISTED_FOR_APPROVAL",
+          "REJECTED",
+          "RESPONDED_TO_FIND_A_TIME"
+        ]
+      },
       "HomePageEvent": {
         "type": "object",
         "required": [
@@ -2533,7 +2561,13 @@
             "type": "string"
           },
           "status": {
-            "type": "string"
+            "$ref": "#/components/schemas/EventStatus"
+          },
+          "ownerIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           },
           "location": {
             "type": [
@@ -2554,7 +2588,7 @@
             "type": "object",
             "properties": {
               "status": {
-                "type": "string"
+                "$ref": "#/components/schemas/GuestStatus"
               }
             }
           }
@@ -2581,7 +2615,7 @@
             "type": "string"
           },
           "status": {
-            "type": "string"
+            "$ref": "#/components/schemas/EventStatus"
           },
           "description": {},
           "displaySettings": {

--- a/spec/partiful.openapi.json
+++ b/spec/partiful.openapi.json
@@ -2511,6 +2511,7 @@
       "EventStatus": {
         "type": "string",
         "enum": [
+          "UNSAVED",
           "PUBLISHED",
           "CANCELED"
         ]

--- a/tests/remote-api-contract.test.js
+++ b/tests/remote-api-contract.test.js
@@ -244,7 +244,7 @@ describe('remote API contract', () => {
     expect(spec.openapi).toBe('3.1.0');
     expect(evidence.contractRevision).toBe('2026-08-12.1');
     expect(spec.info.version).toBe(evidence.contractRevision);
-    expect(evidence.status).toBe('proposed-pending-delegated-review');
+    expect(evidence.status).toBe('owner-reviewed');
     expect(evidence.sources.publicEventMapping20260812)
       .toBe(`${eventAssetResearchPath}#scope-and-provenance`);
     expect(citationResolves(evidence.sources.publicEventMapping20260812)).toBe(true);
@@ -356,10 +356,10 @@ describe('remote API contract', () => {
     );
     expect(ledger.match(/The 1254 material claims/g)).toHaveLength(2);
     expect(ledger).toContain(
-      '**Proposed contract revision:** `2026-08-12.1`',
+      '**Owner-reviewed contract revision:** `2026-08-12.1`',
     );
     expect(ledger).toContain(
-      '**Status:** Proposed; pending delegated review',
+      '**Status:** Owner-reviewed under the issue #114 delegation',
     );
     expect(ledger).toContain('Current first-party public-asset research');
   });
@@ -896,9 +896,9 @@ describe('remote API contract', () => {
   it('defines conservative nullable event reads and bounded local snapshots', () => {
     const product = fs.readFileSync(productContractPath, 'utf8');
     for (const expected of [
-      '**Status:** Proposed product contract pending delegated review',
+      '**Status:** Approved product contract',
       '**Product contract revision:** `2026-08-12.1`',
-      '**Remote API contract revision:** `2026-08-12.1` (proposed)',
+      '**Remote API contract revision:** `2026-08-12.1`',
       '`PUBLISHED` → `active`',
       '`CANCELED` → `cancelled`',
       '`UNSAVED` exists in the current first-party client vocabulary',
@@ -1356,7 +1356,7 @@ describe('remote API contract', () => {
     expect(documentedProductRevision).toBe('2026-08-12.1');
     expect(new Set(envelopeRevisions)).toEqual(new Set([documentedRevision]));
     expect(spec.info.version).toBe(documentedRevision);
-    expect(evidence.status).toBe('proposed-pending-delegated-review');
+    expect(evidence.status).toBe('owner-reviewed');
     expect(spec.info.version).not.toBe(shippedRevision);
     expect(appSource).toContain('ProductContractRevision = "2026-08-10.1"');
     expect(productContract)

--- a/tests/remote-api-contract.test.js
+++ b/tests/remote-api-contract.test.js
@@ -8,6 +8,9 @@ const historicalDraftPath = 'spec/research/historical-27-operation-draft.json';
 const historicalDraft = JSON.parse(fs.readFileSync(historicalDraftPath, 'utf8'));
 const readEvidencePath = 'spec/research/read-evidence-redacted-20260811.json';
 const readEvidence = JSON.parse(fs.readFileSync(readEvidencePath, 'utf8'));
+const eventAssetResearchPath =
+  'docs/research/2026-08-12-event-read-mapping-public-assets.md';
+const productContractPath = 'docs/CLI-PRODUCT-CONTRACT.md';
 const sourceCache = new Map([
   [historicalDraftPath, historicalDraft],
   [readEvidencePath, readEvidence],
@@ -239,9 +242,15 @@ function citationResolves(citation) {
 describe('remote API contract', () => {
   it('is a consistently versioned OpenAPI 3.1 document with unique operation IDs', () => {
     expect(spec.openapi).toBe('3.1.0');
-    expect(evidence.contractRevision).toBe('2026-08-11.5');
+    expect(evidence.contractRevision).toBe('2026-08-12.1');
     expect(spec.info.version).toBe(evidence.contractRevision);
-    expect(evidence.status).toBe('owner-reviewed');
+    expect(evidence.status).toBe('proposed-pending-delegated-review');
+    expect(evidence.sources.publicEventMapping20260812)
+      .toBe(`${eventAssetResearchPath}#scope-and-provenance`);
+    expect(citationResolves(evidence.sources.publicEventMapping20260812)).toBe(true);
+    const appSource = fs.readFileSync('internal/app/app.go', 'utf8');
+    expect(appSource).toContain('ProductContractRevision = "2026-08-10.1"');
+    expect(appSource).toContain('RemoteContractRevision  = "2026-08-11.5"');
     const ids = operations().map(({ operation }) => operation.operationId);
     expect(ids).toHaveLength(27);
     expect(new Set(ids).size).toBe(ids.length);
@@ -287,7 +296,7 @@ describe('remote API contract', () => {
       ...materialClaimPointers(spec.paths, '#/paths', 'paths'),
       ...materialClaimPointers(spec.components, '#/components', 'components'),
     ]);
-    expect(pointers).toHaveLength(1230);
+    expect(pointers).toHaveLength(1253);
     for (const pointer of pointers) {
       const claim = evidence.claims[pointer];
       expect(claim, pointer).toBeDefined();
@@ -345,7 +354,14 @@ describe('remote API contract', () => {
     expect(ledger).toMatch(
       /Eleven of those\s+operations have a typed `200` response body\./,
     );
-    expect(ledger.match(/The 1230 material claims/g)).toHaveLength(2);
+    expect(ledger.match(/The 1253 material claims/g)).toHaveLength(2);
+    expect(ledger).toContain(
+      '**Proposed contract revision:** `2026-08-12.1`',
+    );
+    expect(ledger).toContain(
+      '**Status:** Proposed; pending delegated review',
+    );
+    expect(ledger).toContain('Current first-party public-asset research');
   });
 
   it('contains remote transport facts rather than product or implementation policy', () => {
@@ -693,6 +709,7 @@ describe('remote API contract', () => {
         response: 'dated-live-observation',
         status: 'dated-live-observation',
       });
+
       expect(evidence.readObservation.eventLists[rawField]).toMatchObject({
         rawPath: `result.data.${rawField}`,
         firstCount: count,
@@ -727,23 +744,193 @@ describe('remote API contract', () => {
         startDate: { type: 'string' },
         endDate: { type: ['string', 'null'] },
         timezone: { type: 'string' },
-        status: { type: 'string' },
+        status: { $ref: '#/components/schemas/EventStatus' },
+        ownerIds: {
+          type: 'array',
+          items: { type: 'string' },
+        },
         location: { type: ['string', 'null'] },
         displaySettings: { type: 'object' },
         image: { type: ['object', 'null'] },
         guest: {
           type: 'object',
-          properties: { status: { type: 'string' } },
+          properties: {
+            status: { $ref: '#/components/schemas/GuestStatus' },
+          },
         },
       },
     });
     expect(evidence.readObservation.productProjection).toMatchObject({
       eventId: 'supported-by-complete-item-id',
-      titleStartEndTimezone: 'observed-types-only-presence-not-proven',
-      myRsvp: 'selected-item-guest-status-observed',
-      stateMapping: 'explicit-unknown',
-      userRoleMapping: 'explicit-unknown',
+      optionalScalars: 'null-when-reviewed-property-is-unavailable',
+      myRsvp: 'lossless-closed-guest-status-normalization-or-null',
+      stateMapping: {
+        PUBLISHED: 'active',
+        CANCELED: 'cancelled',
+      },
+      userRoleMapping: {
+        ownerMembership: 'host',
+        nonOwnerWithGuest: 'attendee',
+        nonOwnerWithoutGuest: 'none',
+        ownerIdsUnavailable: null,
+        cohost: 'reserved-not-emitted',
+      },
     });
+  });
+
+  it('records the current first-party event mapping assets without private data', () => {
+    expect(fs.existsSync(eventAssetResearchPath)).toBe(true);
+    const research = fs.readFileSync(eventAssetResearchPath, 'utf8');
+    for (const expected of [
+      'z1npyrEHkwRMn_JlKXQXR',
+      'pages/events-16d5030ecfa4fd91.js',
+      'pages/_app-05be110884cfdc20.js',
+      'module `18539`',
+      'module `50218`',
+      'module `54257`',
+      'LIVE: "PUBLISHED"',
+      'CANCELED: "CANCELED"',
+      'event.ownerIds.includes(userId)',
+      'READY_TO_SEND',
+      'RESPONDED_TO_FIND_A_TIME',
+    ]) {
+      expect(research, expected).toContain(expected);
+    }
+    for (const unsafe of [
+      /(?<![\w])\+[1-9]\d{9,14}(?!\d)/,
+      /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/i,
+      /\beyJ[A-Za-z0-9_-]{12,}\.[A-Za-z0-9_-]{8,}\./,
+      /"(?:eventId|guestId|userId|id|name)"\s*:\s*"[^"]+"/,
+    ]) {
+      expect(research).not.toMatch(unsafe);
+    }
+  });
+
+  it('promotes only the public-asset event status, owner, and guest-status facts', () => {
+    expect(spec.components.schemas.EventStatus).toEqual({
+      type: 'string',
+      enum: ['PUBLISHED', 'CANCELED'],
+    });
+    expect(spec.components.schemas.GuestStatus).toEqual({
+      type: 'string',
+      enum: [
+        'READY_TO_SEND',
+        'SENDING',
+        'SEND_ERROR',
+        'DELIVERY_ERROR',
+        'SENT',
+        'INTERESTED',
+        'WAITLIST',
+        'MAYBE',
+        'DECLINED',
+        'GOING',
+        'PENDING_APPROVAL',
+        'APPROVED',
+        'WITHDRAWN',
+        'WAITLISTED_FOR_APPROVAL',
+        'REJECTED',
+        'RESPONDED_TO_FIND_A_TIME',
+      ],
+    });
+
+    const homePageEvent = spec.components.schemas.HomePageEvent;
+    expect(homePageEvent.required).toEqual(['id']);
+    expect(homePageEvent.properties.status)
+      .toEqual({ $ref: '#/components/schemas/EventStatus' });
+    expect(homePageEvent.properties.ownerIds).toEqual({
+      type: 'array',
+      items: { type: 'string' },
+    });
+    expect(homePageEvent.properties.guest.properties.status)
+      .toEqual({ $ref: '#/components/schemas/GuestStatus' });
+    expect(spec.components.schemas.EventInfo.properties.status)
+      .toEqual({ $ref: '#/components/schemas/EventStatus' });
+    expect(spec.components.schemas.EventInfo.properties).not.toHaveProperty('ownerIds');
+    expect(spec.components.schemas.EventInfo.properties).not.toHaveProperty('guest');
+
+    const publicAssetClass = 'current-first-party-public-asset-research';
+    expect(evidence.allowedClassifications).toContain(publicAssetClass);
+    for (const [pointer, citation] of [
+      [
+        '#/components/schemas/EventStatus/type',
+        evidence.sources.publicEventStatus20260812,
+      ],
+      [
+        '#/components/schemas/GuestStatus/type',
+        evidence.sources.publicGuestStatus20260812,
+      ],
+      [
+        '#/components/schemas/HomePageEvent/properties/ownerIds',
+        evidence.sources.publicEventOwnership20260812,
+      ],
+    ]) {
+      expect(evidence.claims[pointer]).toEqual({
+        classification: publicAssetClass,
+        citation,
+      });
+      expect(citationResolves(citation), citation).toBe(true);
+    }
+    expect(evidence.publicEventAssetResearch).toMatchObject({
+      sourceCitation: evidence.sources.publicEventMapping20260812,
+      observedAt: '2026-08-12T02:03:29Z',
+      buildId: 'z1npyrEHkwRMn_JlKXQXR',
+      modules: {
+        eventStatus: 18539,
+        eventOwnership: 50218,
+        guestStatus: 54257,
+      },
+      eventStatus: {
+        LIVE: 'PUBLISHED',
+        CANCELED: 'CANCELED',
+      },
+      ownership: {
+        field: 'ownerIds',
+        comparison: 'event.ownerIds.includes(userId)',
+        ownerProductRole: 'host',
+        cohostDistinction: 'not-present',
+      },
+      guestStatuses: spec.components.schemas.GuestStatus.enum,
+    });
+  });
+
+  it('defines conservative nullable event reads and bounded local snapshots', () => {
+    const product = fs.readFileSync(productContractPath, 'utf8');
+    for (const expected of [
+      '**Status:** Proposed product contract pending delegated review',
+      '**Product contract revision:** `2026-08-12.1`',
+      '**Remote API contract revision:** `2026-08-12.1` (proposed)',
+      '`PUBLISHED` → `active`',
+      '`CANCELED` → `cancelled`',
+      '`ownerIds` contains the current user → `host`',
+      '`ownerIds` is present, does not contain the current user, and `guest` is present → `attendee`',
+      '`cohost` is reserved',
+      '| `READY_TO_SEND` | `ready-to-send` |',
+      '| `RESPONDED_TO_FIND_A_TIME` | `responded-to-find-a-time` |',
+      'Null `myRsvp` means that no current guest object or status is available.',
+      'unavailable-not-claimed',
+      '1,000 items',
+      '8 MiB',
+      'digest-bound',
+      '`CURSOR_SNAPSHOT_CHANGED`',
+      '`404 NOT_FOUND` → `resource.not_found`',
+      'does not call `firestoreGetEvent`',
+      'permission mapping is deferred',
+    ]) {
+      expect(product, expected).toContain(expected);
+    }
+    expect(product).toMatch(
+      /`eventId` is the only non-null event-read field[\s\S]+all other documented event-read fields are\s+nullable/i,
+    );
+    expect(product).toMatch(
+      /`links` is\s+`null`[\s\S]+does not mean that the remote event has\s+no\s+links/,
+    );
+    expect(product).toMatch(
+      /unrecognized received status[\s\S]+`contract\.protocol_changed`/,
+    );
+
+    const appSource = fs.readFileSync('internal/app/app.go', 'utf8');
+    expect(appSource).toContain('ProductContractRevision = "2026-08-10.1"');
+    expect(appSource).toContain('RemoteContractRevision  = "2026-08-11.5"');
   });
 
   it('formalizes only the observed event-detail and guest read variants', () => {
@@ -765,7 +952,7 @@ describe('remote API contract', () => {
       startDate: { type: 'string' },
       endDate: { type: ['string', 'null'] },
       timezone: { type: 'string' },
-      status: { type: 'string' },
+      status: { $ref: '#/components/schemas/EventStatus' },
       description: {},
       displaySettings: { type: 'object' },
       image: { type: ['object', 'null'] },
@@ -791,11 +978,14 @@ describe('remote API contract', () => {
     });
     const eventListCitation =
       'docs/research/2026-08-11-event-contacts-read-observation.md#event-list-observations';
-    for (const field of ['id', 'startDate', 'timezone', 'status', 'displaySettings']) {
+    for (const field of ['id', 'startDate', 'timezone', 'displaySettings']) {
       expect(evidence.claims[
         `#/components/schemas/EventInfo/properties/${field}/type`
       ]?.citation).toBe(eventListCitation);
     }
+    expect(evidence.claims[
+      '#/components/schemas/EventInfo/properties/status/$ref'
+    ]?.citation).toBe(evidence.sources.publicEventStatus20260812);
     for (const field of ['endDate', 'image']) {
       for (const index of [0, 1]) {
         expect(evidence.claims[
@@ -1133,7 +1323,7 @@ describe('remote API contract', () => {
     expect(evidence.readObservation.artifactPath).toBe(readEvidencePath);
   });
 
-  it('ships the owner-reviewed contact remote revision', () => {
+  it('keeps shipped Go revisions unchanged while the event contracts are proposed', () => {
     const productContract = fs.readFileSync(
       'docs/CLI-PRODUCT-CONTRACT.md',
       'utf8',
@@ -1149,16 +1339,21 @@ describe('remote API contract', () => {
     const documentedRevision = productContract.match(
       /\*\*Remote API contract revision:\*\* `([^`]+)`/,
     )?.[1];
+    const documentedProductRevision = productContract.match(
+      /\*\*Product contract revision:\*\* `([^`]+)`/,
+    )?.[1];
     const envelopeRevisions = [...productContract.matchAll(
       /"remoteContractRevision": "([^"]+)"/g,
     )].map((match) => match[1]);
 
     expect(shippedRevision).toBe('2026-08-11.5');
-    expect(documentedRevision).toBe(shippedRevision);
-    expect(new Set(envelopeRevisions)).toEqual(new Set([shippedRevision]));
-    expect(spec.info.version).toBe('2026-08-11.5');
-    expect(evidence.status).toBe('owner-reviewed');
-    expect(spec.info.version).toBe(shippedRevision);
+    expect(documentedRevision).toBe('2026-08-12.1');
+    expect(documentedProductRevision).toBe('2026-08-12.1');
+    expect(new Set(envelopeRevisions)).toEqual(new Set([documentedRevision]));
+    expect(spec.info.version).toBe(documentedRevision);
+    expect(evidence.status).toBe('proposed-pending-delegated-review');
+    expect(spec.info.version).not.toBe(shippedRevision);
+    expect(appSource).toContain('ProductContractRevision = "2026-08-10.1"');
     expect(productContract)
       .not.toContain('currently leaves every operation response status and body unknown');
     expect(contactResearch)

--- a/tests/remote-api-contract.test.js
+++ b/tests/remote-api-contract.test.js
@@ -296,7 +296,7 @@ describe('remote API contract', () => {
       ...materialClaimPointers(spec.paths, '#/paths', 'paths'),
       ...materialClaimPointers(spec.components, '#/components', 'components'),
     ]);
-    expect(pointers).toHaveLength(1253);
+    expect(pointers).toHaveLength(1254);
     for (const pointer of pointers) {
       const claim = evidence.claims[pointer];
       expect(claim, pointer).toBeDefined();
@@ -354,7 +354,7 @@ describe('remote API contract', () => {
     expect(ledger).toMatch(
       /Eleven of those\s+operations have a typed `200` response body\./,
     );
-    expect(ledger.match(/The 1253 material claims/g)).toHaveLength(2);
+    expect(ledger.match(/The 1254 material claims/g)).toHaveLength(2);
     expect(ledger).toContain(
       '**Proposed contract revision:** `2026-08-12.1`',
     );
@@ -809,7 +809,7 @@ describe('remote API contract', () => {
   it('promotes only the public-asset event status, owner, and guest-status facts', () => {
     expect(spec.components.schemas.EventStatus).toEqual({
       type: 'string',
-      enum: ['PUBLISHED', 'CANCELED'],
+      enum: ['UNSAVED', 'PUBLISHED', 'CANCELED'],
     });
     expect(spec.components.schemas.GuestStatus).toEqual({
       type: 'string',
@@ -901,6 +901,7 @@ describe('remote API contract', () => {
       '**Remote API contract revision:** `2026-08-12.1` (proposed)',
       '`PUBLISHED` → `active`',
       '`CANCELED` → `cancelled`',
+      '`UNSAVED` exists in the current first-party client vocabulary',
       '`ownerIds` contains the current user → `host`',
       '`ownerIds` is present, does not contain the current user, and `guest` is present → `attendee`',
       '`cohost` is reserved',
@@ -915,6 +916,10 @@ describe('remote API contract', () => {
       '`404 NOT_FOUND` → `resource.not_found`',
       'does not call `firestoreGetEvent`',
       'permission mapping is deferred',
+      'Missing credentials return `auth.required`',
+      'A refresh rejected by the reviewed remote mapping also returns `auth.expired`',
+      'requires `result.data.event` to be an object',
+      'null, scalar, or array event value returns',
     ]) {
       expect(product, expected).toContain(expected);
     }


### PR DESCRIPTION
## Summary

- record privacy-safe current first-party `/events` asset evidence and propose remote/product revision `2026-08-12.1`
- define nullable event reads, lossless read RSVP values, conservative role/state mappings, and bounded local snapshot pagination
- keep shipped Go revisions at product `2026-08-10.1` and remote `2026-08-11.5`; this PR has no Go implementation

## Exact mappings

- `PUBLISHED` → `active`; `CANCELED` → `cancelled`
- current user in `ownerIds` → `host`; known non-owner with guest → `attendee`; known non-owner without guest → `none`; missing `ownerIds` → null
- all 16 guest statuses map one-to-one to lowercase hyphenated read values
- only `eventId` is required; unavailable optional fields are null without claiming remote absence

## Boundaries deferred

- `cohost` stays reserved because current assets do not distinguish it from owner membership
- `permission.denied` stays deferred until an inaccessible-event response is reviewed; unobserved `getEventInfo` 403 is protocol drift
- S3 must not use `firestoreGetEvent`, `getCurrentGuest`, or `firestoreGetGuest`
- list paging is local over one complete response, with 1,000-item/8-MiB ceilings and digest-change conflict

## Validation

- `npm test -- --run tests/remote-api-contract.test.js` (31 passed)
- `TZ=America/Los_Angeles npm test` (352 passed, 6 live tests skipped)
- `npm run typecheck`
- `go test -race ./...`
- `go vet ./... && go build ./... && go mod tidy` with no module diff
- privacy scan and `git diff --check`

Refs #164

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the CLI and remote API contracts to proposed revision 2026-08-12.1.
  - Documented event pagination, status and RSVP mappings, ownership roles, nullable fields, and protocol-drift handling.
  - Clarified that unavailable fields are represented as `null` without implying remote absence.
  - Added research evidence covering event reads, public assets, guest statuses, and pagination behavior.

- **API Schema**
  - Added event and guest status enums.
  - Added event owner identifiers and refined status field definitions.

- **Tests**
  - Expanded contract coverage for revised schemas, mappings, pagination, nullable reads, and evidence validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->