### PR TITLE
docs(contract): propose executable RSVP policy

### DIFF
--- a/docs/CLI-PRODUCT-CONTRACT.md
+++ b/docs/CLI-PRODUCT-CONTRACT.md
@@ -1,10 +1,12 @@
 # CLI product contract
 
-**Status:** Approved product contract
+**Status:** Proposed pending delegated review
 
-**Product contract revision:** `2026-08-12.2`
+**Product contract revision:** `2026-08-12.3`
 
-**Remote API contract revision:** `2026-08-12.2`
+**Remote API contract revision:** `2026-08-12.3`
+
+**Owner-reviewed baseline:** product and remote `2026-08-12.2`
 
 **Currently shipped Go revisions:** product and remote `2026-08-12.1`
 
@@ -81,8 +83,8 @@ Every successful command returns:
   "meta": {
     "command": "events.get",
     "cliVersion": "1.0.0",
-    "productContractRevision": "2026-08-12.2",
-    "remoteContractRevision": "2026-08-12.2",
+    "productContractRevision": "2026-08-12.3",
+    "remoteContractRevision": "2026-08-12.3",
     "warnings": []
   }
 }
@@ -105,8 +107,8 @@ Every failed command returns:
   "meta": {
     "command": "guests.list",
     "cliVersion": "1.0.0",
-    "productContractRevision": "2026-08-12.2",
-    "remoteContractRevision": "2026-08-12.2"
+    "productContractRevision": "2026-08-12.3",
+    "remoteContractRevision": "2026-08-12.3"
   }
 }
 ```
@@ -153,8 +155,8 @@ Collection commands return:
   "meta": {
     "command": "events.list",
     "cliVersion": "1.0.0",
-    "productContractRevision": "2026-08-12.2",
-    "remoteContractRevision": "2026-08-12.2",
+    "productContractRevision": "2026-08-12.3",
+    "remoteContractRevision": "2026-08-12.3",
     "warnings": [],
     "page": {
       "limit": 25,
@@ -226,8 +228,8 @@ remote mutation:
   "meta": {
     "command": "events.update",
     "cliVersion": "1.0.0",
-    "productContractRevision": "2026-08-12.2",
-    "remoteContractRevision": "2026-08-12.2",
+    "productContractRevision": "2026-08-12.3",
+    "remoteContractRevision": "2026-08-12.3",
     "warnings": []
   }
 }
@@ -243,8 +245,11 @@ error.
 
 The plan token is also bound to the command, normalized input, exact remote
 request projection, and a digest of every pre-read fact used by the plan.
-Secrets and personal data are redacted. There is no separate `--dry-run`
-flag: omitting `--apply` is the only dry-run behavior.
+Secrets, account identifiers, and the account fingerprint are redacted. A
+command-specific contract can permit user-supplied personal data in the exact
+input and request shown for review; that data is not copied to diagnostics or
+errors. There is no separate `--dry-run` flag: omitting `--apply` is the only
+dry-run behavior.
 
 ### Standard mutation
 
@@ -260,9 +265,11 @@ Standard-mutation plan tokens are single-use and expire after five minutes.
 Apply reacquires the private account fingerprint and every bound remote
 precondition before it consumes the token. Changed input, account, or
 precondition, expiry, or reuse returns `safety.plan_stale` before a mutation
-request. A successful precondition check permits exactly one mutation
-request. The CLI does not automatically retry a mutation after a response,
-timeout, connection loss, or ambiguous completion.
+request. After successful precondition checks, apply atomically consumes the
+token immediately before dispatch and makes exactly one transport attempt.
+The consumed token cannot be reused after a response, timeout, connection
+loss, or ambiguous completion. The CLI does not automatically retry; an
+uncertain transport outcome requires a new plan.
 
 ### Consequential action
 
@@ -604,7 +611,7 @@ Applied success returns:
 
 #### `partiful rsvp get <event-id>`
 
-Returns an `RsvpRead`:
+For the reviewed current-guest object variant, returns an `RsvpRead`:
 
 ```json
 {
@@ -617,13 +624,21 @@ Returns an `RsvpRead`:
 reads. It is not restricted to writable intents. No public RSVP read returns
 the current guest's private ID or account ID.
 
-Revision `2026-08-12.2` deliberately removes the unsupported shared read/write
-shape. The existing observation proves one current-guest object and its
-status. It does not prove null behavior or operation-wide presence and types
-for party size, plus ones, message, timezone, or questionnaire response.
-`rsvp get` therefore remains implementation-gated until a reviewed
-no-current-guest result and every required variant are available. The CLI must
-not turn an unknown null or alternate response into a guessed RSVP.
+The accepted object variant is an object with a nonempty string `id` and a
+`status` from the reviewed `GuestStatus` vocabulary. An explicit null or
+missing `currentGuest` uses the current first-party client's null-safe
+no-guest behavior and returns the documented no-RSVP shape:
+
+```json
+{"eventId":"evt_example","status":null}
+```
+
+This null-safe selection is current first-party product behavior. It is not a
+claim that a dated remote observation returned null or omitted the property.
+A scalar, array, object without a valid ID and status, or any other response
+variant returns `contract.protocol_changed`. Revision `2026-08-12.2`
+separated this read from the writable shape; revision `2026-08-12.3` permits
+only the exact reviewed object and null-safe no-guest product variants.
 
 #### `partiful rsvp set <event-id>`
 
@@ -635,6 +650,7 @@ values: `going`, `not-going`, and `interested`.
 ```json
 {
   "status": "going",
+  "displayName": "Example Attendee",
   "partySize": 1,
   "plusOnes": [],
   "message": null,
@@ -643,19 +659,27 @@ values: `going`, `not-going`, and `interested`.
 }
 ```
 
-`partySize` is a positive integer. `plusOnes` contains display-name strings;
-it never contains a private user or guest ID. `partySize` must equal one plus
-the number of named plus ones. `timezone` is required and identifies the
-attendee's IANA timezone. `message` is a string of at most 400 characters or
-null. Null maps to omission from the remote request.
+`displayName` is required for `going` and `not-going`. After trimming leading
+and trailing whitespace, it must contain 1–50 characters. The normalized
+value maps exactly to `addGuest.rsvp.name`; the CLI does not use an
+unavailable private profile lookup or reuse a current-guest name.
+
+`partySize` is a positive integer. `plusOnes` contains nonempty normalized
+display-name strings; it never contains a private user or guest ID.
+Each plus-one value is trimmed and must remain nonempty. `partySize` must equal
+one plus the number of named plus ones. `timezone` is required, identifies the
+attendee's IANA timezone, and is submitted unchanged after validation.
+`message` is a string or null. A non-null message is trimmed, must then contain
+at most 400 characters, and normalizes to null when empty. Null maps to
+omission from the remote request.
 
 For `going`, `questionnaireResponse` is null when the event has no
 questionnaire. Otherwise it is
 `{"questionnaireVersion","answers"}`, with a nonnegative version and string
-answers keyed by question ID. The plan requires the submitted version to
-equal the current event's latest questionnaire version. `not-going` requires
-`questionnaireResponse: null`, matching the first-party flow, which skips the
-questionnaire for `DECLINED`.
+answers keyed by question ID. This is caller-supplied normalized input; the
+answer strings are submitted unchanged, and the CLI does not read the event
+to validate the version. `not-going` requires `questionnaireResponse: null`,
+matching the first-party flow, which skips the questionnaire for `DECLINED`.
 
 `interested` accepts only:
 
@@ -665,9 +689,9 @@ questionnaire for `DECLINED`.
 }
 ```
 
-Party, plus-one, message, timezone, and questionnaire fields are invalid with
-`interested`. Interest removal is an established remote boolean request but
-is not a fourth writable product intent in this revision.
+`displayName`, party, plus-one, message, timezone, and questionnaire fields
+are invalid with `interested`. Interest removal is an established remote
+boolean request but is not a fourth writable product intent in this revision.
 
 The exact product-to-remote mappings are:
 
@@ -681,54 +705,69 @@ not invent an analytics source. The `addGuest` mapping uses
 input timezone, sends `shouldFollowOrgs: false`, and omits a null message. It
 omits phone number, channel preference, captcha token, image,
 `emailInvitationId`, `_discoverSource`, and password. It attaches the private
-existing `guestId` only when the reviewed current-guest pre-read returned one.
-The attendee name comes from that current guest. No output exposes either
-private value.
+existing `guestId` only when the reviewed current-guest pre-read returned an
+object with a nonempty string ID and reviewed status. A null or missing
+`currentGuest` marks no current guest and omits `guestId`. All going and
+not-going requests use the input `displayName`, whether a current guest is
+present or absent.
 
-The plan-only invocation performs these reads and no mutation:
+The plan-only invocation performs these steps and no mutation:
 
 1. acquire an authenticated session and private stable account fingerprint;
-2. read the selected event facts needed for party-size, questionnaire,
-   password, ticketing, and RSVP-action preconditions; and
-3. call `getCurrentGuest` once and bind a canonical digest of the complete
-   reviewed representation, including current-guest existence, private guest
-   ID, name, status, count, plus ones, and questionnaire response when
-   available.
+2. call `getCurrentGuest` once, which is the only remote precondition read;
+   and
+3. bind an explicit no-current-guest marker or the current-guest identity/status snapshot.
 
-The plan binds those facts, normalized product input, and the exact callable
-request projection. Apply reacquires the same account fingerprint, repeats
-the same reads once, compares every binding, and returns `safety.plan_stale`
-before the write if anything changed. It then consumes the five-minute,
-single-use token and sends at most one `addGuest` or `markEventInterest`
-request. It does not automatically retry either mutation.
+The present snapshot contains only the private guest ID and reviewed status.
+The absent marker represents null or missing `currentGuest`. Non-object,
+non-null values and objects without a valid ID and status return
+`contract.protocol_changed`; they do not produce a plan. The CLI does not read
+event party limits, questionnaire versions, password state, ticketing state,
+or other event fields as S5 preconditions. If the product input supplies
+plus-one, message, timezone, or questionnaire values, the plan binds the exact
+normalized values and the request submits them exactly. Any server rejection
+status remains protocol drift under the reviewed remote evidence.
 
-Applied callable completion returns the normalized submission:
+The five-minute, single-use plan binds the operation, exact normalized product
+input, exact callable request projection, private account fingerprint, and
+current-guest snapshot or absent marker. The input `displayName` can appear in
+the exact plan input and request so the caller can review it. It never appears
+in diagnostics, errors, or the applied result, and the private account
+fingerprint is never output.
+
+Apply reacquires the account fingerprint and calls `getCurrentGuest` once. A
+change between present and absent, guest ID, or status returns
+`safety.plan_stale` before token consumption. No other remote fact is read.
+After the check, apply consumes the token immediately before dispatch and
+makes exactly one transport attempt. It never retries automatically. A
+timeout, connection loss, or other uncertain transport outcome consumes the
+token and requires a new plan.
+
+For `going` and `not-going`, an `addGuest` HTTP `200` with the reviewed
+Firebase callable `result` envelope returns:
 
 ```json
