### PR TITLE
docs(contract): add RSVP read evidence

### DIFF
--- a/docs/CLI-PRODUCT-CONTRACT.md
+++ b/docs/CLI-PRODUCT-CONTRACT.md
@@ -1,6 +1,6 @@
 # CLI product contract
 
-**Status:** Proposed pending delegated review
+**Status:** Approved product contract
 
 **Product contract revision:** `2026-08-12.3`
 
@@ -854,8 +854,8 @@ reviewed callable and client completion condition. It does not prove
 persisted RSVP state, delivery, notification, or another business side
 effect.
 
-This `2026-08-12.3` contract is proposed pending delegated review. Shipped Go
-revisions remain unchanged until implementation.
+This `2026-08-12.3` contract is owner-reviewed under the issue #114
+delegation. Shipped Go revisions remain unchanged until implementation.
 
 ### Contacts
 

--- a/docs/CLI-PRODUCT-CONTRACT.md
+++ b/docs/CLI-PRODUCT-CONTRACT.md
@@ -749,9 +749,12 @@ The product then applies these local rules:
   `partySize <= maxCountPerGuest`;
 - a numeric `maxCapacity` without numeric `remainingCapacity` is unsupported
   because this slice cannot calculate a safe capacity delta;
-- for going, create uses current count zero and update computes
-  `additionalCount = max(0, partySize - currentGuest.count)`; when
-  `remainingCapacity` is present, it requires
+- for going, create uses current capacity count zero. Update subtracts
+  `currentGuest.count` only when the current status is `GOING` or `APPROVED`,
+  the two statuses the current client counts as attended; every other current
+  status uses capacity count zero. It computes
+  `additionalCount = max(0, partySize - currentCapacityCount)` and, when
+  `remainingCapacity` is present, requires
   `additionalCount <= remainingCapacity`;
 - every supplied plus one has a nonempty normalized name, and
   `partySize = 1 + plusOnes.length`; this also satisfies
@@ -763,7 +766,7 @@ The product then applies these local rules:
   questionnaire response and omits it; and
 - `not-going` omits `questionnaireResponse` for every event.
 
-Input violations return `validation.invalid_input`. An RSVP-disabled,
+Input violations return `input.invalid`. An RSVP-disabled,
 application, ticketed, password-protected, at-capacity, or insufficient
 capacity event returns `state.conflict` without a mutation. These are product
 compatibility decisions, not server error mappings. Any received server

--- a/docs/CLI-PRODUCT-CONTRACT.md
+++ b/docs/CLI-PRODUCT-CONTRACT.md
@@ -1,10 +1,12 @@
 # CLI product contract
 
-**Status:** Approved product contract
+**Status:** Proposed pending delegated review
 
-**Product contract revision:** `2026-08-12.2`
+**Product contract revision:** `2026-08-12.3`
 
-**Remote API contract revision:** `2026-08-12.2`
+**Remote API contract revision:** `2026-08-12.3`
+
+**Owner-reviewed baseline:** product and remote `2026-08-12.2`
 
 **Currently shipped Go revisions:** product and remote `2026-08-12.1`
 
@@ -81,8 +83,8 @@ Every successful command returns:
   "meta": {
     "command": "events.get",
     "cliVersion": "1.0.0",
-    "productContractRevision": "2026-08-12.2",
-    "remoteContractRevision": "2026-08-12.2",
+    "productContractRevision": "2026-08-12.3",
+    "remoteContractRevision": "2026-08-12.3",
     "warnings": []
   }
 }