-{
-  "eventId": "evt_example",
-  "intent": "going",
-  "submitted": true,
-  "partySize": 1,
-  "plusOnes": [],
-  "message": null,
-  "timezone": "America/Los_Angeles",
-  "questionnaireResponse": null
-}
+{"eventId":"evt_example","intent":"going","submitted":true}
 ```
 
-For `interested`, the result contains only `eventId`, `intent`, and
-`submitted`. `submitted: true` means that the one callable request completed
-with the reviewed callable envelope and client completion fields. This
-completion does not prove that the remote RSVP state changed, that a message
-or notification was delivered, or that another business side effect occurred.
+For `interested`, the same minimal shape uses intent `interested`, but
+`submitted: true` is returned only when `result.data.success` is truthy and
+`result.data.interested` strictly equals the submitted boolean. Truthy has the
+current JavaScript-client meaning: it excludes a missing value, null, false,
+numeric zero, and the empty string. A failed predicate, any unrecognized
+status, or any unsupported envelope returns `contract.protocol_changed` and
+never returns `submitted: true`.
 
-The contract is proposed, not releasable. Current evidence does not establish
-`getCurrentGuest` null behavior, a required attendee name when no current
-guest exists, or all selected-event precondition fields. These are
-irreducible blockers for fresh RSVP creation and for a complete safe
-precondition read. No Go RSVP command or mutation can ship until delegated
-review accepts this revision and later evidence closes those blockers.
+The CLI does not perform a post-write read. It never echoes `displayName` or
+the other normalized RSVP input in the applied result. `submitted: true`
+means only that one exact request met the reviewed callable and client
+completion condition. It does not prove persisted RSVP state, message or
+notification delivery, or another business side effect.
+
+This `2026-08-12.3` contract is proposed pending delegated review. After
+approval, S5 can implement these exact read, set, and plan behaviors without
+additional event preconditions. Unobserved remote nulls, mutation failures,
+server-side validation, and persisted business state remain unknown.
 
 ### Contacts
 

--- a/docs/REMOTE-API-CONTRACT.md
+++ b/docs/REMOTE-API-CONTRACT.md
@@ -1,8 +1,8 @@
 # Remote API contract
 
-`spec/partiful.openapi.json` is owner-reviewed revision `2026-08-12.2` of the
-remote transport snapshot. Its owner-reviewed baseline is
-`2026-08-12.1`, which is based on owner-reviewed revision `2026-08-11.5`. It
+`spec/partiful.openapi.json` is proposed revision `2026-08-12.3` of the remote
+transport snapshot, pending delegated review. Its owner-reviewed baseline is
+`2026-08-12.2`, which is based on owner-reviewed revision `2026-08-12.1`. It
 describes only network operations and wire shapes. It does not prescribe
 commands, output, credentials, mutation safeguards, or implementation
 architecture.
@@ -99,7 +99,7 @@ reviewed `200` and `404 NOT_FOUND`; an unobserved `403` remains protocol drift.
 because its selected and synthetic requests both returned
 `403 PERMISSION_DENIED`.
 
-## RSVP mapping proposal
+## RSVP mapping baseline
 
 Revision `2026-08-12.2` adds unauthenticated first-party public-asset research
 from
@@ -107,7 +107,7 @@ from
 `z1npyrEHkwRMn_JlKXQXR` establishes the current client request and completion
 behavior without making a live mutation.
 
-The proposal corrects only these request facts:
+The revision corrects only these request facts:
 
 - `getCurrentGuest` sends `params.eventId`;
 - `addGuest` maps product going and not-going to `GOING` and `DECLINED`,
@@ -139,11 +139,37 @@ vocabulary. No current-guest property becomes required. The single live
 object and matching Firestore document remain the only response observation;
 callable null, alternate, and failure variants remain unknown.
 
-The proposal does not make RSVP releasable. Safe create-versus-update
-selection still lacks a reviewed null-current-guest response, and the
-selected-event precondition read does not guarantee all facts used by the
-current client. Those blockers are recorded in the research note and product
-contract.
+Revision `2026-08-12.2` did not select product behavior for an absent current
+guest and therefore did not make RSVP releasable.
+
+## RSVP execution-selection proposal
+
+Revision `2026-08-12.3` adds no live response, status, failure, or persisted
+state claim. All `2026-08-12.2` endpoint request and completion facts remain
+unchanged.
+
+The current first-party client reads `data.currentGuest` null-safely and adds
+`rsvp.guestId` only when a current guest supplies an ID. The product selection
+therefore treats an object with a nonempty string ID and reviewed status as
+present and includes that private ID in `addGuest`. Null or missing
+`currentGuest` is an explicit no-current-guest marker and omits `guestId`.
+Non-object, non-null values and objects without a valid ID and status are
+protocol drift. These are current-client selection predicates, not a dated
+claim that the remote endpoint returned null or omitted the property.
+
+To avoid converting a one-object observation into an operation-wide presence
+claim, the OpenAPI response no longer requires the `currentGuest` property.
+The one observed object and matching Firestore status remain the only dated
+response evidence. Nullability, omission, alternate variants, and failure
+bodies remain explicit unknowns at the remote boundary.
+
+For `addGuest`, only the reviewed callable HTTP `200` and `result` envelope
+establish submitted-request completion; no business response field or stored
+RSVP state is claimed. For `markEventInterest`, current-client completion
+still additionally requires truthy `data.success` and `data.interested`
+strictly equal to the submitted boolean. Every failed predicate,
+unrecognized status, unsupported envelope, and server-side input rejection
+remains protocol drift. No post-write read is added.
 
 ## Historical provenance
 

--- a/docs/adr/0001-greenfield-go-module-seams.md
+++ b/docs/adr/0001-greenfield-go-module-seams.md
@@ -32,15 +32,24 @@ bearer session separately.
 Mutation authority owns persistent five-minute, single-use plan records. A
 record binds the account fingerprint, command, normalized input, exact remote
 request projection, and a digest of every pre-read fact. Apply reacquires the
-fingerprint and preconditions before consuming the record. It permits one
+fingerprint and preconditions before consuming the record. After comparison,
+it consumes the record immediately before dispatch. It permits exactly one
 remote mutation attempt and never retries automatically after an ambiguous
-completion.
+completion; any uncertain transport outcome requires a new plan.
+
+For RSVP, mutation authority binds only the current-guest identity and status,
+or an explicit no-current-guest marker. It does not widen the event-read seam
+to obtain party limits, questionnaire versions, password state, ticketing
+state, or other unreviewed event preconditions.
 
 The remote seam distinguishes a callable protocol completion from verified
 business state. For RSVP mutations, it validates only the reviewed HTTP
 status, callable result envelope, and client-required completion fields. The
-application can return the normalized submitted request, but it cannot claim
-stored RSVP state, delivery, or another side effect without a separately
-reviewed post-write read. The RSVP command remains outside the releasable
-catalog while current-guest null behavior and required precondition reads are
-unknown.
+application can return only the product-permitted submitted projection; it
+cannot claim stored RSVP state, delivery, or another side effect without a
+separately reviewed post-write read. The proposed RSVP result uses only
+`eventId`, intent, and `submitted: true`; no post-write read is performed.
+Current-client null-safe selection can distinguish a present guest from the
+explicit absent marker without claiming that a null remote response was
+observed. The command remains outside the releasable catalog until delegated
+review approves that selection and submitted-request boundary.

--- a/docs/research/2026-08-10-contract-evidence-sources.md
+++ b/docs/research/2026-08-10-contract-evidence-sources.md
@@ -181,8 +181,8 @@ module IDs, and privacy-safe integrity metadata.
 Its “addGuest request” section supports the narrow `GOING` and `DECLINED`
 request projections, named plus-one shape, questionnaire response, omitted
 null message, timezone, and stripped private contact fields. Its “addGuest
-completion” section records that the client requires decoded `data` to be an
-object but does not require a business field.
+completion” section records JavaScript destructuring of decoded `data`
+without an operation-wide type or required business-field claim.
 
 Its “markEventInterest request and completion” section supports boolean
 interest and removal requests, optional `source` with direct-page omission,
@@ -190,3 +190,10 @@ and the exact `success`/`interested` completion check. Its
 “getCurrentGuest” section supports the event-ID request and documents why
 callable null and alternate responses remain unknown. No live mutation or
 account-scoped read was used.
+
+The “getCurrentGuest” and “addGuest request” sections also support the
+current-client selection predicate used by proposed revision `2026-08-12.3`:
+client state access is null-safe, an existing guest ID is included, and
+`guestId` is omitted when no guest exists. This supports product
+create/update selection only. It does not establish that a remote null or
+missing response was observed.

--- a/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
+++ b/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
@@ -1,8 +1,8 @@
 # Partiful remote API contract evidence ledger
 
-**Owner-reviewed contract revision:** `2026-08-12.2`
-**Owner-reviewed baseline:** `2026-08-12.1`
-**Status:** Owner-reviewed under the issue #114 delegation
+**Proposed contract revision:** `2026-08-12.3`
+**Owner-reviewed baseline:** `2026-08-12.2`
+**Status:** Proposed pending delegated review
 **Contract:** `spec/partiful.openapi.json`
 **Machine-readable ledger:** `spec/partiful.api-evidence.json`
 **Stable citation sources:** `docs/research/2026-08-10-contract-evidence-sources.md`
@@ -71,7 +71,7 @@ HTTP `200` status and two operations with protocol-specified callable
 completion have typed response bodies. The schema-free send-code `200` and
 OpenAPI `default` responses do not claim a body.
 
-The 1285 material claims are audited by
+The 1284 material claims are audited by
 `tests/remote-api-contract.test.js`. Each ledger citation resolves either to a
 JSON Pointer in the committed non-authoritative historical artifact or to a
 heading in the committed stable source index. This keeps the audit independent
@@ -229,9 +229,23 @@ remote response type claims or live observations of stored Partiful state.
 Every unobserved error and status remains explicit unknown.
 
 `CurrentGuest.status` references the existing closed `GuestStatus` vocabulary,
-but remains optional. Current-guest nullability, no-guest create behavior,
-required profile name, selected-event mutation preconditions, endpoint
+but remains optional. The dated response evidence still establishes only one
+object. Current-guest nullability, omission, alternate variants, endpoint
 failure mappings, and post-write business state remain unknown.
+
+Revision `2026-08-12.3` adds only a current-client selection predicate. The
+client reads `currentGuest` null-safely, includes `rsvp.guestId` when an object
+supplies an ID, and omits `guestId` when there is no guest. The product accepts
+only an object with a nonempty string ID and reviewed status, or a null/missing
+guest marker; other variants are protocol drift. This is not a dated remote
+null observation. The OpenAPI response no longer requires the
+`currentGuest` property, so it does not convert the one object sample into an
+operation-wide presence claim.
+
+S5 obtains the required RSVP name from explicit product input. Selected-event
+party, questionnaire, password, and ticketing facts remain remotely unknown
+and are not S5 preconditions. Server-side request rejection remains protocol
+drift; no post-write business state is claimed.
 
 ## Contact read evidence
 
@@ -293,7 +307,7 @@ by the Go implementation's Firebase requests:
 Origin is unmodelled and remains unknown because the reviewed evidence
 establishes no Origin request fact.
 
-The 1285 material claims are audited by `tests/remote-api-contract.test.js`.
+The 1284 material claims are audited by `tests/remote-api-contract.test.js`.
 
 ## Resolved conflict
 

--- a/spec/partiful.api-evidence.json
+++ b/spec/partiful.api-evidence.json
@@ -1,5 +1,6 @@
 {
-  "contractRevision": "2026-08-12.2",
+  "contractRevision": "2026-08-12.3",
+  "ownerReviewedBaseline": "2026-08-12.2",
   "contractPath": "spec/partiful.openapi.json",
   "allowedClassifications": [
     "dated-live-observation",
@@ -409,9 +410,9 @@
     "Only one CurrentGuest object was observed; operation-wide field presence, nullability, alternate variants, plus-one shape, unsupported statuses, and failure bodies remain unknown.",
     "Firestore event GET returned PERMISSION_DENIED for selected readable and synthetic IDs with one credential; success, not-found, attendee-denial, and other credential behavior remain unknown.",
     "Contact invalid-cursor behavior, cursor lifetime and reuse, ordering key, snapshot behavior, useAuthUser, rate limiting, unsupported statuses, future catalog completeness, server duplicate behavior, and duplicates outside two traversals remain unknown.",
-    "getCurrentGuest null and alternate responses, no-guest addGuest name and create behavior, selected-event RSVP preconditions, mutation failures, and post-write RSVP business state remain unknown."
+    "getCurrentGuest null, omission, and alternate responses remain unobserved; null-safe create/update selection is current-client behavior, not a dated remote response claim. addGuest and markEventInterest server-side input rejection, mutation failures, and post-write RSVP business state remain unknown. Selected-event party, questionnaire, password, and ticketing facts remain unknown and are not S5 preconditions."
   ],
-  "status": "owner-reviewed",
+  "status": "proposed-pending-delegated-review",
   "claims": {
     "#/servers/0/url": {
       "classification": "typescript-derived-inference",
@@ -5041,10 +5042,6 @@
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
     },
-    "#/components/schemas/GetCurrentGuestResponse/properties/result/properties/data/required/0": {
-      "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
-    },
     "#/components/schemas/GetCurrentGuestResponse/properties/result/properties/data/properties/currentGuest": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
@@ -5907,6 +5904,17 @@
       "clientCompletionPredicate": "truthy-success-and-interested-equals-submitted"
     },
     "successSemantics": "submitted-request-only",
+    "currentGuestSelection": {
+      "classification": "current-first-party-public-asset-research",
+      "selectionCitation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request",
+      "nullSafeCitation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#getcurrentguest",
+      "present": "object-with-nonempty-string-id-and-reviewed-status",
+      "presentGuestIdProjection": "include-rsvp.guestId",
+      "absent": "null-or-missing-currentGuest",
+      "absentGuestIdProjection": "omit-rsvp.guestId",
+      "unsupported": "protocol-drift",
+      "remoteNullObservation": false
+    },
     "currentGuestNullability": "explicit-unknown",
     "errorsAndOtherStatuses": "explicit-unknown"
   }

--- a/spec/partiful.openapi.json
+++ b/spec/partiful.openapi.json
@@ -2,8 +2,8 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Partiful remote API contract",
-    "version": "2026-08-12.2",
-    "description": "Owner-reviewed remote-only transport snapshot. Evidence classifications and uncertainty are recorded in spec/partiful.api-evidence.json."
+    "version": "2026-08-12.3",
+    "description": "Proposed remote-only transport snapshot pending delegated review. Evidence classifications and uncertainty are recorded in spec/partiful.api-evidence.json."
   },
   "servers": [
     {
@@ -2779,9 +2779,6 @@
             "properties": {
               "data": {
                 "type": "object",
-                "required": [
-                  "currentGuest"
-                ],
                 "properties": {
                   "currentGuest": {
                     "$ref": "#/components/schemas/CurrentGuest"

--- a/tests/remote-api-contract.test.js
+++ b/tests/remote-api-contract.test.js
@@ -13,6 +13,7 @@ const eventAssetResearchPath =
 const rsvpAssetResearchPath =
   'docs/research/2026-08-12-rsvp-mapping-public-assets.md';
 const productContractPath = 'docs/CLI-PRODUCT-CONTRACT.md';
+const remoteContractPath = 'docs/REMOTE-API-CONTRACT.md';
 const sourceCache = new Map([
   [historicalDraftPath, historicalDraft],
   [readEvidencePath, readEvidence],
@@ -244,9 +245,10 @@ function citationResolves(citation) {
 describe('remote API contract', () => {
   it('is a consistently versioned OpenAPI 3.1 document with unique operation IDs', () => {
     expect(spec.openapi).toBe('3.1.0');
-    expect(evidence.contractRevision).toBe('2026-08-12.2');
+    expect(evidence.contractRevision).toBe('2026-08-12.3');
+    expect(evidence.ownerReviewedBaseline).toBe('2026-08-12.2');
     expect(spec.info.version).toBe(evidence.contractRevision);
-    expect(evidence.status).toBe('owner-reviewed');
+    expect(evidence.status).toBe('proposed-pending-delegated-review');
     expect(evidence.sources.publicEventMapping20260812)
       .toBe(`${eventAssetResearchPath}#scope-and-provenance`);
     expect(citationResolves(evidence.sources.publicEventMapping20260812)).toBe(true);