@@ -105,8 +107,8 @@ Every failed command returns:
   "meta": {
     "command": "guests.list",
     "cliVersion": "1.0.0",
-    "productContractRevision": "2026-08-12.2",
-    "remoteContractRevision": "2026-08-12.2"
+    "productContractRevision": "2026-08-12.3",
+    "remoteContractRevision": "2026-08-12.3"
   }
 }
 ```
@@ -153,8 +155,8 @@ Collection commands return:
   "meta": {
     "command": "events.list",
     "cliVersion": "1.0.0",
-    "productContractRevision": "2026-08-12.2",
-    "remoteContractRevision": "2026-08-12.2",
+    "productContractRevision": "2026-08-12.3",
+    "remoteContractRevision": "2026-08-12.3",
     "warnings": [],
     "page": {
       "limit": 25,
@@ -226,8 +228,8 @@ remote mutation:
   "meta": {
     "command": "events.update",
     "cliVersion": "1.0.0",
-    "productContractRevision": "2026-08-12.2",
-    "remoteContractRevision": "2026-08-12.2",
+    "productContractRevision": "2026-08-12.3",
+    "remoteContractRevision": "2026-08-12.3",
     "warnings": []
   }
 }
@@ -243,8 +245,11 @@ error.
 
 The plan token is also bound to the command, normalized input, exact remote
 request projection, and a digest of every pre-read fact used by the plan.
-Secrets and personal data are redacted. There is no separate `--dry-run`
-flag: omitting `--apply` is the only dry-run behavior.
+Secrets, account identifiers, private remote identifiers, and the account
+fingerprint are redacted from public plan JSON. A command-specific contract
+can show caller-supplied personal input for exact review, but that input is
+not copied to diagnostics or errors. There is no separate `--dry-run` flag:
+omitting `--apply` is the only dry-run behavior.
 
 ### Standard mutation
 
@@ -260,9 +265,11 @@ Standard-mutation plan tokens are single-use and expire after five minutes.
 Apply reacquires the private account fingerprint and every bound remote
 precondition before it consumes the token. Changed input, account, or
 precondition, expiry, or reuse returns `safety.plan_stale` before a mutation
-request. A successful precondition check permits exactly one mutation
-request. The CLI does not automatically retry a mutation after a response,
-timeout, connection loss, or ambiguous completion.
+request. After successful precondition checks, apply atomically consumes the
+token immediately before dispatch and makes exactly one transport attempt.
+The consumed token cannot be reused after a response, timeout, connection
+loss, or ambiguous completion. The CLI does not automatically retry; an
+uncertain transport outcome requires a new plan.
 
 ### Consequential action
 
@@ -604,7 +611,7 @@ Applied success returns:
 
 #### `partiful rsvp get <event-id>`
 
-Returns an `RsvpRead`:
+For the reviewed object variant, returns an `RsvpRead`:
 
 ```json
 {
@@ -617,13 +624,21 @@ Returns an `RsvpRead`:
 reads. It is not restricted to writable intents. No public RSVP read returns
 the current guest's private ID or account ID.
 
-Revision `2026-08-12.2` deliberately removes the unsupported shared read/write
-shape. The existing observation proves one current-guest object and its
-status. It does not prove null behavior or operation-wide presence and types
-for party size, plus ones, message, timezone, or questionnaire response.
-`rsvp get` therefore remains implementation-gated until a reviewed
-no-current-guest result and every required variant are available. The CLI must
-not turn an unknown null or alternate response into a guessed RSVP.
+The accepted object must have a nonempty string `id` and a `status` from the
+reviewed `GuestStatus` vocabulary. The dated read evidence also establishes
+that `currentGuest: null` is the authoritative no-current-guest marker. It
+returns:
+
+```json
+{"eventId":"evt_example","status":null}
+```
+
+The `currentGuest` property is required in the callable envelope.
+A missing `currentGuest` property is protocol drift. A scalar, array, object
+without a valid ID and status, or any other variant returns
+`contract.protocol_changed`. Party size, plus ones, message, timezone,
+questionnaire response, name, and user ID remain unavailable in the product
+read and are not guessed or returned.
 
 #### `partiful rsvp set <event-id>`
 
@@ -635,6 +650,7 @@ values: `going`, `not-going`, and `interested`.
 ```json
 {
   "status": "going",
+  "displayName": "Example Attendee",
   "partySize": 1,
   "plusOnes": [],
   "message": null,
@@ -643,19 +659,23 @@ values: `going`, `not-going`, and `interested`.
 }
 ```
 
-`partySize` is a positive integer. `plusOnes` contains display-name strings;
-it never contains a private user or guest ID. `partySize` must equal one plus
-the number of named plus ones. `timezone` is required and identifies the
-attendee's IANA timezone. `message` is a string of at most 400 characters or
-null. Null maps to omission from the remote request.
+`displayName` is required for `going` and `not-going`. It is trimmed, must
+then contain 1–50 characters, and maps exactly to `addGuest.rsvp.name`. The
+CLI does not use a private profile lookup or a current-guest name.
 
-For `going`, `questionnaireResponse` is null when the event has no
-questionnaire. Otherwise it is
+`partySize` is a positive integer. `plusOnes` contains only display-name
+strings; each is trimmed and must remain nonempty. It never contains a private
+user or guest ID. The local input rule is
+`partySize = 1 + plusOnes.length`. `timezone` is required, must identify an
+IANA timezone, and is submitted unchanged after validation. `message` is a
+string or null. A non-null message is trimmed, must then contain at most 400
+characters, and normalizes to null when empty. Null maps to request omission.
+
+For `going`, `questionnaireResponse` is null or
 `{"questionnaireVersion","answers"}`, with a nonnegative version and string
-answers keyed by question ID. The plan requires the submitted version to
-equal the current event's latest questionnaire version. `not-going` requires
-`questionnaireResponse: null`, matching the first-party flow, which skips the
-questionnaire for `DECLINED`.
+answers keyed by question ID. The event pre-read decides which form is valid.
+`not-going` accepts only null and omits `questionnaireResponse` from the
+remote request, matching the first-party `DECLINED` flow.
 
 `interested` accepts only:
 
@@ -665,9 +685,9 @@ questionnaire for `DECLINED`.
 }
 ```
 
-Party, plus-one, message, timezone, and questionnaire fields are invalid with
-`interested`. Interest removal is an established remote boolean request but
-is not a fourth writable product intent in this revision.
+`displayName`, party, plus-one, message, timezone, and questionnaire fields
+are invalid with `interested`. Interest removal is an established remote
+boolean request but is not a fourth writable product intent in this revision.
 
 The exact product-to-remote mappings are:
 
@@ -680,55 +700,159 @@ not invent an analytics source. The `addGuest` mapping uses
 `count = partySize`, maps each plus-one string to `{"name": string}`, uses the
 input timezone, sends `shouldFollowOrgs: false`, and omits a null message. It
 omits phone number, channel preference, captcha token, image,
-`emailInvitationId`, `_discoverSource`, and password. It attaches the private
-existing `guestId` only when the reviewed current-guest pre-read returned one.
-The attendee name comes from that current guest. No output exposes either
-private value.
+`emailInvitationId`, `_discoverSource`, and password.
 
-The plan-only invocation performs these reads and no mutation:
+The current-guest selection is:
 
-1. acquire an authenticated session and private stable account fingerprint;
-2. read the selected event facts needed for party-size, questionnaire,
-   password, ticketing, and RSVP-action preconditions; and
-3. call `getCurrentGuest` once and bind a canonical digest of the complete
-   reviewed representation, including current-guest existence, private guest
-   ID, name, status, count, plus ones, and questionnaire response when
-   available.
+- explicit `currentGuest: null` selects create and omits `guestId`; and
+- an object with a nonempty string ID, reviewed status, and nonnegative integer
+  count selects update and includes the private `guestId`.
 
-The plan binds those facts, normalized product input, and the exact callable
-request projection. Apply reacquires the same account fingerprint, repeats
-the same reads once, compares every binding, and returns `safety.plan_stale`
-before the write if anything changed. It then consumes the five-minute,
-single-use token and sends at most one `addGuest` or `markEventInterest`
-request. It does not automatically retry either mutation.
+Every other current-guest variant returns `contract.protocol_changed` and
+does not produce a plan.
 
-Applied callable completion returns the normalized submission:
+##### Compatible-event safeguards
+
+The plan-only invocation acquires the authenticated session and private stable
+account fingerprint, then calls `getEventInfo` once and `getCurrentGuest` once.
+It performs no mutation.
+
+The compatible event class is deliberately narrow:
+
+- `rsvpsEnabled` must be present, boolean, and `true`;
+- `atCapacity` and `plusOneNamesRequired` must be present booleans;
+- absent `guestAction` and `guestAction: "RSVP"` are supported;
+  `guestAction: "APPLY"` is unsupported;
+- `ticketing` must be absent or null; an object is unsupported;
+- `password` and `passwordProtected` must be absent; explicit null is an
+  unobserved raw variant, while any non-null value is an unsupported protected
+  event;
+- `questionnaireEnabled` can be absent, `false`, or `true`; explicit null is
+  unobserved and is protocol drift;
+- `questionnaireVersions` must be present and either null or an array;
+- `maxCountPerGuest` can be absent or a positive integer;
+- `maxCapacity` can be absent, null, or an integer;
+- `remainingCapacity` can be absent or an integer, including a negative
+  integer; and
+- `enableWaitlist` can be absent, null, or boolean.
+
+Any missing required field, wrong type, unsupported enum, or other unobserved
+raw variant returns `contract.protocol_changed`. The snapshot preserves
+missing, explicit null, and present values as distinct states. It does not
+collapse an absent property to JSON null.
+
+The product then applies these local rules:
+
+- `atCapacity: true` is unsupported for `going`, even when
+  `enableWaitlist: true`; this CLI does not enter a waitlist;
+- for going or not-going, a present maximum requires
+  `partySize <= maxCountPerGuest`;
+- a numeric `maxCapacity` without numeric `remainingCapacity` is unsupported
+  because this slice cannot calculate a safe capacity delta;
+- for going, create uses current count zero and update computes
+  `additionalCount = max(0, partySize - currentGuest.count)`; when
+  `remainingCapacity` is present, it requires
+  `additionalCount <= remainingCapacity`;
+- every supplied plus one has a nonempty normalized name, and
+  `partySize = 1 + plusOnes.length`; this also satisfies
+  `plusOneNamesRequired: true`;
+- when `questionnaireEnabled: true`, going requires a non-null
+  questionnaire response and a nonempty `questionnaireVersions` array; the
+  required version is `questionnaireVersions.length - 1`;
+- when `questionnaireEnabled` is absent or false, going requires a null
+  questionnaire response and omits it; and
+- `not-going` omits `questionnaireResponse` for every event.
+
+Input violations return `validation.invalid_input`. An RSVP-disabled,
+application, ticketed, password-protected, at-capacity, or insufficient
+capacity event returns `state.conflict` without a mutation. These are product
+compatibility decisions, not server error mappings. Any received server
+rejection remains `contract.protocol_changed` under the current evidence.
+
+##### Plan binding and apply
+
+The private five-minute, single-use record binds the operation, exact
+normalized product input, exact private callable request, private account
+fingerprint, and current-guest marker, ID, status, and count. It also binds the
+normalized event safeguard snapshot. The event snapshot includes raw presence
+and normalized values for every compatible-event field listed above. It binds
+questionnaire version-array length rather than questionnaire contents.
+
+The public plan can show caller-supplied `displayName`, plus-one names,
+message, and questionnaire answers for exact review. It never exposes the
+account fingerprint, guest ID, account ID, or user ID. The exact private
+request stays in the mutation record. Public RSVP plan example:
 
 ```json
 {
-  "eventId": "evt_example",
-  "intent": "going",
-  "submitted": true,
-  "partySize": 1,
-  "plusOnes": [],
-  "message": null,
-  "timezone": "America/Los_Angeles",
-  "questionnaireResponse": null
+  "operation": "addGuest",
+  "mode": "update",
+  "input": {
+    "status": "going",
+    "displayName": "Example Attendee",
+    "partySize": 1,
+    "plusOnes": [],
+    "message": null,
+    "timezone": "America/Los_Angeles",
+    "questionnaireResponse": null
+  },
+  "request": {
+    "eventId": "evt_example",
+    "rsvp": {
+      "name": "Example Attendee",
+      "count": 1,
+      "plusOnes": [],
+      "status": "GOING",
+      "guestId": "<redacted>",
+      "timezone": "America/Los_Angeles",
+      "shouldFollowOrgs": false
+    }
+  },
+  "preconditions": {
+    "currentGuest": "present",
+    "eventSafeguards": "bound"
+  },
+  "expiresInSeconds": 300,
+  "planToken": "<opaque>"
 }
 ```
 
-For `interested`, the result contains only `eventId`, `intent`, and
-`submitted`. `submitted: true` means that the one callable request completed
-with the reviewed callable envelope and client completion fields. This
-completion does not prove that the remote RSVP state changed, that a message
-or notification was delivered, or that another business side effect occurred.
+Apply reacquires the private account fingerprint.
+Apply re-reads `getEventInfo` once and `getCurrentGuest` once, normalizes the
+same facts, and compares every binding. Changed input, operation, account,
+request, current-guest marker, ID, status, count, event safeguard value, field
+presence, null distinction, questionnaire version length, expiry, or reuse
+returns `safety.plan_stale` before dispatch.
 
-The contract is proposed, not releasable. Current evidence does not establish
-`getCurrentGuest` null behavior, a required attendee name when no current
-guest exists, or all selected-event precondition fields. These are
-irreducible blockers for fresh RSVP creation and for a complete safe
-precondition read. No Go RSVP command or mutation can ship until delegated
-review accepts this revision and later evidence closes those blockers.
+After those checks, apply consumes the token immediately before dispatch and
+makes exactly one transport attempt. It never retries automatically. A
+timeout, connection loss, or other uncertain outcome consumes the token and
+requires a new plan.
+
+##### Submitted-request result
+
+For `going` and `not-going`, an `addGuest` HTTP `200` with the reviewed
+Firebase callable `result` envelope returns only:
+
+```json
+{"eventId":"evt_example","intent":"going","submitted":true}
+```
+
+For `interested`, the same minimal result uses intent `interested`, but
+`submitted: true` is returned only when `result.data.success` is truthy and
+`result.data.interested` strictly equals the submitted boolean. A failed
+predicate, unrecognized status, or unsupported envelope returns
+`contract.protocol_changed`.
+
+The CLI does not perform a post-write read. It does not echo `displayName`,
+message, questionnaire answers, plus-one names, or private IDs in the applied
+result. `submitted: true` means only that the exact submitted request met the
+reviewed callable and client completion condition. It does not prove
+persisted RSVP state, delivery, notification, or another business side
+effect.
+
+This `2026-08-12.3` contract is proposed pending delegated review. Shipped Go
+revisions remain unchanged until implementation.
 
 ### Contacts
 

--- a/docs/REMOTE-API-CONTRACT.md
+++ b/docs/REMOTE-API-CONTRACT.md
@@ -1,7 +1,7 @@
 # Remote API contract
 
-`spec/partiful.openapi.json` is proposed revision `2026-08-12.3` of the remote
-transport snapshot, pending delegated review. Its owner-reviewed baseline is
+`spec/partiful.openapi.json` is owner-reviewed revision `2026-08-12.3` of the
+remote transport snapshot. Its owner-reviewed baseline is
 `2026-08-12.2`, which is based on owner-reviewed revision `2026-08-12.1`. It
 describes only network operations and wire shapes. It does not prescribe
 commands, output, credentials, mutation safeguards, or implementation

--- a/docs/REMOTE-API-CONTRACT.md
+++ b/docs/REMOTE-API-CONTRACT.md
@@ -1,8 +1,8 @@
 # Remote API contract
 
-`spec/partiful.openapi.json` is owner-reviewed revision `2026-08-12.2` of the
-remote transport snapshot. Its owner-reviewed baseline is
-`2026-08-12.1`, which is based on owner-reviewed revision `2026-08-11.5`. It
+`spec/partiful.openapi.json` is proposed revision `2026-08-12.3` of the remote
+transport snapshot, pending delegated review. Its owner-reviewed baseline is
+`2026-08-12.2`, which is based on owner-reviewed revision `2026-08-12.1`. It
 describes only network operations and wire shapes. It does not prescribe
 commands, output, credentials, mutation safeguards, or implementation
 architecture.
@@ -45,12 +45,15 @@ Related event-list representations support only optional `endDate`
 string/null and `image` object/null unions; unsupported selected-only variants
 remain unconstrained.
 
-The current guest callable and its Firestore guest document returned `200`,
+At the `2026-08-11.5` baseline, the current guest callable and its Firestore
+guest document returned `200`,
 and their guest status matched. The one current-guest object does not
 establish operation-wide field presence or variants, so `CurrentGuest` has no
 operation-wide top-level type and no required field list. `count`, `plusOnes`,
-and `userId` remain unconstrained; ordinary non-null plus-one shape is
-unknown. Firestore event GET returned
+and `userId` remained unconstrained; ordinary non-null plus-one shape was
+unknown. The RSVP read-evidence proposal below supersedes only the observed
+top-level object/null union and selected count type. Firestore event GET
+returned
 `403 PERMISSION_DENIED` for both the selected readable ID and a synthetic ID
 with the observed authenticated request context. This does not establish
 attendee denial or Firestore not-found behavior.
@@ -99,7 +102,7 @@ reviewed `200` and `404 NOT_FOUND`; an unobserved `403` remains protocol drift.
 because its selected and synthetic requests both returned
 `403 PERMISSION_DENIED`.
 
-## RSVP mapping proposal
+## RSVP mapping baseline
 
 Revision `2026-08-12.2` adds unauthenticated first-party public-asset research
 from
@@ -107,7 +110,7 @@ from
 `z1npyrEHkwRMn_JlKXQXR` establishes the current client request and completion
 behavior without making a live mutation.
 
-The proposal corrects only these request facts:
+The revision corrects only these request facts:
 
 - `getCurrentGuest` sends `params.eventId`;
 - `addGuest` maps product going and not-going to `GOING` and `DECLINED`,
@@ -139,11 +142,57 @@ vocabulary. No current-guest property becomes required. The single live
 object and matching Firestore document remain the only response observation;
 callable null, alternate, and failure variants remain unknown.
 
-The proposal does not make RSVP releasable. Safe create-versus-update
-selection still lacks a reviewed null-current-guest response, and the
-selected-event precondition read does not guarantee all facts used by the
-current client. Those blockers are recorded in the research note and product
-contract.
+Revision `2026-08-12.2` did not include a dated null-current-guest response or
+the event safeguard aggregates needed by S5.
+
+## RSVP read-evidence proposal
+
+Revision `2026-08-12.3` adds the owner-authorized, sanitized read evidence in
+`docs/research/2026-08-12-rsvp-read-observation.md`. The source artifact is
+`spec/research/rsvp-read-evidence-redacted-20260812.json`. No credential,
+identifier, name, message, answer, or other raw value is present.
+
+The observation covered 36 upcoming and 294 past events, 330 unique details,
+and HTTP `200` for every `getEventInfo` call. This account-visible set adds
+optional `EventInfo` schemas for the exact RSVP safeguard fields. It does not
+establish behavior outside the set, inaccessible-event responses, or types for
+unretained event fields.
+
+The following fields were present as booleans on all 330 details:
+`rsvpsEnabled`, `atCapacity`, and `plusOneNamesRequired`.
+`questionnaireVersions` was present on all details as an array or null.
+Optional observed variants add schemas for boolean `questionnaireEnabled`,
+object/null `ticketing`, string `guestAction` values `APPLY` and `RSVP`,
+number `maxCountPerGuest`, number/null `maxCapacity`, number
+`remainingCapacity`, and boolean/null `enableWaitlist`. Optional means absence
+was observed; it does not make the property remotely required.
+
+The artifact's normalized null buckets include absent properties. Its raw
+field-presence counts remain authoritative. In particular:
+
+- `questionnaireEnabled` was absent 237 times and boolean 93 times;
+- `guestAction` was absent 308 times, `APPLY` 18 times, and `RSVP` 4 times;
+- `maxCountPerGuest` was absent 294 times and numeric 36 times;
+- `remainingCapacity` was absent 278 times and numeric 52 times; and
+- `password` and `passwordProtected` were absent on all 330 details.
+
+The proposal does not add password properties to OpenAPI or convert raw
+absence to an observed JSON null.
+
+One `getCurrentGuest` call returned HTTP `200` with explicit
+`result.data.currentGuest: null`. Another returned HTTP `200` with an object
+whose selected fields included string ID, string status, and number count.
+`CurrentGuest` therefore permits only the observed object/null top-level
+union, while no object property becomes operation-wide required. The
+`currentGuest` envelope property remains required because it was present in
+both variants. A missing property, scalar, array, other object shape,
+unsupported status, and failure response remain unknown and must fail closed.
+
+All `2026-08-12.2` RSVP mutation request and completion facts remain
+unchanged. This read evidence adds no `addGuest` or `markEventInterest`
+business-success claim. Every server rejection, unobserved status or body,
+persisted state, post-write read, delivery, waitlist, ticketing, application,
+and protected-event behavior remains explicit unknown.
 
 ## Historical provenance
 

--- a/docs/adr/0001-greenfield-go-module-seams.md
+++ b/docs/adr/0001-greenfield-go-module-seams.md
@@ -31,16 +31,25 @@ bearer session separately.
 
 Mutation authority owns persistent five-minute, single-use plan records. A
 record binds the account fingerprint, command, normalized input, exact remote
-request projection, and a digest of every pre-read fact. Apply reacquires the
-fingerprint and preconditions before consuming the record. It permits one
-remote mutation attempt and never retries automatically after an ambiguous
-completion.
+request projection, and a digest of every pre-read fact. For RSVP, those facts
+include the current-guest marker, ID, status, and count. They also include the
+normalized event safeguard snapshot. The public plan redacts the guest ID,
+account fingerprint, account ID, and user ID while the private record binds
+the exact values.
+
+Apply reacquires the fingerprint and performs the same event and current-guest
+reads once. After comparison, it consumes the record immediately before
+dispatch. It permits exactly one remote mutation attempt and never retries
+automatically after an ambiguous completion. Any uncertain outcome requires a
+new plan.
 
 The remote seam distinguishes a callable protocol completion from verified
 business state. For RSVP mutations, it validates only the reviewed HTTP
 status, callable result envelope, and client-required completion fields. The
 application can return the normalized submitted request, but it cannot claim
 stored RSVP state, delivery, or another side effect without a separately
-reviewed post-write read. The RSVP command remains outside the releasable
-catalog while current-guest null behavior and required precondition reads are
-unknown.
+reviewed post-write read. The RSVP application returns only the minimal
+submitted request projection: event ID, intent, and `submitted: true`. It
+performs no post-write read. RSVP remains outside the releasable catalog until
+delegated review approves the dated object/null current-guest variants and
+event safeguard boundary.

--- a/docs/research/2026-08-10-contract-evidence-sources.md
+++ b/docs/research/2026-08-10-contract-evidence-sources.md
@@ -190,3 +190,23 @@ and the exact `success`/`interested` completion check. Its
 “getCurrentGuest” section supports the event-ID request and documents why
 callable null and alternate responses remain unknown. No live mutation or
 account-scoped read was used.
+
+## Dated RSVP read observation
+
+The owner-authorized read-only observation in
+`docs/research/2026-08-12-rsvp-read-observation.md`, under “Scope and
+provenance,” records the sanitized artifact
+`spec/research/rsvp-read-evidence-redacted-20260812.json`. The agent did not
+use credentials or make live requests during contract work.
+
+Its “Current-guest variants” section supports one HTTP `200` explicit null and
+one HTTP `200` object with selected field types. Its “Event safeguard
+observations” section supports HTTP `200` for 330 listed event details and the
+field-presence and type/value aggregates used by S5. Raw presence counts
+remain separate from normalized null buckets.
+
+The “Narrow compatibility policy” combines those read facts with the already
+reviewed request behavior in the public RSVP mapping note. Compatibility
+exclusions are product safety policy; they do not establish server rejection
+or mutation-success behavior. The “Privacy boundary” defines the exact
+allowlist and mutation tests for the sanitized artifact.

--- a/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
+++ b/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
@@ -1,8 +1,8 @@
 # Partiful remote API contract evidence ledger
 
-**Owner-reviewed contract revision:** `2026-08-12.2`
-**Owner-reviewed baseline:** `2026-08-12.1`
-**Status:** Owner-reviewed under the issue #114 delegation
+**Proposed contract revision:** `2026-08-12.3`
+**Owner-reviewed baseline:** `2026-08-12.2`
+**Status:** Proposed pending delegated review
 **Contract:** `spec/partiful.openapi.json`
 **Machine-readable ledger:** `spec/partiful.api-evidence.json`
 **Stable citation sources:** `docs/research/2026-08-10-contract-evidence-sources.md`
@@ -71,7 +71,7 @@ HTTP `200` status and two operations with protocol-specified callable
 completion have typed response bodies. The schema-free send-code `200` and
 OpenAPI `default` responses do not claim a body.
 
-The 1285 material claims are audited by
+The 1316 material claims are audited by
 `tests/remote-api-contract.test.js`. Each ledger citation resolves either to a
 JSON Pointer in the committed non-authoritative historical artifact or to a
 heading in the committed stable source index. This keeps the audit independent
@@ -181,13 +181,15 @@ list. Related event-list representations support only optional `endDate`
 string/null and `image` object/null unions. Selected-only fields without
 related variant evidence remain unconstrained.
 
-`getCurrentGuest` returned `200` with an object at
+The August 11 `getCurrentGuest` observation returned `200` with an object at
 `result.data.currentGuest`. This single object cannot establish
 operation-wide field presence, nullability, or alternate variants, so
 `CurrentGuest` has no operation-wide top-level type and no required field
 list. Cross-source fields retain only their supported types; `count`,
 `plusOnes`, and `userId` remain unconstrained. A null current guest, an
-ordinary non-null plus-one shape, and other variants remain unknown.
+ordinary non-null plus-one shape, and other variants remained unknown at that
+revision. The RSVP dated-read section below supersedes only the null and
+selected count-type gaps.
 
 `firestoreGetGuest` returned `200` for the current guest document. Its
 document ID and status matched the callable guest. The complete Firestore
@@ -229,9 +231,39 @@ remote response type claims or live observations of stored Partiful state.
 Every unobserved error and status remains explicit unknown.
 
 `CurrentGuest.status` references the existing closed `GuestStatus` vocabulary,
-but remains optional. Current-guest nullability, no-guest create behavior,
-required profile name, selected-event mutation preconditions, endpoint
-failure mappings, and post-write business state remain unknown.
+but remains optional. Revision `2026-08-12.2` left current-guest nullability,
+no-guest create behavior, required profile name, selected-event mutation
+preconditions, endpoint failure mappings, and post-write business state
+unknown.
+
+## RSVP dated read evidence
+
+The owner-authorized sanitized observation at
+`spec/research/rsvp-read-evidence-redacted-20260812.json` covers 36 upcoming
+and 294 past events, 330 unique `getEventInfo` details, and HTTP `200` for all
+330 detail calls. The human source is
+`docs/research/2026-08-12-rsvp-read-observation.md`.
+
+One `getCurrentGuest` HTTP `200` returned explicit null, and one returned an
+object. The selected object fields establish string ID, string status, and
+number count. `CurrentGuest` now admits the observed object/null top-level
+union and types count as number. No object field becomes operation-wide
+required. Missing `currentGuest`, scalar, array, non-null plus-one shape,
+other object variants, unsupported statuses, and failure responses remain
+unknown.
+
+The optional `EventInfo` safeguard schemas record only the retained field
+types and values. `rsvpsEnabled`, `atCapacity`, and
+`plusOneNamesRequired` were present booleans in all 330 details.
+`questionnaireVersions` was always present as array or null. Optional
+questionnaire, ticketing, action, capacity, and waitlist fields preserve the
+observed unions. Raw presence counts remain separate from aggregate null
+buckets; absent properties are not rewritten into remote null claims.
+
+These read facts support a narrow product-compatible event class. They do not
+establish server rejection mappings or any mutation success. Ticketing,
+application, waitlist, password-protected submission, persisted RSVP state,
+post-write reads, and all unobserved errors remain unknown.
 
 ## Contact read evidence
 
@@ -293,7 +325,7 @@ by the Go implementation's Firebase requests:
 Origin is unmodelled and remains unknown because the reviewed evidence
 establishes no Origin request fact.
 
-The 1285 material claims are audited by `tests/remote-api-contract.test.js`.
+The 1316 material claims are audited by `tests/remote-api-contract.test.js`.
 
 ## Resolved conflict
 

--- a/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
+++ b/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
@@ -1,8 +1,8 @@
 # Partiful remote API contract evidence ledger
 
-**Proposed contract revision:** `2026-08-12.3`
+**Owner-reviewed contract revision:** `2026-08-12.3`
 **Owner-reviewed baseline:** `2026-08-12.2`
-**Status:** Proposed pending delegated review
+**Status:** Owner-reviewed under the issue #114 delegation
 **Contract:** `spec/partiful.openapi.json`
 **Machine-readable ledger:** `spec/partiful.api-evidence.json`
 **Stable citation sources:** `docs/research/2026-08-10-contract-evidence-sources.md`

--- a/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
+++ b/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
@@ -260,6 +260,10 @@ questionnaire, ticketing, action, capacity, and waitlist fields preserve the
 observed unions. Raw presence counts remain separate from aggregate null
 buckets; absent properties are not rewritten into remote null claims.
 
+The current client counts only `GOING` and `APPROVED` guests as attended for
+capacity calculations. RSVP update planning subtracts an existing party count
+only for those two statuses.
+
 These read facts support a narrow product-compatible event class. They do not
 establish server rejection mappings or any mutation success. Ticketing,
 application, waitlist, password-protected submission, persisted RSVP state,

--- a/docs/research/2026-08-12-rsvp-mapping-public-assets.md
+++ b/docs/research/2026-08-12-rsvp-mapping-public-assets.md
@@ -244,3 +244,14 @@ The current public and owner-reviewed evidence leaves these blockers:
 These blockers prevent a releasable Go RSVP read or addGuest-backed mutation.
 They do not prevent review of the exact request projections, the interest
 completion check, or the mutation safety contract.
+
+## Later dated read evidence
+
+The blocker list above records the public-asset-only boundary at capture time.
+The later owner-authorized read-only observation in
+`docs/research/2026-08-12-rsvp-read-observation.md` supplies an explicit null
+current guest and event safeguard aggregates for proposed revision
+`2026-08-12.3`. Caller-supplied `displayName` is a product decision that
+removes the profile-read dependency. These later facts do not change this
+note's request mappings or add any mutation response, failure, or persisted
+state evidence.

--- a/docs/research/2026-08-12-rsvp-mapping-public-assets.md
+++ b/docs/research/2026-08-12-rsvp-mapping-public-assets.md
@@ -69,6 +69,13 @@ Read status stays separate. A present `CurrentGuest.status` can use the full
 16-value lossless `EventReadRsvp` mapping. This does not make all 16 values
 writable.
 
+## Capacity-consuming guest statuses
+
+Shared event helper module `50218` calculates `attendedGuestCount` by summing
+only statuses accepted by guest-status helper `i9`. Module `54257` defines
+that set as `GOING` and `APPROVED`. A current guest in any other status is not
+subtracted from remaining capacity when planning an update.
+
 ## getCurrentGuest
 
 Page module `77504` sends:

--- a/docs/research/2026-08-12-rsvp-read-observation.md
+++ b/docs/research/2026-08-12-rsvp-read-observation.md
@@ -1,0 +1,132 @@
+# RSVP read observation
+
+## Scope and provenance
+
+On August 12, 2026, the repository owner authorized authenticated, read-only
+RSVP evidence capture. The supplied sanitized artifact is
+`spec/research/rsvp-read-evidence-redacted-20260812.json`, captured at
+`2026-08-12T13:49:55.431Z`. The agent did not use credentials, make a live
+request, or handle raw response values. The raw private capture was deleted
+before this contract work.
+
+The artifact contains only counts, field names, value types, bounded numeric
+ranges, safe enum values, and HTTP statuses. It contains no event, guest, user,
+or account identifiers; names; messages; questionnaire answers; credentials;
+tokens; phone numbers; or email addresses. This observation proposes contract
+revision `2026-08-12.3`; it does not approve that revision.
+
+## Event coverage
+
+The read found 36 upcoming and 294 past list events, with 330 unique event
+details. All 330 `getEventInfo` calls returned HTTP `200`. The detail artifact
+records 90 field names and their presence counts, but it retains values only
+for the allowlisted RSVP safeguard fields.
+
+Forty-one list events had no inline guest and 289 had an inline guest. One
+candidate from each class was used for the current-guest variant checks. Those
+two probes do not establish the frequency of either callable variant.
+
+## Current-guest variants
+
+One `getCurrentGuest` call returned HTTP `200` with explicit null at
+`result.data.currentGuest`. This is authoritative evidence for the
+no-current-guest marker. The property itself was present.
+
+One other call returned HTTP `200` with an object. The sanitized object had
+string `id`, `name`, `status`, and `userId`; number `count` and
+`plusOneCount`; null `anchorGuestId`, `plusOnes`, and `rsvpDate`; object
+`invitedBy`; and array `rsvpHistory`. Only ID, status, and count are needed by
+the S5 plan. Their values were not retained.
+
+The explicit null and selected object are the only observed callable variants.
+A missing `currentGuest` property, scalar, array, object without a valid ID or
+status, non-number count, non-null plus-one variant, unsupported status, and
+failure response remain unknown.
+
+Current public asset module `52105`, cited in
+`docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request`,
+adds `guestId` for an existing guest and omits it for no guest. Combined with
+the dated null and object observations, the narrow selection is exact:
+
+- explicit `currentGuest: null` selects create and omits `guestId`;
+- an object with valid ID and status selects update and includes its private
+  ID; the mutation-compatible subset also requires nonnegative integer count;
+  and
+- every other variant fails closed.
+
+## Event safeguard observations
+
+The table keeps raw property presence separate from the artifact's normalized
+null buckets.
+
+| Field | Raw presence | Observed retained variants |
+| --- | ---: | --- |
+| `rsvpsEnabled` | 330 | 325 true, 5 false |
+| `atCapacity` | 330 | 315 false, 15 true |
+| `plusOneNamesRequired` | 330 | 317 false, 13 true |
+| `questionnaireEnabled` | 93 | 47 true, 46 false, 237 absent |
+| `questionnaireVersions` | 330 | 89 arrays and 241 null; array lengths 1 (44), 2 (39), or 3 (6) |
+| `ticketing` | 101 | 91 objects, 10 explicit null, 229 absent |
+| `guestAction` | 22 | 18 `APPLY`, 4 `RSVP`, 308 absent |
+| `maxCountPerGuest` | 36 | 36 numbers from 1 through 10, 294 absent |
+| `maxCapacity` | 68 | 52 numbers from 8 through 300, 16 explicit null, 262 absent |
+| `remainingCapacity` | 52 | 52 numbers from -9 through 116, 278 absent |
+| `enableWaitlist` | 78 | 33 true, 31 false, 14 explicit null, 252 absent |
+| `password` | 0 | 330 absent |
+| `passwordProtected` | 0 | 330 absent |
+
+The normalized artifact uses null for an absent optional value in several
+aggregate groups. The raw presence list is authoritative when absence and
+explicit null differ. A mutation safeguard snapshot must retain that
+distinction instead of converting every absence to JSON null.
+
+## Narrow compatibility policy
+
+The dated evidence establishes field presence and variants, not server
+enforcement. The following rules are conservative product exclusions:
+
+- require `rsvpsEnabled: true`;
+- reject `guestAction: "APPLY"` because the approved request mapping has no
+  application flow;
+- require absent or null `ticketing`; require absent `password` and
+  `passwordProtected` because no present password variant was observed and the
+  approved request mapping has no ticket purchase or password input;
+- reject `atCapacity: true` for going because no reviewed waitlist request
+  mapping exists, including when `enableWaitlist` is true;
+- enforce a numeric `maxCountPerGuest` against party size when present;
+- reject a numeric `maxCapacity` without numeric `remainingCapacity`;
+- enforce numeric `remainingCapacity` against only the additional party count,
+  using the bound current-guest count for an update; and
+- continue to require named plus ones and exact party-size consistency.
+
+These rules define the product's supported event class. They do not claim that
+the server returns a particular error or stores a successful write.
+
+Current public asset module `82565`, cited in
+`docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request`,
+sets questionnaire version to `questionnaireVersions.length - 1` for going
+and skips the questionnaire for `DECLINED`. Module `7073` supports the named
+plus-one request shape. The product therefore requires the latest version when
+`questionnaireEnabled` is true, submits no questionnaire response otherwise,
+and always omits it for not-going.
+
+## Privacy boundary
+
+Contract tests require the artifact's exact top-level shape, exact
+current-guest type inventory, exact safeguard aggregates, and an allowlist of
+all 90 retained event field names. Mutation tests reject unknown keys,
+unallowlisted field names, and arbitrary values. Separate patterns reject
+identity and credential keys, JWT-like strings, phone numbers, email
+addresses, messages, display names, and questionnaire answers.
+
+The public plan can show caller-supplied RSVP input. Its private stored record
+binds the exact guest ID, account fingerprint, and request, but public plan
+JSON must redact the guest ID and never contain account or user IDs.
+
+## Remaining unknowns
+
+No RSVP mutation response was observed. Server rejection status and body
+mappings, stored RSVP state, delivery, notification behavior, waitlist,
+ticketing, application, protected-event submission, inaccessible-event
+responses, unobserved current-guest variants, and post-write reads remain
+unknown. They are not inferred from the read-only evidence.

--- a/spec/partiful.api-evidence.json
+++ b/spec/partiful.api-evidence.json
@@ -1,5 +1,6 @@
 {
-  "contractRevision": "2026-08-12.2",
+  "contractRevision": "2026-08-12.3",
+  "ownerReviewedBaseline": "2026-08-12.2",
   "contractPath": "spec/partiful.openapi.json",
   "allowedClassifications": [
     "dated-live-observation",
@@ -48,7 +49,11 @@
     "publicInterestRequest20260812": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#markeventinterest-request-and-completion",
     "publicInterestCompletion20260812": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#markeventinterest-request-and-completion",
     "publicRsvpGuestStatus20260812": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#guest-status-and-product-intent",
-    "publicRsvpBlockers20260812": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#apply-preconditions-and-irreducible-blockers"
+    "publicRsvpBlockers20260812": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#apply-preconditions-and-irreducible-blockers",
+    "rsvpReadObservation20260812": "docs/research/2026-08-12-rsvp-read-observation.md#scope-and-provenance",
+    "rsvpReadCurrentGuest20260812": "docs/research/2026-08-12-rsvp-read-observation.md#current-guest-variants",
+    "rsvpReadSafeguards20260812": "docs/research/2026-08-12-rsvp-read-observation.md#event-safeguard-observations",
+    "rsvpReadPrivacy20260812": "docs/research/2026-08-12-rsvp-read-observation.md#privacy-boundary"
   },
   "operations": {
     "createEvent": {
@@ -113,7 +118,7 @@
     },
     "getCurrentGuest": {
       "classification": "dated-live-observation",
-      "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+      "citation": "docs/research/2026-08-12-rsvp-read-observation.md#current-guest-variants"
     },
     "firestoreGetEvent": {
       "classification": "dated-live-observation",
@@ -285,9 +290,9 @@
       "request": "current-first-party-public-asset-research",
       "requestCitation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#getcurrentguest",
       "response": "dated-live-observation",
-      "responseCitation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations",
+      "responseCitation": "docs/research/2026-08-12-rsvp-read-observation.md#current-guest-variants",
       "status": "dated-live-observation",
-      "statusCitation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+      "statusCitation": "docs/research/2026-08-12-rsvp-read-observation.md#current-guest-variants"
     },
     "firestoreGetEvent": {
       "request": "typescript-derived-inference",
@@ -405,13 +410,13 @@
     "Origin is unmodelled and remains unknown because the reviewed evidence establishes no Origin request fact.",
     "Event-list remote pagination, limits, ordering key, snapshot behavior, unsupported statuses, and failure bodies remain unknown.",
     "Only the selected getEventInfo event was observed signed out; readability of other events and authenticated inaccessible-event denial remain unknown.",
-    "Only one selected EventInfo object was observed; operation-wide field presence, nullability, and alternate variants remain unknown. Related event-list representations support only the optional endDate string/null and image object/null unions.",
-    "Only one CurrentGuest object was observed; operation-wide field presence, nullability, alternate variants, plus-one shape, unsupported statuses, and failure bodies remain unknown.",
+    "The RSVP read observation establishes aggregate presence and safeguard variants for 330 listed EventInfo objects; behavior outside that account-visible set, other field types, inaccessible events, and alternate responses remain unknown.",
+    "One CurrentGuest null and one object variant are observed; operation-wide object field presence, non-null plus-one shapes, unsupported statuses, other variants, and failure bodies remain unknown.",
     "Firestore event GET returned PERMISSION_DENIED for selected readable and synthetic IDs with one credential; success, not-found, attendee-denial, and other credential behavior remain unknown.",
     "Contact invalid-cursor behavior, cursor lifetime and reuse, ordering key, snapshot behavior, useAuthUser, rate limiting, unsupported statuses, future catalog completeness, server duplicate behavior, and duplicates outside two traversals remain unknown.",
-    "getCurrentGuest null and alternate responses, no-guest addGuest name and create behavior, selected-event RSVP preconditions, mutation failures, and post-write RSVP business state remain unknown."
+    "RSVP mutation failures, server-side rejection mappings, ticketing, application, waitlist, protected-event submission, and post-write RSVP business state remain unknown."
   ],
-  "status": "owner-reviewed",
+  "status": "proposed-pending-delegated-review",
   "claims": {
     "#/servers/0/url": {
       "classification": "typescript-derived-inference",
@@ -4897,6 +4902,118 @@
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
     },
+    "#/components/schemas/EventInfo/properties/rsvpsEnabled": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-12-rsvp-read-observation.md#event-safeguard-observations"
+    },
+    "#/components/schemas/EventInfo/properties/rsvpsEnabled/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-12-rsvp-read-observation.md#event-safeguard-observations"
+    },
+    "#/components/schemas/EventInfo/properties/atCapacity": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-12-rsvp-read-observation.md#event-safeguard-observations"
+    },
+    "#/components/schemas/EventInfo/properties/atCapacity/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-12-rsvp-read-observation.md#event-safeguard-observations"
+    },
+    "#/components/schemas/EventInfo/properties/plusOneNamesRequired": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-12-rsvp-read-observation.md#event-safeguard-observations"
+    },
+    "#/components/schemas/EventInfo/properties/plusOneNamesRequired/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-12-rsvp-read-observation.md#event-safeguard-observations"
+    },
+    "#/components/schemas/EventInfo/properties/questionnaireEnabled": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-12-rsvp-read-observation.md#event-safeguard-observations"
+    },
+    "#/components/schemas/EventInfo/properties/questionnaireEnabled/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-12-rsvp-read-observation.md#event-safeguard-observations"
+    },
+    "#/components/schemas/EventInfo/properties/questionnaireVersions": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-12-rsvp-read-observation.md#event-safeguard-observations"
+    },
+    "#/components/schemas/EventInfo/properties/questionnaireVersions/type/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-12-rsvp-read-observation.md#event-safeguard-observations"
+    },
+    "#/components/schemas/EventInfo/properties/questionnaireVersions/type/1": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-12-rsvp-read-observation.md#event-safeguard-observations"
+    },
+    "#/components/schemas/EventInfo/properties/ticketing": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-12-rsvp-read-observation.md#event-safeguard-observations"
+    },
+    "#/components/schemas/EventInfo/properties/ticketing/type/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-12-rsvp-read-observation.md#event-safeguard-observations"
+    },
+    "#/components/schemas/EventInfo/properties/ticketing/type/1": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-12-rsvp-read-observation.md#event-safeguard-observations"
+    },
+    "#/components/schemas/EventInfo/properties/guestAction": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-12-rsvp-read-observation.md#event-safeguard-observations"
+    },
+    "#/components/schemas/EventInfo/properties/guestAction/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-12-rsvp-read-observation.md#event-safeguard-observations"
+    },
+    "#/components/schemas/EventInfo/properties/guestAction/enum/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-12-rsvp-read-observation.md#event-safeguard-observations"
+    },
+    "#/components/schemas/EventInfo/properties/guestAction/enum/1": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-12-rsvp-read-observation.md#event-safeguard-observations"
+    },
+    "#/components/schemas/EventInfo/properties/maxCountPerGuest": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-12-rsvp-read-observation.md#event-safeguard-observations"
+    },
+    "#/components/schemas/EventInfo/properties/maxCountPerGuest/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-12-rsvp-read-observation.md#event-safeguard-observations"
+    },
+    "#/components/schemas/EventInfo/properties/maxCapacity": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-12-rsvp-read-observation.md#event-safeguard-observations"
+    },
+    "#/components/schemas/EventInfo/properties/maxCapacity/type/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-12-rsvp-read-observation.md#event-safeguard-observations"
+    },
+    "#/components/schemas/EventInfo/properties/maxCapacity/type/1": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-12-rsvp-read-observation.md#event-safeguard-observations"
+    },
+    "#/components/schemas/EventInfo/properties/remainingCapacity": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-12-rsvp-read-observation.md#event-safeguard-observations"
+    },
+    "#/components/schemas/EventInfo/properties/remainingCapacity/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-12-rsvp-read-observation.md#event-safeguard-observations"
+    },
+    "#/components/schemas/EventInfo/properties/enableWaitlist": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-12-rsvp-read-observation.md#event-safeguard-observations"
+    },
+    "#/components/schemas/EventInfo/properties/enableWaitlist/type/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-12-rsvp-read-observation.md#event-safeguard-observations"
+    },
+    "#/components/schemas/EventInfo/properties/enableWaitlist/type/1": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-12-rsvp-read-observation.md#event-safeguard-observations"
+    },
     "#/components/schemas/GetEventInfoResponse/type": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
@@ -4981,6 +5098,14 @@
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
     },
+    "#/components/schemas/CurrentGuest/type/0": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-12-rsvp-read-observation.md#current-guest-variants"
+    },
+    "#/components/schemas/CurrentGuest/type/1": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-12-rsvp-read-observation.md#current-guest-variants"
+    },
     "#/components/schemas/CurrentGuest/properties/id": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
@@ -4992,6 +5117,10 @@
     "#/components/schemas/CurrentGuest/properties/count": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
+    },
+    "#/components/schemas/CurrentGuest/properties/count/type": {
+      "classification": "dated-live-observation",
+      "citation": "docs/research/2026-08-12-rsvp-read-observation.md#current-guest-variants"
     },
     "#/components/schemas/CurrentGuest/properties/name": {
       "classification": "dated-live-observation",
@@ -5788,11 +5917,12 @@
       "status": 200,
       "rawPath": "result.data.currentGuest",
       "otherVariants": "explicit-unknown",
-      "currentGuestNullability": "explicit-unknown",
-      "sampleScope": "one-selected-event",
+      "currentGuestNullability": "null-observed",
+      "sampleScope": "two-selected-events-one-object-one-null",
       "fieldPresence": "selected-object-only",
       "fieldNullabilityAndAlternateVariants": "explicit-unknown",
-      "plusOnesVariants": "explicit-unknown"
+      "plusOnesVariants": "explicit-unknown",
+      "selectedObjectCountType": "number"
     },
     "firestoreGuest": {
       "status": 200,
@@ -5864,6 +5994,222 @@
       "inaccessibleEventPermission": "not-observed",
       "listFailures": "explicit-unknown",
       "currentGuestFailures": "explicit-unknown"
+    }
+  },
+  "rsvpReadObservation": {
+    "classification": "dated-live-observation",
+    "citation": "docs/research/2026-08-12-rsvp-read-observation.md#scope-and-provenance",
+    "artifactPath": "spec/research/rsvp-read-evidence-redacted-20260812.json",
+    "capturedAt": "2026-08-12T13:49:55.431Z",
+    "listCounts": {
+      "upcoming": 36,
+      "past": 294,
+      "unique": 330,
+      "noGuestCandidates": 41,
+      "guestCandidates": 289
+    },
+    "getEventInfo": {
+      "status": 200,
+      "count": 330
+    },
+    "currentGuest": {
+      "status": 200,
+      "nullCount": 1,
+      "objectCount": 1,
+      "objectFields": {
+        "id": "string",
+        "count": "number",
+        "status": "string",
+        "name": "string",
+        "plusOnes": "null",
+        "userId": "string"
+      }
+    },
+    "eventSafeguards": {
+      "fieldPresence": {
+        "rsvpsEnabled": 330,
+        "atCapacity": 330,
+        "plusOneNamesRequired": 330,
+        "questionnaireEnabled": 93,
+        "questionnaireVersions": 330,
+        "ticketing": 101,
+        "guestAction": 22,
+        "maxCountPerGuest": 36,
+        "maxCapacity": 68,
+        "remainingCapacity": 52,
+        "enableWaitlist": 78,
+        "password": 0,
+        "passwordProtected": 0
+      },
+      "aggregates": {
+        "questionnaireEnabled": [
+          {
+            "type": "boolean",
+            "count": 93
+          },
+          {
+            "type": "null",
+            "count": 237
+          }
+        ],
+        "questionnaireEnabledValues": [
+          {
+            "value": false,
+            "count": 46
+          },
+          {
+            "value": true,
+            "count": 47
+          }
+        ],
+        "questionnaireVersionLengths": [
+          {
+            "length": 1,
+            "count": 44
+          },
+          {
+            "length": 2,
+            "count": 39
+          },
+          {
+            "length": 3,
+            "count": 6
+          }
+        ],
+        "questionnaireItemFields": [
+          "createdAt",
+          "questions"
+        ],
+        "maxCountPerGuest": [
+          {
+            "type": "null",
+            "count": 294,
+            "min": null,
+            "max": null
+          },
+          {
+            "type": "number",
+            "count": 36,
+            "min": 1,
+            "max": 10
+          }
+        ],
+        "maxCapacity": [
+          {
+            "type": "null",
+            "count": 278,
+            "min": null,
+            "max": null
+          },
+          {
+            "type": "number",
+            "count": 52,
+            "min": 8,
+            "max": 300
+          }
+        ],
+        "remainingCapacity": [
+          {
+            "type": "null",
+            "count": 278,
+            "min": null,
+            "max": null
+          },
+          {
+            "type": "number",
+            "count": 52,
+            "min": -9,
+            "max": 116
+          }
+        ],
+        "ticketing": [
+          {
+            "type": "null",
+            "count": 239
+          },
+          {
+            "type": "object",
+            "count": 91
+          }
+        ],
+        "ticketingFields": [
+          "currency",
+          "mode",
+          "payment",
+          "price",
+          "type"
+        ],
+        "guestAction": [
+          {
+            "value": null,
+            "count": 308
+          },
+          {
+            "value": "APPLY",
+            "count": 18
+          },
+          {
+            "value": "RSVP",
+            "count": 4
+          }
+        ],
+        "rsvpsEnabled": [
+          {
+            "value": false,
+            "count": 5
+          },
+          {
+            "value": true,
+            "count": 325
+          }
+        ],
+        "atCapacity": [
+          {
+            "value": false,
+            "count": 315
+          },
+          {
+            "value": true,
+            "count": 15
+          }
+        ],
+        "enableWaitlist": [
+          {
+            "value": null,
+            "count": 266
+          },
+          {
+            "value": false,
+            "count": 31
+          },
+          {
+            "value": true,
+            "count": 33
+          }
+        ],
+        "plusOneNamesRequired": [
+          {
+            "value": false,
+            "count": 317
+          },
+          {
+            "value": true,
+            "count": 13
+          }
+        ],
+        "password": [
+          {
+            "type": "null",
+            "count": 330
+          }
+        ],
+        "passwordProtected": [
+          {
+            "type": "null",
+            "count": 330
+          }
+        ]
+      }
     }
   },
   "publicRsvpAssetResearch": {

--- a/spec/partiful.api-evidence.json
+++ b/spec/partiful.api-evidence.json
@@ -416,7 +416,7 @@
     "Contact invalid-cursor behavior, cursor lifetime and reuse, ordering key, snapshot behavior, useAuthUser, rate limiting, unsupported statuses, future catalog completeness, server duplicate behavior, and duplicates outside two traversals remain unknown.",
     "RSVP mutation failures, server-side rejection mappings, ticketing, application, waitlist, protected-event submission, and post-write RSVP business state remain unknown."
   ],
-  "status": "proposed-pending-delegated-review",
+  "status": "owner-reviewed",
   "claims": {
     "#/servers/0/url": {
       "classification": "typescript-derived-inference",

--- a/spec/partiful.api-evidence.json
+++ b/spec/partiful.api-evidence.json
@@ -6062,6 +6062,16 @@
             "count": 47
           }
         ],
+        "questionnaireVersionTypes": [
+          {
+            "type": "array",
+            "count": 89
+          },
+          {
+            "type": "null",
+            "count": 241
+          }
+        ],
         "questionnaireVersionLengths": [
           {
             "length": 1,

--- a/spec/partiful.openapi.json
+++ b/spec/partiful.openapi.json
@@ -2,8 +2,8 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Partiful remote API contract",
-    "version": "2026-08-12.2",
-    "description": "Owner-reviewed remote-only transport snapshot. Evidence classifications and uncertainty are recorded in spec/partiful.api-evidence.json."
+    "version": "2026-08-12.3",
+    "description": "Proposed remote-only transport snapshot pending delegated review. Evidence classifications and uncertainty are recorded in spec/partiful.api-evidence.json."
   },
   "servers": [
     {
@@ -2695,7 +2695,57 @@
               "null"
             ]
           },
-          "visibility": {}
+          "visibility": {},
+          "rsvpsEnabled": {
+            "type": "boolean"
+          },
+          "atCapacity": {
+            "type": "boolean"
+          },
+          "plusOneNamesRequired": {
+            "type": "boolean"
+          },
+          "questionnaireEnabled": {
+            "type": "boolean"
+          },
+          "questionnaireVersions": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {}
+          },
+          "ticketing": {
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "guestAction": {
+            "type": "string",
+            "enum": [
+              "APPLY",
+              "RSVP"
+            ]
+          },
+          "maxCountPerGuest": {
+            "type": "number"
+          },
+          "maxCapacity": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "remainingCapacity": {
+            "type": "number"
+          },
+          "enableWaitlist": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          }
         }
       },
       "GetEventInfoResponse": {
@@ -2750,11 +2800,17 @@
         }
       },
       "CurrentGuest": {
+        "type": [
+          "object",
+          "null"
+        ],
         "properties": {
           "id": {
             "type": "string"
           },
-          "count": {},
+          "count": {
+            "type": "number"
+          },
           "name": {
             "type": "string"
           },

--- a/spec/partiful.openapi.json
+++ b/spec/partiful.openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Partiful remote API contract",
     "version": "2026-08-12.3",
-    "description": "Proposed remote-only transport snapshot pending delegated review. Evidence classifications and uncertainty are recorded in spec/partiful.api-evidence.json."
+    "description": "Owner-reviewed remote-only transport snapshot. Evidence classifications and uncertainty are recorded in spec/partiful.api-evidence.json."
   },
   "servers": [
     {

--- a/spec/research/rsvp-read-evidence-redacted-20260812.json
+++ b/spec/research/rsvp-read-evidence-redacted-20260812.json
@@ -1,0 +1,613 @@
+{
+  "purpose": "Privacy-safe RSVP read facts",
+  "capturedAt": "2026-08-12T13:49:55.431Z",
+  "listCounts": {
+    "upcoming": 36,
+    "past": 294,
+    "unique": 330,
+    "noGuestCandidates": 41,
+    "guestCandidates": 289
+  },
+  "currentGuestVariants": [
+    {
+      "sourceGuest": "absent",
+      "status": 200,
+      "currentGuest": {
+        "type": "null"
+      }
+    },
+    {
+      "sourceGuest": "present",
+      "status": 200,
+      "currentGuest": {
+        "type": "object",
+        "fields": [
+          {
+            "name": "anchorGuestId",
+            "type": "null"
+          },
+          {
+            "name": "count",
+            "type": "number"
+          },
+          {
+            "name": "id",
+            "type": "string"
+          },
+          {
+            "name": "invitedBy",
+            "type": "object"
+          },
+          {
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "name": "plusOneCount",
+            "type": "number"
+          },
+          {
+            "name": "plusOnes",
+            "type": "null"
+          },
+          {
+            "name": "rsvpDate",
+            "type": "null"
+          },
+          {
+            "name": "rsvpHistory",
+            "type": "array"
+          },
+          {
+            "name": "status",
+            "type": "string"
+          },
+          {
+            "name": "userId",
+            "type": "string"
+          }
+        ]
+      }
+    }
+  ],
+  "eventDetails": {
+    "count": 330,
+    "statuses": [
+      {
+        "status": 200,
+        "count": 330
+      }
+    ],
+    "fields": [
+      {
+        "name": "_disableTwoWeekReminders",
+        "presentCount": 14
+      },
+      {
+        "name": "address",
+        "presentCount": 10
+      },
+      {
+        "name": "allowGuestPhotoUpload",
+        "presentCount": 329
+      },
+      {
+        "name": "allowGuestsToInviteMutuals",
+        "presentCount": 329
+      },
+      {
+        "name": "allowResponsesAfterRsvpDeadline",
+        "presentCount": 4
+      },
+      {
+        "name": "approvedGuestCount",
+        "presentCount": 329
+      },
+      {
+        "name": "atCapacity",
+        "presentCount": 330
+      },
+      {
+        "name": "attendedGuestCount",
+        "presentCount": 329
+      },
+      {
+        "name": "calendarFile",
+        "presentCount": 329
+      },
+      {
+        "name": "cancelSkipNotify",
+        "presentCount": 1
+      },
+      {
+        "name": "canceledAt",
+        "presentCount": 20
+      },
+      {
+        "name": "cancellationMessage",
+        "presentCount": 11
+      },
+      {
+        "name": "checkInStaffIds",
+        "presentCount": 330
+      },
+      {
+        "name": "cohostIds",
+        "presentCount": 2
+      },
+      {
+        "name": "createdAt",
+        "presentCount": 330
+      },
+      {
+        "name": "customFields",
+        "presentCount": 75
+      },
+      {
+        "name": "customSections",
+        "presentCount": 67
+      },
+      {
+        "name": "declinedGuestCount",
+        "presentCount": 43
+      },
+      {
+        "name": "description",
+        "presentCount": 321
+      },
+      {
+        "name": "disableMaybe",
+        "presentCount": 330
+      },
+      {
+        "name": "discoverableAudience",
+        "presentCount": 1
+      },
+      {
+        "name": "displayInviteButton",
+        "presentCount": 329
+      },
+      {
+        "name": "displaySettings",
+        "presentCount": 330
+      },
+      {
+        "name": "emailInvitesSentCount",
+        "presentCount": 21
+      },
+      {
+        "name": "enableGuestReminders",
+        "presentCount": 329
+      },
+      {
+        "name": "enableWaitlist",
+        "presentCount": 78
+      },
+      {
+        "name": "endDate",
+        "presentCount": 330
+      },
+      {
+        "name": "feedbackShortUrl",
+        "presentCount": 18
+      },
+      {
+        "name": "findATime",
+        "presentCount": 330
+      },
+      {
+        "name": "followerInvitesSentCount",
+        "presentCount": 3
+      },
+      {
+        "name": "goingGuestCount",
+        "presentCount": 329
+      },
+      {
+        "name": "guestAction",
+        "presentCount": 22
+      },
+      {
+        "name": "guestCount",
+        "presentCount": 43
+      },
+      {
+        "name": "guestLimit",
+        "presentCount": 5
+      },
+      {
+        "name": "guestStatusCounts",
+        "presentCount": 330
+      },
+      {
+        "name": "hasGuests",
+        "presentCount": 330
+      },
+      {
+        "name": "hostName",
+        "presentCount": 17
+      },
+      {
+        "name": "id",
+        "presentCount": 330
+      },
+      {
+        "name": "image",
+        "presentCount": 330
+      },
+      {
+        "name": "interestedGuestCount",
+        "presentCount": 329
+      },
+      {
+        "name": "invitationMessage",
+        "presentCount": 284
+      },
+      {
+        "name": "invitedGuestCount",
+        "presentCount": 43
+      },
+      {
+        "name": "invitesSentCount",
+        "presentCount": 21
+      },
+      {
+        "name": "isCapped",
+        "presentCount": 330
+      },
+      {
+        "name": "isPartyCartEnabled",
+        "presentCount": 1
+      },
+      {
+        "name": "isPublic",
+        "presentCount": 18
+      },
+      {
+        "name": "isPublicUpdatedAt",
+        "presentCount": 7
+      },
+      {
+        "name": "location",
+        "presentCount": 220
+      },
+      {
+        "name": "locationInfo",
+        "presentCount": 301
+      },
+      {
+        "name": "maxCapacity",
+        "presentCount": 68
+      },
+      {
+        "name": "maxCountPerGuest",
+        "presentCount": 36
+      },
+      {
+        "name": "maybeGuestCount",
+        "presentCount": 329
+      },
+      {
+        "name": "mutualsProcessedAt",
+        "presentCount": 269
+      },
+      {
+        "name": "otherMutualsInvitedCount",
+        "presentCount": 22
+      },
+      {
+        "name": "ownerIds",
+        "presentCount": 330
+      },
+      {
+        "name": "pendingGuestCount",
+        "presentCount": 43
+      },
+      {
+        "name": "plusOneNamesRequired",
+        "presentCount": 330
+      },
+      {
+        "name": "publicShortUrl",
+        "presentCount": 234
+      },
+      {
+        "name": "publishedAt",
+        "presentCount": 330
+      },
+      {
+        "name": "questionnaire",
+        "presentCount": 330
+      },
+      {
+        "name": "questionnaireEnabled",
+        "presentCount": 93
+      },
+      {
+        "name": "questionnaireVersions",
+        "presentCount": 330
+      },
+      {
+        "name": "rejectedGuestCount",
+        "presentCount": 43
+      },
+      {
+        "name": "remainingCapacity",
+        "presentCount": 52
+      },
+      {
+        "name": "removedGuestCount",
+        "presentCount": 2
+      },
+      {
+        "name": "respondedGuestCount",
+        "presentCount": 43
+      },
+      {
+        "name": "respondedToFindATimeGuestCount",
+        "presentCount": 329
+      },
+      {
+        "name": "rsvpButtonGlyphType",
+        "presentCount": 330
+      },
+      {
+        "name": "rsvpDeadline",
+        "presentCount": 22
+      },
+      {
+        "name": "rsvpsEnabled",
+        "presentCount": 330
+      },
+      {
+        "name": "sentGuestReminderDates",
+        "presentCount": 204
+      },
+      {
+        "name": "sentGuestReminders",
+        "presentCount": 204
+      },
+      {
+        "name": "sentHostReminderDates",
+        "presentCount": 234
+      },
+      {
+        "name": "sentHostReminders",
+        "presentCount": 234
+      },
+      {
+        "name": "showActivityTimestamps",
+        "presentCount": 329
+      },
+      {
+        "name": "showGuestCount",
+        "presentCount": 330
+      },
+      {
+        "name": "showGuestList",
+        "presentCount": 329
+      },
+      {
+        "name": "showGuestsInviteMutualsField",
+        "presentCount": 149
+      },
+      {
+        "name": "showHostList",
+        "presentCount": 329
+      },
+      {
+        "name": "sitemapLastModifiedAt",
+        "presentCount": 11
+      },
+      {
+        "name": "startDate",
+        "presentCount": 330
+      },
+      {
+        "name": "status",
+        "presentCount": 330
+      },
+      {
+        "name": "ticketing",
+        "presentCount": 101
+      },
+      {
+        "name": "timezone",
+        "presentCount": 330
+      },
+      {
+        "name": "title",
+        "presentCount": 330
+      },
+      {
+        "name": "unreadRemovedGuestCount",
+        "presentCount": 2
+      },
+      {
+        "name": "updatedAt",
+        "presentCount": 330
+      },
+      {
+        "name": "visibility",
+        "presentCount": 329
+      },
+      {
+        "name": "waitlistGuestCount",
+        "presentCount": 330
+      },
+      {
+        "name": "withdrawnGuestCount",
+        "presentCount": 43
+      }
+    ],
+    "safeguards": {
+      "questionnaireEnabled": [
+        {
+          "type": "boolean",
+          "count": 93
+        },
+        {
+          "type": "null",
+          "count": 237
+        }
+      ],
+      "questionnaireEnabledValues": [
+        {
+          "value": false,
+          "count": 46
+        },
+        {
+          "value": true,
+          "count": 47
+        }
+      ],
+      "questionnaireVersionLengths": [
+        {
+          "length": 1,
+          "count": 44
+        },
+        {
+          "length": 2,
+          "count": 39
+        },
+        {
+          "length": 3,
+          "count": 6
+        }
+      ],
+      "questionnaireItemFields": [
+        "createdAt",
+        "questions"
+      ],
+      "maxCountPerGuest": [
+        {
+          "type": "null",
+          "count": 294,
+          "min": null,
+          "max": null
+        },
+        {
+          "type": "number",
+          "count": 36,
+          "min": 1,
+          "max": 10
+        }
+      ],
+      "maxCapacity": [
+        {
+          "type": "null",
+          "count": 278,
+          "min": null,
+          "max": null
+        },
+        {
+          "type": "number",
+          "count": 52,
+          "min": 8,
+          "max": 300
+        }
+      ],
+      "remainingCapacity": [
+        {
+          "type": "null",
+          "count": 278,
+          "min": null,
+          "max": null
+        },
+        {
+          "type": "number",
+          "count": 52,
+          "min": -9,
+          "max": 116
+        }
+      ],
+      "ticketing": [
+        {
+          "type": "null",
+          "count": 239
+        },
+        {
+          "type": "object",
+          "count": 91
+        }
+      ],
+      "ticketingFields": [
+        "currency",
+        "mode",
+        "payment",
+        "price",
+        "type"
+      ],
+      "guestAction": [
+        {
+          "value": null,
+          "count": 308
+        },
+        {
+          "value": "APPLY",
+          "count": 18
+        },
+        {
+          "value": "RSVP",
+          "count": 4
+        }
+      ],
+      "rsvpsEnabled": [
+        {
+          "value": false,
+          "count": 5
+        },
+        {
+          "value": true,
+          "count": 325
+        }
+      ],
+      "atCapacity": [
+        {
+          "value": false,
+          "count": 315
+        },
+        {
+          "value": true,
+          "count": 15
+        }
+      ],
+      "enableWaitlist": [
+        {
+          "value": null,
+          "count": 266
+        },
+        {
+          "value": false,
+          "count": 31
+        },
+        {
+          "value": true,
+          "count": 33
+        }
+      ],
+      "plusOneNamesRequired": [
+        {
+          "value": false,
+          "count": 317
+        },
+        {
+          "value": true,
+          "count": 13
+        }
+      ],
+      "password": [
+        {
+          "type": "null",
+          "count": 330
+        }
+      ],
+      "passwordProtected": [
+        {
+          "type": "null",
+          "count": 330
+        }
+      ]
+    }
+  }
+}

--- a/spec/research/rsvp-read-evidence-redacted-20260812.json
+++ b/spec/research/rsvp-read-evidence-redacted-20260812.json
@@ -461,6 +461,16 @@
           "count": 47
         }
       ],
+      "questionnaireVersionTypes": [
+        {
+          "type": "array",
+          "count": 89
+        },
+        {
+          "type": "null",
+          "count": 241
+        }
+      ],
       "questionnaireVersionLengths": [
         {
           "length": 1,

--- a/tests/remote-api-contract.test.js
+++ b/tests/remote-api-contract.test.js
@@ -237,6 +237,10 @@ const expectedRsvpSafeguards = {
     { value: false, count: 46 },
     { value: true, count: 47 },
   ],
+  questionnaireVersionTypes: [
+    { type: 'array', count: 89 },
+    { type: 'null', count: 241 },
+  ],
   questionnaireVersionLengths: [
     { length: 1, count: 44 },
     { length: 2, count: 39 },
@@ -1412,7 +1416,8 @@ describe('remote API contract', () => {
       '`atCapacity: true` is unsupported for `going`',
       'does not enter a waitlist',
       '`partySize <= maxCountPerGuest`',
-      '`additionalCount = max(0, partySize - currentGuest.count)`',
+      '`currentGuest.count` only when the current status is `GOING` or `APPROVED`',
+      '`additionalCount = max(0, partySize - currentCapacityCount)`',
       '`additionalCount <= remainingCapacity`',
       '`partySize = 1 + plusOnes.length`',
       '`questionnaireEnabled: true`',
@@ -1427,6 +1432,7 @@ describe('remote API contract', () => {
       '{"eventId":"evt_example","intent":"going","submitted":true}',
       '`result.data.success` is truthy',
       '`result.data.interested` strictly equals the submitted boolean',
+      'Input violations return `input.invalid`',
     ]) {
       expect(rsvpSection, expected).toContain(expected);
     }

--- a/tests/remote-api-contract.test.js
+++ b/tests/remote-api-contract.test.js
@@ -482,7 +482,7 @@ describe('remote API contract', () => {
     expect(evidence.contractRevision).toBe('2026-08-12.3');
     expect(evidence.ownerReviewedBaseline).toBe('2026-08-12.2');
     expect(spec.info.version).toBe(evidence.contractRevision);
-    expect(evidence.status).toBe('proposed-pending-delegated-review');
+    expect(evidence.status).toBe('owner-reviewed');
     expect(evidence.sources.publicEventMapping20260812)
       .toBe(`${eventAssetResearchPath}#scope-and-provenance`);
     expect(citationResolves(evidence.sources.publicEventMapping20260812)).toBe(true);
@@ -605,10 +605,10 @@ describe('remote API contract', () => {
     );
     expect(ledger.match(/The 1316 material claims/g)).toHaveLength(2);
     expect(ledger).toContain(
-      '**Proposed contract revision:** `2026-08-12.3`',
+      '**Owner-reviewed contract revision:** `2026-08-12.3`',
     );
     expect(ledger).toContain(
-      '**Status:** Proposed pending delegated review',
+      '**Status:** Owner-reviewed under the issue #114 delegation',
     );
     expect(ledger).toContain('Current first-party public-asset research');
   });
@@ -1340,7 +1340,7 @@ describe('remote API contract', () => {
   it('defines conservative nullable event reads and bounded local snapshots', () => {
     const product = fs.readFileSync(productContractPath, 'utf8');
     for (const expected of [
-      '**Status:** Proposed pending delegated review',
+      '**Status:** Approved product contract',
       '**Product contract revision:** `2026-08-12.3`',
       '**Remote API contract revision:** `2026-08-12.3`',
       '**Currently shipped Go revisions:** product and remote `2026-08-12.1`',
@@ -1925,7 +1925,7 @@ describe('remote API contract', () => {
     expect(documentedProductRevision).toBe('2026-08-12.3');
     expect(new Set(envelopeRevisions)).toEqual(new Set([documentedRevision]));
     expect(spec.info.version).toBe(documentedRevision);
-    expect(evidence.status).toBe('proposed-pending-delegated-review');
+    expect(evidence.status).toBe('owner-reviewed');
     expect(spec.info.version).not.toBe(shippedRevision);
     expect(appSource).toContain('ProductContractRevision = "2026-08-12.1"');
     expect(productContract)

--- a/tests/remote-api-contract.test.js
+++ b/tests/remote-api-contract.test.js
@@ -8,10 +8,17 @@ const historicalDraftPath = 'spec/research/historical-27-operation-draft.json';
 const historicalDraft = JSON.parse(fs.readFileSync(historicalDraftPath, 'utf8'));
 const readEvidencePath = 'spec/research/read-evidence-redacted-20260811.json';
 const readEvidence = JSON.parse(fs.readFileSync(readEvidencePath, 'utf8'));
+const rsvpReadEvidencePath =
+  'spec/research/rsvp-read-evidence-redacted-20260812.json';
+const rsvpReadEvidence = JSON.parse(
+  fs.readFileSync(rsvpReadEvidencePath, 'utf8'),
+);
 const eventAssetResearchPath =
   'docs/research/2026-08-12-event-read-mapping-public-assets.md';
 const rsvpAssetResearchPath =
   'docs/research/2026-08-12-rsvp-mapping-public-assets.md';
+const rsvpReadObservationPath =
+  'docs/research/2026-08-12-rsvp-read-observation.md';
 const productContractPath = 'docs/CLI-PRODUCT-CONTRACT.md';
 const sourceCache = new Map([
   [historicalDraftPath, historicalDraft],
@@ -129,6 +136,155 @@ const expectedReadAggregates = {
     firestoreSyntheticIdProbeObserved: true,
   },
 };
+const safeRsvpEventFieldNames = new Set([
+  '_disableTwoWeekReminders',
+  'address',
+  'allowGuestPhotoUpload',
+  'allowGuestsToInviteMutuals',
+  'allowResponsesAfterRsvpDeadline',
+  'approvedGuestCount',
+  'atCapacity',
+  'attendedGuestCount',
+  'calendarFile',
+  'cancelSkipNotify',
+  'canceledAt',
+  'cancellationMessage',
+  'checkInStaffIds',
+  'cohostIds',
+  'createdAt',
+  'customFields',
+  'customSections',
+  'declinedGuestCount',
+  'description',
+  'disableMaybe',
+  'discoverableAudience',
+  'displayInviteButton',
+  'displaySettings',
+  'emailInvitesSentCount',
+  'enableGuestReminders',
+  'enableWaitlist',
+  'endDate',
+  'feedbackShortUrl',
+  'findATime',
+  'followerInvitesSentCount',
+  'goingGuestCount',
+  'guestAction',
+  'guestCount',
+  'guestLimit',
+  'guestStatusCounts',
+  'hasGuests',
+  'hostName',
+  'id',
+  'image',
+  'interestedGuestCount',
+  'invitationMessage',
+  'invitedGuestCount',
+  'invitesSentCount',
+  'isCapped',
+  'isPartyCartEnabled',
+  'isPublic',
+  'isPublicUpdatedAt',
+  'location',
+  'locationInfo',
+  'maxCapacity',
+  'maxCountPerGuest',
+  'maybeGuestCount',
+  'mutualsProcessedAt',
+  'otherMutualsInvitedCount',
+  'ownerIds',
+  'pendingGuestCount',
+  'plusOneNamesRequired',
+  'publicShortUrl',
+  'publishedAt',
+  'questionnaire',
+  'questionnaireEnabled',
+  'questionnaireVersions',
+  'rejectedGuestCount',
+  'remainingCapacity',
+  'removedGuestCount',
+  'respondedGuestCount',
+  'respondedToFindATimeGuestCount',
+  'rsvpButtonGlyphType',
+  'rsvpDeadline',
+  'rsvpsEnabled',
+  'sentGuestReminderDates',
+  'sentGuestReminders',
+  'sentHostReminderDates',
+  'sentHostReminders',
+  'showActivityTimestamps',
+  'showGuestCount',
+  'showGuestList',
+  'showGuestsInviteMutualsField',
+  'showHostList',
+  'sitemapLastModifiedAt',
+  'startDate',
+  'status',
+  'ticketing',
+  'timezone',
+  'title',
+  'unreadRemovedGuestCount',
+  'updatedAt',
+  'visibility',
+  'waitlistGuestCount',
+  'withdrawnGuestCount',
+]);
+const expectedRsvpSafeguards = {
+  questionnaireEnabled: [
+    { type: 'boolean', count: 93 },
+    { type: 'null', count: 237 },
+  ],
+  questionnaireEnabledValues: [
+    { value: false, count: 46 },
+    { value: true, count: 47 },
+  ],
+  questionnaireVersionLengths: [
+    { length: 1, count: 44 },
+    { length: 2, count: 39 },
+    { length: 3, count: 6 },
+  ],
+  questionnaireItemFields: ['createdAt', 'questions'],
+  maxCountPerGuest: [
+    { type: 'null', count: 294, min: null, max: null },
+    { type: 'number', count: 36, min: 1, max: 10 },
+  ],
+  maxCapacity: [
+    { type: 'null', count: 278, min: null, max: null },
+    { type: 'number', count: 52, min: 8, max: 300 },
+  ],
+  remainingCapacity: [
+    { type: 'null', count: 278, min: null, max: null },
+    { type: 'number', count: 52, min: -9, max: 116 },
+  ],
+  ticketing: [
+    { type: 'null', count: 239 },
+    { type: 'object', count: 91 },
+  ],
+  ticketingFields: ['currency', 'mode', 'payment', 'price', 'type'],
+  guestAction: [
+    { value: null, count: 308 },
+    { value: 'APPLY', count: 18 },
+    { value: 'RSVP', count: 4 },
+  ],
+  rsvpsEnabled: [
+    { value: false, count: 5 },
+    { value: true, count: 325 },
+  ],
+  atCapacity: [
+    { value: false, count: 315 },
+    { value: true, count: 15 },
+  ],
+  enableWaitlist: [
+    { value: null, count: 266 },
+    { value: false, count: 31 },
+    { value: true, count: 33 },
+  ],
+  plusOneNamesRequired: [
+    { value: false, count: 317 },
+    { value: true, count: 13 },
+  ],
+  password: [{ type: 'null', count: 330 }],
+  passwordProtected: [{ type: 'null', count: 330 }],
+};
 
 function operations() {
   return Object.entries(spec.paths).flatMap(([path, item]) =>
@@ -191,6 +347,81 @@ function assertExactAllowlistedValue(actual, expected, pointer = 'aggregates') {
   expect(actual, pointer).toBe(expected);
 }
 
+function assertRsvpReadArtifact(actual) {
+  expect(Object.keys(actual).sort()).toEqual([
+    'capturedAt',
+    'currentGuestVariants',
+    'eventDetails',
+    'listCounts',
+    'purpose',
+  ]);
+  expect(actual.purpose).toBe('Privacy-safe RSVP read facts');
+  expect(actual.capturedAt).toBe('2026-08-12T13:49:55.431Z');
+  assertExactAllowlistedValue(actual.listCounts, {
+    upcoming: 36,
+    past: 294,
+    unique: 330,
+    noGuestCandidates: 41,
+    guestCandidates: 289,
+  }, 'rsvp/listCounts');
+  assertExactAllowlistedValue(actual.currentGuestVariants, [
+    {
+      sourceGuest: 'absent',
+      status: 200,
+      currentGuest: { type: 'null' },
+    },
+    {
+      sourceGuest: 'present',
+      status: 200,
+      currentGuest: {
+        type: 'object',
+        fields: [
+          { name: 'anchorGuestId', type: 'null' },
+          { name: 'count', type: 'number' },
+          { name: 'id', type: 'string' },
+          { name: 'invitedBy', type: 'object' },
+          { name: 'name', type: 'string' },
+          { name: 'plusOneCount', type: 'number' },
+          { name: 'plusOnes', type: 'null' },
+          { name: 'rsvpDate', type: 'null' },
+          { name: 'rsvpHistory', type: 'array' },
+          { name: 'status', type: 'string' },
+          { name: 'userId', type: 'string' },
+        ],
+      },
+    },
+  ], 'rsvp/currentGuestVariants');
+  expect(Object.keys(actual.eventDetails).sort()).toEqual([
+    'count',
+    'fields',
+    'safeguards',
+    'statuses',
+  ]);
+  expect(actual.eventDetails.count).toBe(330);
+  assertExactAllowlistedValue(
+    actual.eventDetails.statuses,
+    [{ status: 200, count: 330 }],
+    'rsvp/eventDetails/statuses',
+  );
+  expect(actual.eventDetails.fields).toHaveLength(safeRsvpEventFieldNames.size);
+  const fieldNames = [];
+  for (const field of actual.eventDetails.fields) {
+    expect(Object.keys(field).sort()).toEqual(['name', 'presentCount']);
+    expect(safeRsvpEventFieldNames.has(field.name), field.name).toBe(true);
+    expect(Number.isInteger(field.presentCount)).toBe(true);
+    expect(field.presentCount).toBeGreaterThanOrEqual(0);
+    expect(field.presentCount).toBeLessThanOrEqual(330);
+    fieldNames.push(field.name);
+  }
+  expect(new Set(fieldNames).size).toBe(fieldNames.length);
+  expect([...fieldNames].sort()).toEqual([...safeRsvpEventFieldNames].sort());
+  assertExactAllowlistedValue(
+    actual.eventDetails.safeguards,
+    expectedRsvpSafeguards,
+    'rsvp/eventDetails/safeguards',
+  );
+}
+
 function jsonPointerValue(value, pointer) {
   for (const rawSegment of pointer.replace(/^#/, '').replace(/^\//, '').split('/')) {
     if (!rawSegment) continue;
@@ -244,15 +475,19 @@ function citationResolves(citation) {
 describe('remote API contract', () => {
   it('is a consistently versioned OpenAPI 3.1 document with unique operation IDs', () => {
     expect(spec.openapi).toBe('3.1.0');
-    expect(evidence.contractRevision).toBe('2026-08-12.2');
+    expect(evidence.contractRevision).toBe('2026-08-12.3');
+    expect(evidence.ownerReviewedBaseline).toBe('2026-08-12.2');
     expect(spec.info.version).toBe(evidence.contractRevision);
-    expect(evidence.status).toBe('owner-reviewed');
+    expect(evidence.status).toBe('proposed-pending-delegated-review');
     expect(evidence.sources.publicEventMapping20260812)
       .toBe(`${eventAssetResearchPath}#scope-and-provenance`);
     expect(citationResolves(evidence.sources.publicEventMapping20260812)).toBe(true);
     expect(evidence.sources.publicRsvpMapping20260812)
       .toBe(`${rsvpAssetResearchPath}#scope-and-provenance`);
     expect(citationResolves(evidence.sources.publicRsvpMapping20260812)).toBe(true);
+    expect(evidence.sources.rsvpReadObservation20260812)
+      .toBe(`${rsvpReadObservationPath}#scope-and-provenance`);
+    expect(citationResolves(evidence.sources.rsvpReadObservation20260812)).toBe(true);
     const appSource = fs.readFileSync('internal/app/app.go', 'utf8');
     expect(appSource).toContain('ProductContractRevision = "2026-08-12.1"');
     expect(appSource).toContain('RemoteContractRevision  = "2026-08-12.1"');
@@ -303,7 +538,7 @@ describe('remote API contract', () => {
       ...materialClaimPointers(spec.paths, '#/paths', 'paths'),
       ...materialClaimPointers(spec.components, '#/components', 'components'),
     ]);
-    expect(pointers).toHaveLength(1285);
+    expect(pointers).toHaveLength(1316);
     for (const pointer of pointers) {
       const claim = evidence.claims[pointer];
       expect(claim, pointer).toBeDefined();
@@ -364,12 +599,12 @@ describe('remote API contract', () => {
     expect(ledger).toContain(
       'Two additional callable operations have protocol-specified HTTP `200` completion responses.',
     );
-    expect(ledger.match(/The 1285 material claims/g)).toHaveLength(2);
+    expect(ledger.match(/The 1316 material claims/g)).toHaveLength(2);
     expect(ledger).toContain(
-      '**Owner-reviewed contract revision:** `2026-08-12.2`',
+      '**Proposed contract revision:** `2026-08-12.3`',
     );
     expect(ledger).toContain(
-      '**Status:** Owner-reviewed under the issue #114 delegation',
+      '**Status:** Proposed pending delegated review',
     );
     expect(ledger).toContain('Current first-party public-asset research');
   });
@@ -480,7 +715,7 @@ describe('remote API contract', () => {
       ['getMyUpcomingEventsForHomePage', evidence.sources.readEventLists20260811],
       ['getMyPastEventsForHomePage', evidence.sources.readEventLists20260811],
       ['getEventInfo', evidence.sources.readEventInfo20260811],
-      ['getCurrentGuest', evidence.sources.readGuestFirestore20260811],
+      ['getCurrentGuest', evidence.sources.rsvpReadCurrentGuest20260812],
       ['firestoreGetEvent', evidence.sources.readGuestFirestore20260811],
       ['firestoreGetGuest', evidence.sources.readGuestFirestore20260811],
       ['getContacts', evidence.sources.readContacts20260811],
@@ -981,7 +1216,7 @@ describe('remote API contract', () => {
     expect(spec.components.schemas.CurrentGuest.properties.status)
       .toEqual({ $ref: '#/components/schemas/GuestStatus' });
     expect(evidence.readObservation.getCurrentGuest).toMatchObject({
-      currentGuestNullability: 'explicit-unknown',
+      currentGuestNullability: 'null-observed',
       otherVariants: 'explicit-unknown',
     });
 
@@ -1023,12 +1258,87 @@ describe('remote API contract', () => {
     });
   });
 
+  it('records exact sanitized RSVP read variants and safeguard facts', () => {
+    assertRsvpReadArtifact(rsvpReadEvidence);
+
+    expect(evidence.rsvpReadObservation).toMatchObject({
+      classification: 'dated-live-observation',
+      citation: evidence.sources.rsvpReadObservation20260812,
+      artifactPath: rsvpReadEvidencePath,
+      capturedAt: '2026-08-12T13:49:55.431Z',
+      listCounts: {
+        upcoming: 36,
+        past: 294,
+        unique: 330,
+        noGuestCandidates: 41,
+        guestCandidates: 289,
+      },
+      getEventInfo: {
+        status: 200,
+        count: 330,
+      },
+      currentGuest: {
+        status: 200,
+        nullCount: 1,
+        objectCount: 1,
+        objectFields: {
+          id: 'string',
+          count: 'number',
+          status: 'string',
+          name: 'string',
+          plusOnes: 'null',
+          userId: 'string',
+        },
+      },
+      eventSafeguards: {
+        fieldPresence: {
+          rsvpsEnabled: 330,
+          atCapacity: 330,
+          plusOneNamesRequired: 330,
+          questionnaireEnabled: 93,
+          questionnaireVersions: 330,
+          ticketing: 101,
+          guestAction: 22,
+          maxCountPerGuest: 36,
+          maxCapacity: 68,
+          remainingCapacity: 52,
+          enableWaitlist: 78,
+          password: 0,
+          passwordProtected: 0,
+        },
+        aggregates: expectedRsvpSafeguards,
+      },
+    });
+
+    const event = spec.components.schemas.EventInfo.properties;
+    expect(event).toMatchObject({
+      rsvpsEnabled: { type: 'boolean' },
+      atCapacity: { type: 'boolean' },
+      plusOneNamesRequired: { type: 'boolean' },
+      questionnaireEnabled: { type: 'boolean' },
+      questionnaireVersions: { type: ['array', 'null'], items: {} },
+      ticketing: { type: ['object', 'null'] },
+      guestAction: { type: 'string', enum: ['APPLY', 'RSVP'] },
+      maxCountPerGuest: { type: 'number' },
+      maxCapacity: { type: ['number', 'null'] },
+      remainingCapacity: { type: 'number' },
+      enableWaitlist: { type: ['boolean', 'null'] },
+    });
+    expect(spec.components.schemas.CurrentGuest.type)
+      .toEqual(['object', 'null']);
+    expect(spec.components.schemas.CurrentGuest.properties.count)
+      .toEqual({ type: 'number' });
+    expect(spec.components.schemas.GetCurrentGuestResponse.properties.result
+      .properties.data.required)
+      .toEqual(['currentGuest']);
+  });
+
   it('defines conservative nullable event reads and bounded local snapshots', () => {
     const product = fs.readFileSync(productContractPath, 'utf8');
     for (const expected of [
-      '**Status:** Approved product contract',
-      '**Product contract revision:** `2026-08-12.2`',
-      '**Remote API contract revision:** `2026-08-12.2`',
+      '**Status:** Proposed pending delegated review',
+      '**Product contract revision:** `2026-08-12.3`',
+      '**Remote API contract revision:** `2026-08-12.3`',
       '**Currently shipped Go revisions:** product and remote `2026-08-12.1`',
       '`PUBLISHED` → `active`',
       '`CANCELED` → `cancelled`',
@@ -1055,8 +1365,8 @@ describe('remote API contract', () => {
       '`not-going` → `addGuest.rsvp.status = "DECLINED"`',
       '`interested` → `markEventInterest.interested = true`',
       '`source` is omitted for a direct event-page-equivalent request',
-      'does not prove that the remote RSVP state changed',
-      'does not automatically retry either mutation',
+      'persisted RSVP state',
+      'It never retries automatically.',
       'private stable account fingerprint',
       'five minutes',
       'single-use',
@@ -1076,6 +1386,79 @@ describe('remote API contract', () => {
     const appSource = fs.readFileSync('internal/app/app.go', 'utf8');
     expect(appSource).toContain('ProductContractRevision = "2026-08-12.1"');
     expect(appSource).toContain('RemoteContractRevision  = "2026-08-12.1"');
+  });
+
+  it('defines evidence-backed RSVP planning and submitted-only completion', () => {
+    const product = fs.readFileSync(productContractPath, 'utf8');
+    const rsvpSection = product.slice(
+      product.indexOf('### RSVP'),
+      product.indexOf('### Contacts'),
+    );
+    const adr = fs.readFileSync(
+      'docs/adr/0001-greenfield-go-module-seams.md',
+      'utf8',
+    );
+
+    for (const expected of [
+      '`displayName` is required for `going` and `not-going`',
+      '`currentGuest: null` is the authoritative no-current-guest marker',
+      'A missing `currentGuest` property',
+      '`contract.protocol_changed`',
+      '`getEventInfo` once and `getCurrentGuest` once',
+      '`rsvpsEnabled` must be present, boolean, and `true`',
+      '`guestAction: "APPLY"` is unsupported',
+      '`ticketing` must be absent or null',
+      '`password` and `passwordProtected` must be absent',
+      '`atCapacity: true` is unsupported for `going`',
+      'does not enter a waitlist',
+      '`partySize <= maxCountPerGuest`',
+      '`additionalCount = max(0, partySize - currentGuest.count)`',
+      '`additionalCount <= remainingCapacity`',
+      '`partySize = 1 + plusOnes.length`',
+      '`questionnaireEnabled: true`',
+      '`questionnaireVersions.length - 1`',
+      '`not-going` omits `questionnaireResponse`',
+      'normalized event safeguard snapshot',
+      'five-minute, single-use',
+      'consumes the token immediately before dispatch',
+      'exactly one transport attempt',
+      'requires a new plan',
+      'does not perform a post-write read',
+      '{"eventId":"evt_example","intent":"going","submitted":true}',
+      '`result.data.success` is truthy',
+      '`result.data.interested` strictly equals the submitted boolean',
+    ]) {
+      expect(rsvpSection, expected).toContain(expected);
+    }
+    expect(rsvpSection).toMatch(
+      /Apply re-reads `getEventInfo` once and `getCurrentGuest` once[\s\S]+`safety\.plan_stale`/,
+    );
+    expect(rsvpSection).toMatch(
+      /server\s+rejection[\s\S]+`contract\.protocol_changed`/,
+    );
+    expect(rsvpSection).toContain(
+      '{"eventId":"evt_example","status":null}',
+    );
+
+    const publicPlanMatch = rsvpSection.match(
+      /Public RSVP plan example:\n\n```json\n([\s\S]*?)\n```/,
+    );
+    expect(publicPlanMatch).not.toBeNull();
+    const publicPlan = JSON.parse(publicPlanMatch[1]);
+    expect(publicPlan.request.rsvp.guestId).toBe('<redacted>');
+    expect(publicPlan).not.toHaveProperty('accountFingerprint');
+    expect(JSON.stringify(publicPlan)).not.toMatch(
+      /"(?:accountId|userId)"\s*:/,
+    );
+    expect(JSON.stringify(publicPlan)).not.toMatch(
+      /"guestId"\s*:\s*"(?!<redacted>)/,
+    );
+
+    expect(adr).toContain('normalized event safeguard snapshot');
+    expect(adr).toContain('current-guest marker, ID, status, and count');
+    expect(adr).toMatch(/immediately before\s+dispatch/);
+    expect(adr).toMatch(/requires a\s+new plan/);
+    expect(adr).toContain('submitted request');
   });
 
   it('formalizes only the observed event-detail and guest read variants', () => {
@@ -1160,33 +1543,37 @@ describe('remote API contract', () => {
     expect(spec.components.schemas.GetCurrentGuestResponse.properties.result
       .properties.data.required)
       .toEqual(['currentGuest']);
-    expect(spec.components.schemas.CurrentGuest).not.toHaveProperty('type');
-    expect(evidence.claims['#/components/schemas/CurrentGuest/type']).toBeUndefined();
+    expect(spec.components.schemas.CurrentGuest.type).toEqual(['object', 'null']);
+    expect(evidence.claims['#/components/schemas/CurrentGuest/type/0']
+      .classification).toBe('dated-live-observation');
+    expect(evidence.claims['#/components/schemas/CurrentGuest/type/1']
+      .classification).toBe('dated-live-observation');
     expect(spec.components.schemas.CurrentGuest).toMatchObject({
       properties: {
         id: { type: 'string' },
-        count: {},
+        count: { type: 'number' },
         name: { type: 'string' },
         plusOnes: {},
         status: { $ref: '#/components/schemas/GuestStatus' },
         userId: {},
       },
     });
-    expect(spec.components.schemas.CurrentGuest.properties.count).toEqual({});
+    expect(spec.components.schemas.CurrentGuest.properties.count)
+      .toEqual({ type: 'number' });
     expect(spec.components.schemas.CurrentGuest.properties.plusOnes).toEqual({});
     expect(spec.components.schemas.CurrentGuest.properties.userId).toEqual({});
     expect(spec.components.schemas.CurrentGuest.required ?? []).toEqual([]);
     expect(evidence.readObservation.getCurrentGuest.otherVariants)
       .toBe('explicit-unknown');
     expect(evidence.readObservation.getCurrentGuest.currentGuestNullability)
-      .toBe('explicit-unknown');
+      .toBe('null-observed');
     expect(evidence.readObservation.getCurrentGuest).toMatchObject({
-      sampleScope: 'one-selected-event',
+      sampleScope: 'two-selected-events-one-object-one-null',
       fieldPresence: 'selected-object-only',
       fieldNullabilityAndAlternateVariants: 'explicit-unknown',
       plusOnesVariants: 'explicit-unknown',
     });
-    for (const field of ['count', 'plusOnes', 'userId']) {
+    for (const field of ['plusOnes', 'userId']) {
       expect(evidence.claims[
         `#/components/schemas/CurrentGuest/properties/${field}/type`
       ]).toBeUndefined();
@@ -1197,8 +1584,8 @@ describe('remote API contract', () => {
       ]).toBeUndefined();
     }
     expect(evidence.unresolvedUncertainty).toEqual(expect.arrayContaining([
-      'Only one selected EventInfo object was observed; operation-wide field presence, nullability, and alternate variants remain unknown. Related event-list representations support only the optional endDate string/null and image object/null unions.',
-      'Only one CurrentGuest object was observed; operation-wide field presence, nullability, alternate variants, plus-one shape, unsupported statuses, and failure bodies remain unknown.',
+      'The RSVP read observation establishes aggregate presence and safeguard variants for 330 listed EventInfo objects; behavior outside that account-visible set, other field types, inaccessible events, and alternate responses remain unknown.',
+      'One CurrentGuest null and one object variant are observed; operation-wide object field presence, non-null plus-one shapes, unsupported statuses, other variants, and failure bodies remain unknown.',
     ]));
   });
 
@@ -1468,6 +1855,42 @@ describe('remote API contract', () => {
     expect(evidence.readObservation.artifactPath).toBe(readEvidencePath);
   });
 
+  it('strictly limits the RSVP read artifact to privacy-safe aggregates', () => {
+    assertRsvpReadArtifact(rsvpReadEvidence);
+
+    for (const mutate of [
+      (artifact) => {
+        artifact.rawGuestId = 'synthetic-private-id';
+      },
+      (artifact) => {
+        artifact.currentGuestVariants[0].currentGuest.value = 'synthetic-private-id';
+      },
+      (artifact) => {
+        artifact.eventDetails.fields[0].name = 'syntheticPrivateField';
+      },
+      (artifact) => {
+        artifact.eventDetails.safeguards.rawGuestName = 'synthetic-private-name';
+      },
+    ]) {
+      const mutated = structuredClone(rsvpReadEvidence);
+      mutate(mutated);
+      expect(() => assertRsvpReadArtifact(mutated)).toThrow();
+    }
+
+    const serialized = JSON.stringify(rsvpReadEvidence);
+    for (const unsafe of [
+      /(?<![\w])\+[1-9]\d{9,14}(?!\d)/,
+      /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/i,
+      /\beyJ[A-Za-z0-9_-]{12,}\.[A-Za-z0-9_-]{8,}\./,
+      /"(?:eventId|guestId|userId|accountId|accessToken|refreshToken|authorization|credential)"\s*:/i,
+      /"(?:displayName|phone|phoneNumber|message|answer)"\s*:/i,
+    ]) {
+      expect(serialized).not.toMatch(unsafe);
+    }
+    expect(evidence.rsvpReadObservation.artifactPath)
+      .toBe(rsvpReadEvidencePath);
+  });
+
   it('keeps shipped Go revisions on the reviewed baseline while RSVP is proposed', () => {
     const productContract = fs.readFileSync(
       'docs/CLI-PRODUCT-CONTRACT.md',
@@ -1492,11 +1915,11 @@ describe('remote API contract', () => {
     )].map((match) => match[1]);
 
     expect(shippedRevision).toBe('2026-08-12.1');
-    expect(documentedRevision).toBe('2026-08-12.2');
-    expect(documentedProductRevision).toBe('2026-08-12.2');
+    expect(documentedRevision).toBe('2026-08-12.3');
+    expect(documentedProductRevision).toBe('2026-08-12.3');
     expect(new Set(envelopeRevisions)).toEqual(new Set([documentedRevision]));
     expect(spec.info.version).toBe(documentedRevision);
-    expect(evidence.status).toBe('owner-reviewed');
+    expect(evidence.status).toBe('proposed-pending-delegated-review');
     expect(spec.info.version).not.toBe(shippedRevision);
     expect(appSource).toContain('ProductContractRevision = "2026-08-12.1"');
     expect(productContract)


### PR DESCRIPTION
## Summary

Evidence-backed contract continuation of #166. This supersedes the policy in closed PR #185 with owner-authorized, sanitized read facts. It proposes product/remote revision `2026-08-12.3`; shipped Go constants remain unchanged. No credentials were used and no live call or mutation was made during this work.

- commits the sanitized aggregate artifact and a privacy-safe observation note
- records 330 successful event-detail reads plus explicit currentGuest null/object variants
- maps explicit null to create without `guestId` and a valid object to update with private `guestId`
- requires caller-supplied `displayName` for going/not-going
- requires RSVP-enabled, non-application, non-ticketed, unprotected compatible events
- blocks going at capacity and does not invent waitlist behavior
- enforces named-party consistency, max-per-guest, remaining-capacity delta, and latest questionnaire version
- binds exact private request, account, currentGuest marker/ID/status/count, and normalized event safeguards
- redacts guest/account/user IDs from public plans and adds a direct guestId regression
- consumes a five-minute single-use plan before one attempt, with no retry
- returns minimal submitted intent only; no persisted-state claim or post-write read

The existing `.2` addGuest and markEventInterest request/completion facts are unchanged. Interest still requires truthy success and matching interested. All server rejections and unobserved variants remain protocol drift.

## Validation

- contract tests: 35 passed
- full non-live JavaScript suite: 356 passed, 6 skipped
- TypeScript check passed
- `go test -race ./...`, `go vet ./...`, and `go build ./...` passed
- Go module verify/tidy checks passed
- strict artifact schema/privacy tests passed
- privacy and diff checks passed

## Explicitly unsupported

Ticketed events, application events, password-protected events, at-capacity going/waitlist flows, missing or alternate currentGuest variants, unobserved server errors, mutation business success, and post-write state remain unsupported.

Part of #166.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the RSVP contract to revision 2026-08-12.3.
  - Clarified current-guest responses, including valid guest data and explicit no-guest results.
  - Documented RSVP validation for names, plus-ones, questionnaires, capacity, event compatibility, and privacy-safe response handling.
  - Added evidence describing RSVP and event safeguard behavior while preserving unknown and fail-closed cases.

- **Tests**
  - Expanded contract coverage for RSVP response variants, event safeguards, redaction rules, and revision metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->