@@ -303,7 +305,7 @@ describe('remote API contract', () => {
       ...materialClaimPointers(spec.paths, '#/paths', 'paths'),
       ...materialClaimPointers(spec.components, '#/components', 'components'),
     ]);
-    expect(pointers).toHaveLength(1285);
+    expect(pointers).toHaveLength(1284);
     for (const pointer of pointers) {
       const claim = evidence.claims[pointer];
       expect(claim, pointer).toBeDefined();
@@ -364,12 +366,12 @@ describe('remote API contract', () => {
     expect(ledger).toContain(
       'Two additional callable operations have protocol-specified HTTP `200` completion responses.',
     );
-    expect(ledger.match(/The 1285 material claims/g)).toHaveLength(2);
+    expect(ledger.match(/The 1284 material claims/g)).toHaveLength(2);
     expect(ledger).toContain(
-      '**Owner-reviewed contract revision:** `2026-08-12.2`',
+      '**Proposed contract revision:** `2026-08-12.3`',
     );
     expect(ledger).toContain(
-      '**Status:** Owner-reviewed under the issue #114 delegation',
+      '**Status:** Proposed pending delegated review',
     );
     expect(ledger).toContain('Current first-party public-asset research');
   });
@@ -1020,15 +1022,24 @@ describe('remote API contract', () => {
         removeInterest: { interested: false, source: 'omitted-on-direct-event-page' },
       },
       successSemantics: 'submitted-request-only',
+      currentGuestSelection: {
+        classification: 'current-first-party-public-asset-research',
+        present: 'object-with-nonempty-string-id-and-reviewed-status',
+        presentGuestIdProjection: 'include-rsvp.guestId',
+        absent: 'null-or-missing-currentGuest',
+        absentGuestIdProjection: 'omit-rsvp.guestId',
+        unsupported: 'protocol-drift',
+        remoteNullObservation: false,
+      },
     });
   });
 
   it('defines conservative nullable event reads and bounded local snapshots', () => {
     const product = fs.readFileSync(productContractPath, 'utf8');
     for (const expected of [
-      '**Status:** Approved product contract',
-      '**Product contract revision:** `2026-08-12.2`',
-      '**Remote API contract revision:** `2026-08-12.2`',
+      '**Status:** Proposed pending delegated review',
+      '**Product contract revision:** `2026-08-12.3`',
+      '**Remote API contract revision:** `2026-08-12.3`',
       '**Currently shipped Go revisions:** product and remote `2026-08-12.1`',
       '`PUBLISHED` → `active`',
       '`CANCELED` → `cancelled`',
@@ -1055,8 +1066,8 @@ describe('remote API contract', () => {
       '`not-going` → `addGuest.rsvp.status = "DECLINED"`',
       '`interested` → `markEventInterest.interested = true`',
       '`source` is omitted for a direct event-page-equivalent request',
-      'does not prove that the remote RSVP state changed',
-      'does not automatically retry either mutation',
+      'does not prove persisted RSVP state',
+      'It never retries automatically.',
       'private stable account fingerprint',
       'five minutes',
       'single-use',
@@ -1076,6 +1087,76 @@ describe('remote API contract', () => {
     const appSource = fs.readFileSync('internal/app/app.go', 'utf8');
     expect(appSource).toContain('ProductContractRevision = "2026-08-12.1"');
     expect(appSource).toContain('RemoteContractRevision  = "2026-08-12.1"');
+  });
+
+  it('defines the executable RSVP selection, plan, and submitted-result policy', () => {
+    const product = fs.readFileSync(productContractPath, 'utf8');
+    const rsvpSection = product.slice(
+      product.indexOf('### RSVP'),
+      product.indexOf('### Contacts'),
+    );
+    const adr = fs.readFileSync(
+      'docs/adr/0001-greenfield-go-module-seams.md',
+      'utf8',
+    );
+    const remote = fs.readFileSync(remoteContractPath, 'utf8');
+
+    for (const expected of [
+      '`displayName`',
+      '`addGuest.rsvp.name`',
+      'unavailable private profile lookup',
+      'null or missing `currentGuest`',
+      'omits `guestId`',
+      'current-guest identity/status snapshot',
+      'explicit no-current-guest marker',
+      'performs these steps and no mutation',
+      'consumes the token immediately before dispatch',
+      'exactly one transport attempt',
+      'requires a new plan',
+      '`result.data.success` is truthy',
+      '`result.data.interested` strictly equals the submitted boolean',
+      '`contract.protocol_changed`',
+      'does not perform a post-write read',
+      'never echoes `displayName`',
+      'fingerprint is never output.',
+      '`safety.plan_stale`',
+    ]) {
+      expect(rsvpSection, expected).toContain(expected);
+    }
+    expect(rsvpSection).toContain(
+      '{"eventId":"evt_example","intent":"going","submitted":true}',
+    );
+    expect(rsvpSection).toContain(
+      '{"eventId":"evt_example","status":null}',
+    );
+    expect(rsvpSection).not.toContain(
+      'selected event facts needed for party-size, questionnaire, password, ticketing',
+    );
+    expect(rsvpSection).not.toMatch(
+      /submitted version to\s+equal the current event's latest questionnaire version/,
+    );
+    expect(rsvpSection).toMatch(
+      /`displayName` is required for `going` and `not-going`/,
+    );
+    expect(rsvpSection).toMatch(
+      /`displayName`[\s\S]+invalid with `interested`/,
+    );
+    expect(rsvpSection).toMatch(
+      /only remote precondition read[\s\S]+`getCurrentGuest`/,
+    );
+    expect(remote).toMatch(
+      /All `2026-08-12\.2` endpoint request and completion facts remain\s+unchanged\./,
+    );
+    expect(remote).toContain(
+      'These are current-client selection predicates, not a dated',
+    );
+    expect(remote).toContain(
+      'Nullability, omission, alternate variants, and failure',
+    );
+    expect(adr).toContain('current-guest identity and status');
+    expect(adr).toContain('explicit no-current-guest marker');
+    expect(adr).toContain('immediately before dispatch');
+    expect(adr).toContain('requires a new plan');
   });
 
   it('formalizes only the observed event-detail and guest read variants', () => {
@@ -1159,7 +1240,7 @@ describe('remote API contract', () => {
       .toEqual({ $ref: '#/components/schemas/CurrentGuest' });
     expect(spec.components.schemas.GetCurrentGuestResponse.properties.result
       .properties.data.required)
-      .toEqual(['currentGuest']);
+      .toBeUndefined();
     expect(spec.components.schemas.CurrentGuest).not.toHaveProperty('type');
     expect(evidence.claims['#/components/schemas/CurrentGuest/type']).toBeUndefined();
     expect(spec.components.schemas.CurrentGuest).toMatchObject({
@@ -1468,7 +1549,7 @@ describe('remote API contract', () => {
     expect(evidence.readObservation.artifactPath).toBe(readEvidencePath);
   });
 
-  it('keeps shipped Go revisions on the reviewed baseline while RSVP is proposed', () => {
+  it('keeps shipped Go revisions unchanged while RSVP is proposed', () => {
     const productContract = fs.readFileSync(
       'docs/CLI-PRODUCT-CONTRACT.md',
       'utf8',
@@ -1492,11 +1573,11 @@ describe('remote API contract', () => {
     )].map((match) => match[1]);
 
     expect(shippedRevision).toBe('2026-08-12.1');
-    expect(documentedRevision).toBe('2026-08-12.2');
-    expect(documentedProductRevision).toBe('2026-08-12.2');
+    expect(documentedRevision).toBe('2026-08-12.3');
+    expect(documentedProductRevision).toBe('2026-08-12.3');
     expect(new Set(envelopeRevisions)).toEqual(new Set([documentedRevision]));
     expect(spec.info.version).toBe(documentedRevision);
-    expect(evidence.status).toBe('owner-reviewed');
+    expect(evidence.status).toBe('proposed-pending-delegated-review');
     expect(spec.info.version).not.toBe(shippedRevision);
     expect(appSource).toContain('ProductContractRevision = "2026-08-12.1"');
     expect(productContract)


### PR DESCRIPTION
## Summary

Contract-only continuation of #166. This proposes product/remote revision `2026-08-12.3`, pending delegated review; shipped Go constants remain unchanged. No public-asset research, live call, or RSVP mutation was performed.

- requires caller-supplied nonempty `displayName` for going/not-going and maps it to `addGuest.rsvp.name`
- selects update when currentGuest is an object with valid ID/status; null or missing guest selects create and omits `guestId`
- binds only normalized input, operation, private account fingerprint, exact request, and currentGuest identity/status or absent marker
- removes unsupported event, party-limit, questionnaire-version, password, and ticketing preconditions
- consumes five-minute single-use plans before one dispatch attempt, never retries, and requires a new plan after uncertainty
- returns only `{eventId,intent,submitted:true}` after reviewed completion; it does not claim persisted state
- requires the current truthy-success/matching-interest predicate for interest completion
- permits `rsvp get` only for the reviewed object or current-client null-safe no-RSVP variants; other variants drift

The `.2` endpoint request/completion evidence remains unchanged. The response schema only stops requiring `currentGuest`, so the one observed object is not generalized into an operation-wide presence claim. Null and omission remain unobserved remote variants.

## Validation

- contract tests: 33 passed
- full non-live JavaScript suite: 354 passed, 6 skipped
- TypeScript check passed
- `go test -race ./...`, `go vet ./...`, and `go build ./...` passed
- Go module verify/tidy checks passed
- privacy and diff checks passed

Part of #166.