### PR TITLE
feat(rsvp): add safe reads and mutation plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,29 +97,25 @@ partiful events update <id> --title "New Title"
 partiful events cancel <id>
 ```
 
-### `events rsvp` / `events interested` — RSVP to events
+### `rsvp` — RSVP to events
 
 ```bash
-partiful events rsvp get <id>                      # Read your RSVP and questionnaire answers
-partiful events rsvp set <id>                      # RSVP going (default)
-partiful events rsvp set <id> --status maybe       # going | maybe | declined
-partiful events rsvp set <id> --plus-one Maddie --plus-one Justin   # bring guests
-partiful events rsvp set <id> --name "Kaleb Cole" --message "Stoked!"
-partiful events rsvp set <id> --answer "<question-id-or-text>=<value>"  # repeat per host question
-partiful events interested <id>                    # mark interest
-partiful events interested <id> --remove           # remove interest
+partiful rsvp get <id>
+partiful rsvp set <id> --status going --display-name "Example" \
+  --party-size 1 --timezone America/Los_Angeles
+partiful rsvp set <id> --status not-going --display-name "Example" \
+  --party-size 1 --timezone America/Los_Angeles
+partiful rsvp set <id> --status interested
+partiful rsvp set <id> --input rsvp.json
 ```
 
-`events rsvp get` reads your saved status, guest details, and questionnaire
-answers without changing the RSVP. RSVP writes do a read-before-write: they update your existing guest record if you
-already RSVP'd, otherwise create one. Ticketed events are refused with a clear
-error (use the app to purchase a ticket). For host-questionnaire events, pass one
-repeatable `--answer "<question-id-or-exact-text>=<value>"` per answer; required
-answers are validated before submission. Plain `--dry-run` stays offline, while
-`--answer ... --dry-run` performs read-only guest/event lookups so the preview can
-validate and preserve live questionnaire state, then read the Firestore guest record
-back to verify the saved status and answers. The same verbs are available under
-`explore` (`partiful explore rsvp get <id>`) for the discovery flow.
+`rsvp get` returns only the reviewed status projection. `rsvp set` first
+returns a five-minute, single-use plan and does not mutate. Apply the same
+normalized input with `--apply --plan <token>`. Ticketed, application,
+protected, at-capacity going, and unsupported questionnaire flows fail
+closed. A successful apply reports only that one reviewed request was
+submitted; it does not claim persisted RSVP state and does not read after the
+write.
 
 ### `guests` — Manage event guests
 

--- a/cmd/partiful/main.go
+++ b/cmd/partiful/main.go
@@ -27,6 +27,8 @@ func main() {
 		CursorKeys:           app.FileCursorKeyProvider{Path: cursorKeyPath},
 		CursorRandom:         rand.Reader,
 		AuthRandom:           rand.Reader,
+		MutationPath:         credentialsPath + ".mutation-plans",
+		MutationRandom:       rand.Reader,
 		Terminal: auth.OSTerminal{
 			Input:  os.Stdin,
 			Output: os.Stderr,

--- a/docs/CLI-PRODUCT-CONTRACT.md
+++ b/docs/CLI-PRODUCT-CONTRACT.md
@@ -6,9 +6,9 @@
 
 **Remote API contract revision:** `2026-08-12.3`
 
-**Owner-reviewed baseline:** product and remote `2026-08-12.2`
+**Owner-reviewed baseline:** product and remote `2026-08-12.3`
 
-**Currently shipped Go revisions:** product and remote `2026-08-12.1`
+**Currently shipped Go revisions:** product and remote `2026-08-12.3`
 
 This document defines the public behavior of the greenfield Go `partiful` CLI.
 It is the authority for commands, inputs, JSON outputs, failures, and mutation
@@ -855,7 +855,7 @@ persisted RSVP state, delivery, notification, or another business side
 effect.
 
 This `2026-08-12.3` contract is owner-reviewed under the issue #114
-delegation. Shipped Go revisions remain unchanged until implementation.
+delegation and is shipped by the Go implementation.
 
 ### Contacts
 

--- a/docs/REMOTE-API-CONTRACT.md
+++ b/docs/REMOTE-API-CONTRACT.md
@@ -7,6 +7,8 @@ describes only network operations and wire shapes. It does not prescribe
 commands, output, credentials, mutation safeguards, or implementation
 architecture.
 
+The Go CLI ships remote contract revision `2026-08-12.3`.
+
 ## Authority and change process
 
 Live, privacy-safe observations can initiate a correction but do not authorize

--- a/docs/adr/0001-greenfield-go-module-seams.md
+++ b/docs/adr/0001-greenfield-go-module-seams.md
@@ -50,6 +50,6 @@ application can return the normalized submitted request, but it cannot claim
 stored RSVP state, delivery, or another side effect without a separately
 reviewed post-write read. The RSVP application returns only the minimal
 submitted request projection: event ID, intent, and `submitted: true`. It
-performs no post-write read. RSVP remains outside the releasable catalog until
-delegated review approves the dated object/null current-guest variants and
-event safeguard boundary.
+performs no post-write read. RSVP enters the releasable catalog only with the
+approved dated object/null current-guest variants, event safeguard boundary,
+and matching product and remote revision constants.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -14,8 +14,8 @@ import (
 
 const (
 	Version                 = "1.0.0"
-	ProductContractRevision = "2026-08-12.1"
-	RemoteContractRevision  = "2026-08-12.1"
+	ProductContractRevision = "2026-08-12.3"
+	RemoteContractRevision  = "2026-08-12.3"
 )
 
 type Request struct {
@@ -38,6 +38,8 @@ type Dependencies struct {
 	CursorKeys           CursorKeyProvider
 	CursorRandom         io.Reader
 	AuthRandom           io.Reader
+	MutationPath         string
+	MutationRandom       io.Reader
 	Terminal             auth.PrivateTerminal
 }
 
@@ -55,6 +57,8 @@ const (
 	contactsListCommand
 	eventsListCommand
 	eventsGetCommand
+	rsvpGetCommand
+	rsvpSetCommand
 )
 
 type commandDefinition struct {
@@ -270,6 +274,62 @@ var commandCatalog = []commandDefinition{
 		},
 		safety: readOnlySafety(),
 	},
+	{
+		path:       "rsvp.get",
+		invocation: []string{"rsvp", "get"},
+		kind:       rsvpGetCommand,
+		positionals: []positionalDefinition{{
+			Name:        "event-id",
+			Required:    true,
+			Description: "Event identifier.",
+		}},
+		flags:         []flagDefinition{},
+		inputSchema:   eventGetInputSchema(),
+		successSchema: rsvpReadSuccessSchema(),
+		failureTypes: []string{
+			"auth.required",
+			"auth.expired",
+			"remote.unavailable",
+			"contract.protocol_changed",
+			"internal.failure",
+		},
+		safety: readOnlySafety(),
+	},
+	{
+		path:       "rsvp.set",
+		invocation: []string{"rsvp", "set"},
+		kind:       rsvpSetCommand,
+		positionals: []positionalDefinition{{
+			Name:        "event-id",
+			Required:    true,
+			Description: "Event identifier.",
+		}},
+		flags: []flagDefinition{
+			{Name: "--input", Description: "Read one structured JSON input object.", TakesValue: true},
+			{Name: "--status", Description: "Writable RSVP intent.", TakesValue: true},
+			{Name: "--display-name", Description: "Attendee display name.", TakesValue: true},
+			{Name: "--party-size", Description: "Total attendee count.", TakesValue: true},
+			{Name: "--plus-one", Description: "Named plus one; this flag can repeat.", TakesValue: true},
+			{Name: "--message", Description: "Optional RSVP message.", TakesValue: true},
+			{Name: "--timezone", Description: "IANA timezone.", TakesValue: true},
+			{Name: "--questionnaire-response", Description: "Questionnaire response JSON.", TakesValue: true},
+			{Name: "--apply", Description: "Apply a reviewed mutation plan."},
+			{Name: "--plan", Description: "Opaque mutation plan token.", TakesValue: true},
+		},
+		inputSchema:   rsvpSetInputSchema(),
+		successSchema: rsvpSetSuccessSchema(),
+		failureTypes: []string{
+			"auth.required",
+			"auth.expired",
+			"resource.not_found",
+			"state.conflict",
+			"safety.plan_stale",
+			"remote.unavailable",
+			"contract.protocol_changed",
+			"internal.failure",
+		},
+		safety: standardMutationSafety(),
+	},
 }
 
 type positionalDefinition struct {
@@ -287,14 +347,16 @@ type flagDefinition struct {
 
 type jsonSchema struct {
 	Type                 any                   `json:"type,omitempty"`
-	AdditionalProperties *bool                 `json:"additionalProperties,omitempty"`
+	AdditionalProperties any                   `json:"additionalProperties,omitempty"`
 	Required             []string              `json:"required,omitempty"`
 	Properties           map[string]jsonSchema `json:"properties,omitempty"`
 	Enum                 []string              `json:"enum,omitempty"`
+	Const                any                   `json:"const,omitempty"`
 	Format               string                `json:"format,omitempty"`
 	Minimum              *int                  `json:"minimum,omitempty"`
 	Maximum              *int                  `json:"maximum,omitempty"`
 	MinLength            *int                  `json:"minLength,omitempty"`
+	MaxLength            *int                  `json:"maxLength,omitempty"`
 	Pattern              string                `json:"pattern,omitempty"`
 	DependentRequired    map[string][]string   `json:"dependentRequired,omitempty"`
 	Items                *jsonSchema           `json:"items,omitempty"`
@@ -373,7 +435,7 @@ func schemaSuccessSchema() jsonSchema {
 		map[string]jsonSchema{
 			"kind": {
 				Type: "string",
-				Enum: []string{"read-only", "local-mutation"},
+				Enum: []string{"read-only", "local-mutation", "standard-mutation"},
 			},
 			"planRequired":         {Type: "boolean"},
 			"confirmationRequired": {Type: "boolean"},
@@ -599,6 +661,21 @@ func eventGetSuccessSchema() jsonSchema {
 			"guestLimit":  {Type: "null"},
 			"poster":      {Type: "null"},
 			"links":       {Type: "null"},
+		},
+	)
+}
+
+func rsvpReadSuccessSchema() jsonSchema {
+	return objectSchema(
+		[]string{"eventId", "status"},
+		map[string]jsonSchema{
+			"eventId": {Type: "string"},
+			"status": {
+				OneOf: []jsonSchema{
+					{Type: "string", Enum: eventReadRsvpValues()},
+					{Type: "null"},
+				},
+			},
 		},
 	)
 }
@@ -1089,6 +1166,10 @@ func Execute(ctx context.Context, request Request, dependencies Dependencies) Re
 				return executeEventsList(ctx, definition, argv, dependencies, pretty)
 			case eventsGetCommand:
 				return executeEventGet(ctx, definition, argv, dependencies, pretty)
+			case rsvpGetCommand:
+				return executeRSVPGet(ctx, definition, argv, dependencies, pretty)
+			case rsvpSetCommand:
+				return executeRSVPSet(ctx, request, definition, argv, dependencies, pretty)
 			}
 		}
 	}
@@ -1120,7 +1201,9 @@ func (definition commandDefinition) matches(argv []string) bool {
 		definition.kind == postersSearchCommand ||
 		definition.kind == contactsListCommand ||
 		definition.kind == eventsListCommand ||
-		definition.kind == eventsGetCommand) &&
+		definition.kind == eventsGetCommand ||
+		definition.kind == rsvpGetCommand ||
+		definition.kind == rsvpSetCommand) &&
 		len(argv) >= len(definition.invocation) {
 		return slices.Equal(argv[:len(definition.invocation)], definition.invocation)
 	}

--- a/internal/app/execute_test.go
+++ b/internal/app/execute_test.go
@@ -112,7 +112,7 @@ func TestExecuteEventsListProjectsReviewedUpcomingEventWithoutPrompting(t *testi
 		}},
 	})
 
-	const want = `{"ok":true,"data":{"items":[{"eventId":"event-example","title":"Example event","start":"2026-09-12T19:00:00-07:00","end":null,"timezone":"America/Los_Angeles","state":"active","userRole":"host","myRsvp":"going"}]},"meta":{"command":"events.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
+	const want = `{"ok":true,"data":{"items":[{"eventId":"event-example","title":"Example event","start":"2026-09-12T19:00:00-07:00","end":null,"timezone":"America/Los_Angeles","state":"active","userRole":"host","myRsvp":"going"}]},"meta":{"command":"events.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
 	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want reviewed upcoming event projection", result)
 	}
@@ -184,7 +184,7 @@ func TestExecuteEventsListRefreshesAndUsesTokenIdentityWithoutPrompting(t *testi
 		}},
 	})
 
-	const want = `{"ok":true,"data":{"items":[{"eventId":"event-example","title":null,"start":null,"end":null,"timezone":null,"state":null,"userRole":"host","myRsvp":null}]},"meta":{"command":"events.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
+	const want = `{"ok":true,"data":{"items":[{"eventId":"event-example","title":null,"start":null,"end":null,"timezone":null,"state":null,"userRole":"host","myRsvp":null}]},"meta":{"command":"events.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
 	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want refreshed identity projection", result)
 	}
@@ -747,7 +747,7 @@ func TestExecuteEventsGetProjectsReviewedDetailAndNullUnavailableFields(t *testi
 		}},
 	})
 
-	const want = `{"ok":true,"data":{"eventId":"event-example","title":"Example event","start":"2026-09-12T19:00:00-07:00","end":"2026-09-12T22:00:00-07:00","timezone":"America/Los_Angeles","state":"cancelled","userRole":null,"myRsvp":null,"description":null,"location":null,"address":null,"visibility":null,"guestLimit":null,"poster":null,"links":null},"meta":{"command":"events.get","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"eventId":"event-example","title":"Example event","start":"2026-09-12T19:00:00-07:00","end":"2026-09-12T22:00:00-07:00","timezone":"America/Los_Angeles","state":"cancelled","userRole":null,"myRsvp":null,"description":null,"location":null,"address":null,"visibility":null,"guestLimit":null,"poster":null,"links":null},"meta":{"command":"events.get","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want reviewed nullable event detail", result)
 	}
@@ -880,6 +880,70 @@ func TestExecuteEventsGetMapsOnlyReviewedFailuresAndObjectVariants(t *testing.T)
 				}
 			}
 		})
+	}
+}
+
+func TestExecuteRSVPGetProjectsReviewedGuestWithoutPrivateIdentifiers(t *testing.T) {
+	const (
+		privateGuestID = "private-guest-id"
+		privateUserID  = "private-user-id"
+		privateName    = "Private Guest Name"
+	)
+	requestCount := 0
+	result := app.Execute(context.Background(), app.Request{
+		Argv: []string{"rsvp", "get", "event-example"},
+	}, app.Dependencies{
+		Files: fakeFilesystem{
+			readFile: func(string) ([]byte, error) {
+				return []byte(
+					`{"accessToken":"private-access-token","userId":"private-account","expiresAt":"2026-08-12T02:00:00Z"}`,
+				), nil
+			},
+		},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 12, 0, 0, 0, 0, time.UTC)
+		},
+		AuthRandom: strings.NewReader("0123456789abcdef"),
+		HTTP: scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+			requestCount++
+			if request.Method != http.MethodPost ||
+				request.URL.String() != "https://api.partiful.com/getCurrentGuest" {
+				t.Fatalf("request = %s %s, want reviewed current-guest operation", request.Method, request.URL)
+			}
+			body, err := io.ReadAll(request.Body)
+			if err != nil {
+				t.Fatalf("read request body: %v", err)
+			}
+			const wantBody = `{"data":{"params":{"eventId":"event-example"},"amplitudeDeviceId":"MDEyMzQ1Njc4OWFiY2RlZg"}}`
+			if string(body) != wantBody {
+				t.Fatalf("request body = %s, want %s", body, wantBody)
+			}
+			return jsonResponse(
+				http.StatusOK,
+				`{"result":{"data":{"currentGuest":{"id":"`+privateGuestID+`","count":2,"status":"APPROVED","name":"`+privateName+`","plusOnes":null,"userId":"`+privateUserID+`"}}}}`,
+			), nil
+		}},
+	})
+
+	if result.ExitCode != 0 ||
+		!strings.Contains(result.Stdout, `"data":{"eventId":"event-example","status":"approved"}`) ||
+		result.Stderr != "" {
+		t.Fatalf("result = %#v, want reviewed RSVP projection", result)
+	}
+	if requestCount != 1 {
+		t.Fatalf("request count = %d, want one current-guest read", requestCount)
+	}
+	for _, privateValue := range []string{
+		privateGuestID,
+		privateUserID,
+		privateName,
+		"private-account",
+		"private-access-token",
+	} {
+		if strings.Contains(result.Stdout+result.Stderr, privateValue) {
+			t.Fatalf("output exposed private value %q", privateValue)
+		}
 	}
 }
 
@@ -1051,7 +1115,7 @@ func TestExecutePostersListReturnsFirstLocalPage(t *testing.T) {
 		}},
 	}))
 
-	const want = `{"ok":true,"data":{"items":[{"posterId":"first","name":"First","url":"https://example.invalid/first.png","contentType":"image/png","width":1200,"height":630,"tags":["party"],"categories":["fun"]},{"posterId":"duplicate","name":"Duplicate","url":"https://example.invalid/duplicate.gif","contentType":"image/gif","width":null,"height":null,"tags":["dance"],"categories":[]},{"posterId":"duplicate","name":"Duplicate Again","url":"https://example.invalid/duplicate-2.gif","contentType":"image/gif","width":640,"height":480,"tags":[],"categories":["night"]}]},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
+	const want = `{"ok":true,"data":{"items":[{"posterId":"first","name":"First","url":"https://example.invalid/first.png","contentType":"image/png","width":1200,"height":630,"tags":["party"],"categories":["fun"]},{"posterId":"duplicate","name":"Duplicate","url":"https://example.invalid/duplicate.gif","contentType":"image/gif","width":null,"height":null,"tags":["dance"],"categories":[]},{"posterId":"duplicate","name":"Duplicate Again","url":"https://example.invalid/duplicate-2.gif","contentType":"image/gif","width":640,"height":480,"tags":[],"categories":["night"]}]},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -1457,7 +1521,7 @@ func TestExecutePostersListRejectsCursorWhenPayloadChanges(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, dependencies)
 
-	const want = `{"ok":false,"error":{"type":"state.conflict","code":"CURSOR_SNAPSHOT_CHANGED","message":"The poster catalog changed after this cursor was issued.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"state.conflict","code":"CURSOR_SNAPSHOT_CHANGED","message":"The poster catalog changed after this cursor was issued.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
 	if result.ExitCode != 6 {
 		t.Fatalf("exit code = %d, want 6", result.ExitCode)
 	}
@@ -1602,7 +1666,7 @@ func TestExecutePostersListRejectsUnexpectedSuccessContentType(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
 	const wantStderr = "partiful: poster catalog protocol changed\n"
 	if result.ExitCode != 9 {
 		t.Fatalf("exit code = %d, want 9", result.ExitCode)
@@ -1628,7 +1692,7 @@ func TestExecutePostersListRejectsMalformedCursorBeforeRemoteFailure(t *testing.
 		}},
 	}))
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_INVALID","message":"The cursor is malformed.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_INVALID","message":"The cursor is malformed.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -1683,7 +1747,7 @@ func TestExecutePostersSearchRejectsCursorWithDifferentNormalizedFilter(t *testi
 		Stdin: strings.NewReader(""),
 	}, dependencies)
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_FILTER_MISMATCH","message":"The cursor does not match this command and filters.","retryable":false,"details":{}},"meta":{"command":"posters.search","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_FILTER_MISMATCH","message":"The cursor does not match this command and filters.","retryable":false,"details":{}},"meta":{"command":"posters.search","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -1706,7 +1770,7 @@ func TestExecutePostersListMapsNetworkFailureToRemoteUnavailable(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"remote.unavailable","code":"POSTER_CATALOG_UNAVAILABLE","message":"The poster catalog is unavailable.","retryable":true,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"remote.unavailable","code":"POSTER_CATALOG_UNAVAILABLE","message":"The poster catalog is unavailable.","retryable":true,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
 	const wantStderr = "partiful: poster catalog unavailable\n"
 	if result.ExitCode != 8 {
 		t.Fatalf("exit code = %d, want 8", result.ExitCode)
@@ -1736,7 +1800,7 @@ func TestExecutePostersListFailsClosedOnReceivedNon200(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
 	const wantStderr = "partiful: poster catalog protocol changed\n"
 	if result.ExitCode != 9 {
 		t.Fatalf("exit code = %d, want 9", result.ExitCode)
@@ -1814,7 +1878,7 @@ func TestExecutePostersListFailsClosedOnMalformed200Body(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
 	if result.ExitCode != 9 {
 		t.Fatalf("exit code = %d, want 9", result.ExitCode)
 	}
@@ -1879,7 +1943,7 @@ func TestExecutePostersListRequiresMaxItemsWithAll(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"MAX_ITEMS_REQUIRED","message":"--all requires --max-items.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"MAX_ITEMS_REQUIRED","message":"--all requires --max-items.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -1901,7 +1965,7 @@ func TestExecutePostersListRejectsLimitWithAll(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"LIMIT_WITH_ALL","message":"--limit cannot be combined with --all.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"LIMIT_WITH_ALL","message":"--limit cannot be combined with --all.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -1919,7 +1983,7 @@ func TestExecutePostersListRejectsLimitAboveMaximum(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"LIMIT_INVALID","message":"Limit must be an integer from 1 to 100.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"LIMIT_INVALID","message":"Limit must be an integer from 1 to 100.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -1934,7 +1998,7 @@ func TestExecutePostersListRejectsEmptyCursor(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_INVALID","message":"The cursor is malformed.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_INVALID","message":"The cursor is malformed.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -1952,7 +2016,7 @@ func TestExecutePostersSearchRequiresNonEmptyQuery(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"QUERY_REQUIRED","message":"Search query must not be empty.","retryable":false,"details":{}},"meta":{"command":"posters.search","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"QUERY_REQUIRED","message":"Search query must not be empty.","retryable":false,"details":{}},"meta":{"command":"posters.search","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -1967,7 +2031,7 @@ func TestExecuteVersion(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":true,"data":{"version":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1"},"meta":{"command":"version","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"version":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"},"meta":{"command":"version","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -1985,7 +2049,7 @@ func TestExecuteEventsListRequiresWhen(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"WHEN_INVALID","message":"--when must be upcoming or past.","retryable":false,"details":{}},"meta":{"command":"events.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"WHEN_INVALID","message":"--when must be upcoming or past.","retryable":false,"details":{}},"meta":{"command":"events.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -2007,14 +2071,14 @@ func TestExecutePrettyPrintsOneCompleteEnvelope(t *testing.T) {
   "ok": true,
   "data": {
     "version": "1.0.0",
-    "productContractRevision": "2026-08-12.1",
-    "remoteContractRevision": "2026-08-12.1"
+    "productContractRevision": "2026-08-12.3",
+    "remoteContractRevision": "2026-08-12.3"
   },
   "meta": {
     "command": "version",
     "cliVersion": "1.0.0",
-    "productContractRevision": "2026-08-12.1",
-    "remoteContractRevision": "2026-08-12.1",
+    "productContractRevision": "2026-08-12.3",
+    "remoteContractRevision": "2026-08-12.3",
     "warnings": []
   }
 }
@@ -2036,7 +2100,7 @@ func TestExecuteAcceptsNonInteractiveGlobalFlag(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":true,"data":{"version":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1"},"meta":{"command":"version","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"version":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"},"meta":{"command":"version","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -2068,8 +2132,8 @@ func TestExecuteRejectsRepeatedScalarFlag(t *testing.T) {
   "meta": {
     "command": "version",
     "cliVersion": "1.0.0",
-    "productContractRevision": "2026-08-12.1",
-    "remoteContractRevision": "2026-08-12.1"
+    "productContractRevision": "2026-08-12.3",
+    "remoteContractRevision": "2026-08-12.3"
   }
 }
 `
@@ -2090,7 +2154,7 @@ func TestExecuteSchemaListsOnlyCompletedCatalog(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":true,"data":{"commands":["auth.login","auth.logout","auth.status","contacts.list","doctor","events.get","events.list","posters.list","posters.search","schema","version"]},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"commands":["auth.login","auth.logout","auth.status","contacts.list","doctor","events.get","events.list","posters.list","posters.search","rsvp.get","rsvp.set","schema","version"]},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -2108,7 +2172,7 @@ func TestExecuteSchemaProjectsExecutableDefinition(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":true,"data":{"command":"auth.status","positionals":[],"flags":[],"inputSchema":{"type":"object","additionalProperties":false},"successSchema":{"type":"object","additionalProperties":false,"required":["authenticated","tokenState","expiresAt"],"properties":{"authenticated":{"type":"boolean"},"expiresAt":{"type":["string","null"],"format":"date-time"},"tokenState":{"type":"string","enum":["healthy","expiring","expired","missing"]}}},"failureTypes":["usage.invalid","input.invalid","auth.expired","remote.unavailable","contract.protocol_changed","internal.failure"],"safety":{"kind":"local-mutation","planRequired":false,"confirmationRequired":false}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"command":"auth.status","positionals":[],"flags":[],"inputSchema":{"type":"object","additionalProperties":false},"successSchema":{"type":"object","additionalProperties":false,"required":["authenticated","tokenState","expiresAt"],"properties":{"authenticated":{"type":"boolean"},"expiresAt":{"type":["string","null"],"format":"date-time"},"tokenState":{"type":"string","enum":["healthy","expiring","expired","missing"]}}},"failureTypes":["usage.invalid","input.invalid","auth.expired","remote.unavailable","contract.protocol_changed","internal.failure"],"safety":{"kind":"local-mutation","planRequired":false,"confirmationRequired":false}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -2166,7 +2230,7 @@ func TestExecuteRejectsUnknownSchemaPathWithoutEchoingInput(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_SCHEMA_NOT_FOUND","message":"No completed command has that schema path.","retryable":false,"details":{}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_SCHEMA_NOT_FOUND","message":"No completed command has that schema path.","retryable":false,"details":{}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -2197,7 +2261,7 @@ func TestExecuteAuthStatusWhenCredentialsAreMissing(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"missing","expiresAt":null},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"missing","expiresAt":null},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -2215,7 +2279,7 @@ func TestExecuteAuthLoginRequiresPrivateTerminal(t *testing.T) {
 		Stdin: strings.NewReader("private-stdin-value"),
 	}, app.Dependencies{})
 
-	const wantStdout = `{"ok":false,"error":{"type":"auth.human_required","code":"PRIVATE_TERMINAL_REQUIRED","message":"Authentication login requires a private terminal.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"auth.human_required","code":"PRIVATE_TERMINAL_REQUIRED","message":"Authentication login requires a private terminal.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
 	const wantStderr = "partiful: private terminal required\n"
 	if result.ExitCode != 3 {
 		t.Fatalf("exit code = %d, want 3", result.ExitCode)
@@ -2274,7 +2338,7 @@ func TestExecuteAuthLoginRejectsEmptyPrivateInputBeforeHTTP(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"input.invalid","code":"AUTH_INPUT_INVALID","message":"Authentication input is invalid.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"input.invalid","code":"AUTH_INPUT_INVALID","message":"Authentication input is invalid.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
 	if result.ExitCode != 2 || result.Stdout != wantStdout {
 		t.Fatalf("result = %#v, want invalid private input failure", result)
 	}
@@ -2416,7 +2480,7 @@ func TestExecuteAuthLoginPersistsReviewedSessionWithoutRevealingPrivateValues(t 
 		}},
 	})
 
-	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T01:10:00Z"},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T01:10:00Z"},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want redacted login success", result)
 	}
@@ -2489,7 +2553,7 @@ func TestExecuteAuthLoginMapsReviewedWrongCodeWithoutEchoingIt(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"input.invalid","code":"AUTH_CODE_REJECTED","message":"The verification code was rejected.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"input.invalid","code":"AUTH_CODE_REJECTED","message":"The verification code was rejected.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
 	const wantStderr = "partiful: authentication code rejected\n"
 	if result.ExitCode != 2 || result.Stdout != wantStdout || result.Stderr != wantStderr {
 		t.Fatalf("result = %#v, want reviewed wrong-code failure", result)
@@ -2630,7 +2694,7 @@ func TestExecuteAuthLoginMapsRejectedCustomTokenToExpired(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"INVALID_CUSTOM_TOKEN","message":"Authentication expired during login. Start login again.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"INVALID_CUSTOM_TOKEN","message":"Authentication expired during login. Start login again.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
 	const wantStderr = "partiful: authentication expired\n"
 	if result.ExitCode != 3 || result.Stdout != wantStdout || result.Stderr != wantStderr {
 		t.Fatalf("result = %#v, want reviewed custom-token failure", result)
@@ -2817,7 +2881,7 @@ func TestExecuteAuthLoginFailsClosedOnMalformedReviewedSuccess(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"AUTH_PROTOCOL_CHANGED","message":"Authentication no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"AUTH_PROTOCOL_CHANGED","message":"Authentication no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
 	const wantStderr = "partiful: authentication protocol changed\n"
 	if result.ExitCode != 9 || result.Stdout != wantStdout || result.Stderr != wantStderr {
 		t.Fatalf("result = %#v, want protocol drift failure", result)
@@ -2914,7 +2978,7 @@ func TestExecuteAuthLoginMapsNoResponseWithoutLeakingTransportError(t *testing.T
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"remote.unavailable","code":"AUTH_SERVICE_UNAVAILABLE","message":"The authentication service is unavailable.","retryable":true,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"remote.unavailable","code":"AUTH_SERVICE_UNAVAILABLE","message":"The authentication service is unavailable.","retryable":true,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
 	const wantStderr = "partiful: authentication service unavailable\n"
 	if result.ExitCode != 8 || result.Stdout != wantStdout || result.Stderr != wantStderr {
 		t.Fatalf("result = %#v, want auth unavailable failure", result)
@@ -2968,7 +3032,7 @@ func TestExecuteAuthLoginAtomicPersistenceFailurePreservesExistingCredentials(t 
 		Argv: []string{"auth", "login"},
 	}, dependencies)
 
-	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIAL_STORE_UNAVAILABLE","message":"Local credential storage is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIAL_STORE_UNAVAILABLE","message":"Local credential storage is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
 	if result.ExitCode != 10 || result.Stdout != wantStdout {
 		t.Fatalf("result = %#v, want atomic persistence failure", result)
 	}
@@ -3080,7 +3144,7 @@ func TestExecuteContactsListTraversesReviewedPagesAndReturnsOnlyPublicFields(t *
 		}},
 	})
 
-	const want = `{"ok":true,"data":{"items":[{"displayName":"Alice Example","sharedEventCount":2}]},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
+	const want = `{"ok":true,"data":{"items":[{"displayName":"Alice Example","sharedEventCount":2}]},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
 	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want reviewed public contact collection", result)
 	}
@@ -3135,7 +3199,7 @@ func TestExecuteContactsListFiltersLocallyAfterFirstIdentityOccurrenceWins(t *te
 		}},
 	})
 
-	const want = `{"ok":true,"data":{"items":[{"displayName":"Alice First","sharedEventCount":1},{"displayName":"Second ALICE","sharedEventCount":3}]},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
+	const want = `{"ok":true,"data":{"items":[{"displayName":"Alice First","sharedEventCount":1},{"displayName":"Second ALICE","sharedEventCount":3}]},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
 	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want locally filtered first-occurrence contacts", result)
 	}
@@ -3445,7 +3509,7 @@ func TestExecuteContactsListAcceptsOpenReviewedResponseFields(t *testing.T) {
 		}},
 	})
 
-	const want = `{"ok":true,"data":{"items":[{"displayName":"Open Contact","sharedEventCount":4}]},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
+	const want = `{"ok":true,"data":{"items":[{"displayName":"Open Contact","sharedEventCount":4}]},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
 	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want reviewed open response traversal", result)
 	}
@@ -3558,7 +3622,7 @@ func TestExecuteContactsListAcceptsUnknownUnauthenticatedErrorFields(t *testing.
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"REMOTE_SESSION_UNAUTHENTICATED","message":"Stored authentication is no longer accepted. Log in again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"REMOTE_SESSION_UNAUTHENTICATED","message":"Stored authentication is no longer accepted. Log in again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
 	if result.ExitCode != 3 || result.Stdout != wantStdout {
 		t.Fatalf("result = %#v, want reviewed unauthenticated mapping", result)
 	}
@@ -3591,7 +3655,7 @@ func TestExecuteContactsListMapsReviewedUnauthenticatedResponseToExpired(t *test
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"REMOTE_SESSION_UNAUTHENTICATED","message":"Stored authentication is no longer accepted. Log in again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"REMOTE_SESSION_UNAUTHENTICATED","message":"Stored authentication is no longer accepted. Log in again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
 	if result.ExitCode != 3 || result.Stdout != wantStdout {
 		t.Fatalf("result = %#v, want reviewed unauthenticated mapping", result)
 	}
@@ -3727,7 +3791,7 @@ func TestExecuteContactsListRejectsCursorWhenContactCatalogChanges(t *testing.T)
 		Stdin: strings.NewReader(""),
 	}, dependencies)
 
-	const want = `{"ok":false,"error":{"type":"state.conflict","code":"CURSOR_SNAPSHOT_CHANGED","message":"The contact catalog changed after this cursor was issued.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"state.conflict","code":"CURSOR_SNAPSHOT_CHANGED","message":"The contact catalog changed after this cursor was issued.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
 	if result.ExitCode != 6 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want contact snapshot conflict", result)
 	}
@@ -3873,7 +3937,7 @@ func TestExecuteContactsListMapsRejectedRefreshWithoutAttemptingRead(t *testing.
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"INVALID_REFRESH_TOKEN","message":"Stored authentication has expired. Log in again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"INVALID_REFRESH_TOKEN","message":"Stored authentication has expired. Log in again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
 	if result.ExitCode != 3 || result.Stdout != wantStdout {
 		t.Fatalf("result = %#v, want rejected refresh failure", result)
 	}
@@ -3934,7 +3998,7 @@ func TestExecuteContactsListReportsUnavailableConfigurationBeforeProtectedRead(t
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CONFIG_DIRECTORY_UNAVAILABLE","message":"Local configuration directory is unavailable.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CONFIG_DIRECTORY_UNAVAILABLE","message":"Local configuration directory is unavailable.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
 	if result.ExitCode != 10 || result.Stdout != wantStdout {
 		t.Fatalf("result = %#v, want unavailable configuration failure", result)
 	}
@@ -3963,7 +4027,7 @@ func TestExecuteContactsListRequiresAuthenticationWithoutRemoteCall(t *testing.T
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"auth.required","code":"AUTHENTICATION_REQUIRED","message":"Authentication is required. Log in and try again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"auth.required","code":"AUTHENTICATION_REQUIRED","message":"Authentication is required. Log in and try again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
 	if result.ExitCode != 3 || result.Stdout != wantStdout {
 		t.Fatalf("result = %#v, want authentication requirement", result)
 	}
@@ -4114,7 +4178,7 @@ func TestExecuteAuthStatusRedactsHealthyCredentials(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T02:00:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T02:00:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -4148,7 +4212,7 @@ func TestExecuteAuthStatusReportsExpiringToken(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"expiring","expiresAt":"2026-08-11T00:04:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"expiring","expiresAt":"2026-08-11T00:04:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -4223,7 +4287,7 @@ func TestExecuteAuthStatusDeterministicallyRefreshesExpiringSession(t *testing.T
 	first := app.Execute(context.Background(), app.Request{
 		Argv: []string{"auth", "status"},
 	}, dependencies)
-	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T01:10:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T01:10:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[]}}` + "\n"
 	if first.ExitCode != 0 || first.Stdout != want || first.Stderr != "" {
 		t.Fatalf("first status = %#v, want refreshed healthy session", first)
 	}
@@ -4397,7 +4461,7 @@ func TestExecuteAuthStatusMapsReviewedInvalidRefreshTokenToExpired(t *testing.T)
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"INVALID_REFRESH_TOKEN","message":"Stored authentication has expired. Log in again.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"INVALID_REFRESH_TOKEN","message":"Stored authentication has expired. Log in again.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
 	const wantStderr = "partiful: authentication expired\n"
 	if result.ExitCode != 3 || result.Stdout != wantStdout || result.Stderr != wantStderr {
 		t.Fatalf("result = %#v, want reviewed invalid-refresh failure", result)
@@ -4516,7 +4580,7 @@ func TestExecuteAuthStatusReportsExpiredToken(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"expired","expiresAt":"2026-08-10T23:59:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"expired","expiresAt":"2026-08-10T23:59:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -4545,7 +4609,7 @@ func TestExecuteAuthStatusFailureDoesNotRevealCredentialContents(t *testing.T) {
 		},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIALS_INVALID","message":"Local credentials are invalid.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIALS_INVALID","message":"Local credentials are invalid.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
 	const wantStderr = "partiful: local operation failed\n"
 	if result.ExitCode != 10 {
 		t.Fatalf("exit code = %d, want 10", result.ExitCode)
@@ -4581,7 +4645,7 @@ func TestExecuteAuthLogoutAtomicallyRemovesCredentials(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, dependencies)
 
-	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"missing","expiresAt":null},"meta":{"command":"auth.logout","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"missing","expiresAt":null},"meta":{"command":"auth.logout","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -4660,7 +4724,7 @@ func TestExecuteAuthLogoutFailureLeavesCredentialsAvailableAndRedactsError(t *te
 		Stdin: strings.NewReader(""),
 	}, dependencies)
 
-	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIAL_STORE_UNAVAILABLE","message":"Local credential storage is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.logout","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIAL_STORE_UNAVAILABLE","message":"Local credential storage is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.logout","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
 	if result.ExitCode != 10 {
 		t.Fatalf("exit code = %d, want 10", result.ExitCode)
 	}
@@ -4697,7 +4761,7 @@ func TestExecuteDoctorReportsHealthyCredentialsWithoutPrivateData(t *testing.T) 
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":true,"checks":[{"name":"credentials","status":"pass","message":"Authentication credentials are available.","remediation":null}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":true,"checks":[{"name":"credentials","status":"pass","message":"Authentication credentials are available.","remediation":null}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -4730,7 +4794,7 @@ func TestExecuteDoctorReportsMissingCredentialsAsARedactedCheck(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials are missing.","remediation":"Establish authentication before using commands that require it."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials are missing.","remediation":"Establish authentication before using commands that require it."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -4759,7 +4823,7 @@ func TestExecuteDoctorWarnsWhenCredentialsExpireSoon(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":true,"checks":[{"name":"credentials","status":"warn","message":"Authentication credentials expire soon.","remediation":"Refresh authentication before the credentials expire."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":true,"checks":[{"name":"credentials","status":"warn","message":"Authentication credentials expire soon.","remediation":"Refresh authentication before the credentials expire."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -4788,7 +4852,7 @@ func TestExecuteDoctorFailsExpiredCredentialsCheck(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials have expired.","remediation":"Re-establish authentication."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials have expired.","remediation":"Re-establish authentication."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -4817,7 +4881,7 @@ func TestExecuteDoctorRedactsInvalidCredentialFile(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials are invalid.","remediation":"Remove the invalid credentials and re-establish authentication."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials are invalid.","remediation":"Remove the invalid credentials and re-establish authentication."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -4849,7 +4913,7 @@ func TestExecuteDoctorRedactsCredentialStorageFailure(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Credential storage is unavailable.","remediation":"Check local credential file permissions."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Credential storage is unavailable.","remediation":"Check local credential file permissions."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -4933,7 +4997,7 @@ func TestExecuteSchemaDescribesBothDiscoveryResultShapes(t *testing.T) {
 						"additionalProperties": false,
 						"required": ["kind", "planRequired", "confirmationRequired"],
 						"properties": {
-							"kind": {"type": "string", "enum": ["read-only", "local-mutation"]},
+							"kind": {"type": "string", "enum": ["read-only", "local-mutation", "standard-mutation"]},
 							"planRequired": {"type": "boolean"},
 							"confirmationRequired": {"type": "boolean"}
 						}
@@ -4957,7 +5021,7 @@ func TestExecuteUsesDefinitionForFlagFailureCommandMetadata(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"FLAG_REPEATED","message":"A scalar flag cannot be repeated.","retryable":false,"details":{"flag":"--non-interactive"}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"FLAG_REPEATED","message":"A scalar flag cannot be repeated.","retryable":false,"details":{"flag":"--non-interactive"}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -5001,7 +5065,7 @@ func TestExecuteUsesKnownCommandMetadataForInvalidArity(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_NOT_FOUND","message":"Unknown command.","retryable":false,"details":{}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_NOT_FOUND","message":"Unknown command.","retryable":false,"details":{}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -5026,7 +5090,7 @@ func TestExecuteAuthStatusReportsConfigurationDirectoryFailure(t *testing.T) {
 		},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CONFIG_DIRECTORY_UNAVAILABLE","message":"Local configuration directory is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CONFIG_DIRECTORY_UNAVAILABLE","message":"Local configuration directory is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
 	if result.ExitCode != 10 {
 		t.Fatalf("exit code = %d, want 10", result.ExitCode)
 	}
@@ -5051,7 +5115,7 @@ func TestExecuteDoctorDiagnosesConfigurationDirectoryFailure(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Configuration directory is unavailable.","remediation":"Set a usable user configuration directory."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.1","remoteContractRevision":"2026-08-12.1","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Configuration directory is unavailable.","remediation":"Set a usable user configuration directory."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}

--- a/internal/app/rsvp.go
+++ b/internal/app/rsvp.go
@@ -1,0 +1,83 @@
+package app
+
+import (
+	"context"
+	"errors"
+
+	"github.com/KalebCole/partiful-cli/internal/remote"
+)
+
+type rsvpRead struct {
+	EventID string  `json:"eventId"`
+	Status  *string `json:"status"`
+}
+
+func executeRSVPGet(
+	ctx context.Context,
+	definition commandDefinition,
+	argv []string,
+	dependencies Dependencies,
+	pretty bool,
+) Result {
+	eventID, inputError := parseEventID(definition, argv)
+	if inputError != nil {
+		return failure(definition.path, 2, *inputError, pretty)
+	}
+	session, sessionFailure := acquireProtectedSession(
+		ctx,
+		definition.path,
+		dependencies,
+		pretty,
+	)
+	if sessionFailure != nil {
+		return *sessionFailure
+	}
+	deviceID, err := randomDeviceID(dependencies.AuthRandom)
+	if err != nil {
+		return internalFailure(definition.path, pretty)
+	}
+	guest, err := (remote.Client{HTTP: dependencies.HTTP}).GetCurrentGuest(
+		ctx,
+		session.AccessToken,
+		deviceID,
+		eventID,
+	)
+	if err != nil {
+		if errors.Is(err, remote.ErrUnavailable) {
+			return rsvpUnavailableFailure(definition.path, pretty)
+		}
+		return rsvpProtocolChangedFailure(definition.path, pretty)
+	}
+	var status *string
+	if guest.Present {
+		status, err = projectEventRSVP(&guest.Status)
+		if err != nil {
+			return rsvpProtocolChangedFailure(definition.path, pretty)
+		}
+	}
+	return success(definition.path, rsvpRead{EventID: eventID, Status: status}, pretty)
+}
+
+func rsvpUnavailableFailure(command string, pretty bool) Result {
+	result := failure(command, 8, errorBody{
+		Type:      "remote.unavailable",
+		Code:      "RSVP_UNAVAILABLE",
+		Message:   "The RSVP is unavailable.",
+		Retryable: true,
+		Details:   map[string]any{},
+	}, pretty)
+	result.Stderr = "partiful: RSVP unavailable\n"
+	return result
+}
+
+func rsvpProtocolChangedFailure(command string, pretty bool) Result {
+	result := failure(command, 9, errorBody{
+		Type:      "contract.protocol_changed",
+		Code:      "RSVP_PROTOCOL_CHANGED",
+		Message:   "The RSVP no longer matches the reviewed remote contract.",
+		Retryable: false,
+		Details:   map[string]any{},
+	}, pretty)
+	result.Stderr = "partiful: RSVP protocol changed\n"
+	return result
+}

--- a/internal/app/rsvp_execute_test.go
+++ b/internal/app/rsvp_execute_test.go
@@ -1,0 +1,1496 @@
+package app_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KalebCole/partiful-cli/internal/app"
+)
+
+func TestExecuteRSVPGetReturnsExplicitNoRSVPAndFailsClosedOnOtherVariants(t *testing.T) {
+	cases := []struct {
+		name        string
+		body        string
+		remoteError error
+		exitCode    int
+		contains    string
+	}{
+		{
+			name:     "explicit null",
+			body:     `{"result":{"data":{"currentGuest":null}}}`,
+			exitCode: 0,
+			contains: `"data":{"eventId":"event-example","status":null}`,
+		},
+		{
+			name:     "missing current guest",
+			body:     `{"result":{"data":{}}}`,
+			exitCode: 9,
+			contains: `"type":"contract.protocol_changed"`,
+		},
+		{
+			name:     "scalar current guest",
+			body:     `{"result":{"data":{"currentGuest":"private scalar"}}}`,
+			exitCode: 9,
+			contains: `"type":"contract.protocol_changed"`,
+		},
+		{
+			name:     "missing private identity",
+			body:     `{"result":{"data":{"currentGuest":{"status":"GOING"}}}}`,
+			exitCode: 9,
+			contains: `"type":"contract.protocol_changed"`,
+		},
+		{
+			name:     "unreviewed status",
+			body:     `{"result":{"data":{"currentGuest":{"id":"private-id","status":"UNKNOWN"}}}}`,
+			exitCode: 9,
+			contains: `"type":"contract.protocol_changed"`,
+		},
+		{
+			name:        "transport unavailable",
+			remoteError: errors.New("private transport failure"),
+			exitCode:    8,
+			contains:    `"type":"remote.unavailable"`,
+		},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			dependencies := rsvpTestDependencies(&memoryFilesystem{files: map[string][]byte{
+				rsvpCredentialsPath: []byte(rsvpCredentials),
+			}})
+			dependencies.HTTP = scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
+				if testCase.remoteError != nil {
+					return nil, testCase.remoteError
+				}
+				return jsonResponse(http.StatusOK, testCase.body), nil
+			}}
+
+			result := app.Execute(context.Background(), app.Request{
+				Argv: []string{"rsvp", "get", "event-example"},
+			}, dependencies)
+
+			if result.ExitCode != testCase.exitCode ||
+				!strings.Contains(result.Stdout, testCase.contains) {
+				t.Fatalf("result = %#v, want exit %d containing %q", result, testCase.exitCode, testCase.contains)
+			}
+			for _, privateValue := range []string{
+				"private scalar",
+				"private-id",
+				"private transport failure",
+				"private-account",
+				"private-access-token",
+			} {
+				if strings.Contains(result.Stdout+result.Stderr, privateValue) {
+					t.Fatalf("output exposed private value %q", privateValue)
+				}
+			}
+		})
+	}
+}
+
+func TestExecuteRSVPCommandsRequireAuthenticationBeforeRemoteAccess(t *testing.T) {
+	for _, argv := range [][]string{
+		{"rsvp", "get", "event-example"},
+		{"rsvp", "set", "event-example", "--status", "interested"},
+	} {
+		t.Run(strings.Join(argv[:2], " "), func(t *testing.T) {
+			httpCalled := false
+			result := app.Execute(
+				context.Background(),
+				app.Request{Argv: argv},
+				app.Dependencies{
+					Files:           &memoryFilesystem{files: map[string][]byte{}},
+					CredentialsPath: rsvpCredentialsPath,
+					Now: func() time.Time {
+						return time.Date(2026, time.August, 12, 0, 0, 0, 0, time.UTC)
+					},
+					HTTP: scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
+						httpCalled = true
+						return nil, errors.New("must not call HTTP")
+					}},
+				},
+			)
+			if result.ExitCode != 3 ||
+				!strings.Contains(result.Stdout, `"type":"auth.required"`) ||
+				httpCalled {
+				t.Fatalf("result = %#v, HTTP = %t, want protected command", result, httpCalled)
+			}
+		})
+	}
+}
+
+func TestExecuteRSVPSetPlansNormalizedGoingCreateWithoutMutation(t *testing.T) {
+	files := &memoryFilesystem{files: map[string][]byte{
+		rsvpCredentialsPath: []byte(rsvpCredentials),
+	}}
+	dependencies := rsvpTestDependencies(files)
+	dependencies.MutationRandom = strings.NewReader(strings.Repeat("p", 32))
+	call := 0
+	dependencies.HTTP = scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+		call++
+		switch call {
+		case 1:
+			assertRSVPRequest(
+				t,
+				request,
+				"getEventInfo",
+				`{"data":{"params":{"eventId":"event-example"},"amplitudeDeviceId":"MDEyMzQ1Njc4OWFiY2RlZg"}}`,
+			)
+			return jsonResponse(http.StatusOK, `{"result":{"data":{"event":{
+				"rsvpsEnabled":true,
+				"atCapacity":false,
+				"plusOneNamesRequired":true,
+				"questionnaireEnabled":false,
+				"questionnaireVersions":null,
+				"ticketing":null,
+				"guestAction":"RSVP",
+				"maxCountPerGuest":4,
+				"maxCapacity":50,
+				"remainingCapacity":3,
+				"enableWaitlist":false
+			}}}}`), nil
+		case 2:
+			assertRSVPRequest(
+				t,
+				request,
+				"getCurrentGuest",
+				`{"data":{"params":{"eventId":"event-example"},"amplitudeDeviceId":"MDEyMzQ1Njc4OWFiY2RlZg"}}`,
+			)
+			return jsonResponse(
+				http.StatusOK,
+				`{"result":{"data":{"currentGuest":null}}}`,
+			), nil
+		default:
+			t.Fatalf("unexpected mutation request %d: %s", call, request.URL)
+			return nil, nil
+		}
+	}}
+
+	result := app.Execute(context.Background(), app.Request{
+		Argv: []string{
+			"rsvp", "set", "event-example",
+			"--status", "going",
+			"--display-name", "  Example Attendee  ",
+			"--party-size", "2",
+			"--plus-one", "  Guest One  ",
+			"--message", "  See you there  ",
+			"--timezone", "America/Los_Angeles",
+		},
+	}, dependencies)
+
+	if result.ExitCode != 0 || result.Stderr != "" {
+		t.Fatalf("result = %#v, want plan success", result)
+	}
+	var envelope struct {
+		Data struct {
+			Operation string `json:"operation"`
+			Mode      string `json:"mode"`
+			Input     struct {
+				Status                string   `json:"status"`
+				DisplayName           string   `json:"displayName"`
+				PartySize             int      `json:"partySize"`
+				PlusOnes              []string `json:"plusOnes"`
+				Message               *string  `json:"message"`
+				Timezone              string   `json:"timezone"`
+				QuestionnaireResponse any      `json:"questionnaireResponse"`
+			} `json:"input"`
+			Request struct {
+				EventID string `json:"eventId"`
+				RSVP    struct {
+					Name             string           `json:"name"`
+					Count            int              `json:"count"`
+					PlusOnes         []map[string]any `json:"plusOnes"`
+					Message          string           `json:"message"`
+					Status           string           `json:"status"`
+					Timezone         string           `json:"timezone"`
+					ShouldFollowOrgs bool             `json:"shouldFollowOrgs"`
+					GuestID          any              `json:"guestId"`
+				} `json:"rsvp"`
+			} `json:"request"`
+			Preconditions struct {
+				CurrentGuest    string `json:"currentGuest"`
+				EventSafeguards string `json:"eventSafeguards"`
+			} `json:"preconditions"`
+			ExpiresInSeconds int    `json:"expiresInSeconds"`
+			PlanToken        string `json:"planToken"`
+		} `json:"data"`
+	}
+	if json.Unmarshal([]byte(result.Stdout), &envelope) != nil {
+		t.Fatalf("decode result: %s", result.Stdout)
+	}
+	if envelope.Data.Operation != "addGuest" ||
+		envelope.Data.Mode != "create" ||
+		envelope.Data.Input.Status != "going" ||
+		envelope.Data.Input.DisplayName != "Example Attendee" ||
+		envelope.Data.Input.PartySize != 2 ||
+		!reflect.DeepEqual(envelope.Data.Input.PlusOnes, []string{"Guest One"}) ||
+		envelope.Data.Input.Message == nil ||
+		*envelope.Data.Input.Message != "See you there" ||
+		envelope.Data.Input.Timezone != "America/Los_Angeles" ||
+		envelope.Data.Input.QuestionnaireResponse != nil {
+		t.Fatalf("plan input = %#v, want normalized exact input", envelope.Data.Input)
+	}
+	if envelope.Data.Request.EventID != "event-example" ||
+		envelope.Data.Request.RSVP.Name != "Example Attendee" ||
+		envelope.Data.Request.RSVP.Count != 2 ||
+		!reflect.DeepEqual(
+			envelope.Data.Request.RSVP.PlusOnes,
+			[]map[string]any{{"name": "Guest One"}},
+		) ||
+		envelope.Data.Request.RSVP.Message != "See you there" ||
+		envelope.Data.Request.RSVP.Status != "GOING" ||
+		envelope.Data.Request.RSVP.Timezone != "America/Los_Angeles" ||
+		envelope.Data.Request.RSVP.ShouldFollowOrgs ||
+		envelope.Data.Request.RSVP.GuestID != nil {
+		t.Fatalf("plan request = %#v, want exact redacted create request", envelope.Data.Request)
+	}
+	if envelope.Data.Preconditions.CurrentGuest != "absent" ||
+		envelope.Data.Preconditions.EventSafeguards != "bound" ||
+		envelope.Data.ExpiresInSeconds != 300 ||
+		envelope.Data.PlanToken == "" {
+		t.Fatalf("plan authority = %#v, want bound five-minute plan", envelope.Data)
+	}
+	if call != 2 {
+		t.Fatalf("request count = %d, want only two pre-reads", call)
+	}
+	if files.atomicWrites != 1 {
+		t.Fatalf("atomic writes = %d, want one persistent plan write", files.atomicWrites)
+	}
+	for _, privateValue := range []string{
+		"private-account",
+		"private-access-token",
+		"private-guest-id",
+	} {
+		if strings.Contains(result.Stdout+result.Stderr, privateValue) {
+			t.Fatalf("output exposed private value %q", privateValue)
+		}
+	}
+}
+
+func TestExecuteRSVPSetUpdatesReviewedGuestOnceAndReturnsOnlySubmittedIntent(t *testing.T) {
+	const privateGuestID = "private-existing-guest"
+	files := &memoryFilesystem{files: map[string][]byte{
+		rsvpCredentialsPath: []byte(rsvpCredentials),
+	}}
+	dependencies := rsvpTestDependencies(files)
+	dependencies.MutationRandom = strings.NewReader(strings.Repeat("u", 32))
+	call := 0
+	dependencies.HTTP = scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+		call++
+		switch call {
+		case 1, 3:
+			assertRSVPRequest(
+				t,
+				request,
+				"getEventInfo",
+				`{"data":{"params":{"eventId":"event-example"},"amplitudeDeviceId":"MDEyMzQ1Njc4OWFiY2RlZg"}}`,
+			)
+			return jsonResponse(http.StatusOK, `{"result":{"data":{"event":{
+				"rsvpsEnabled":true,
+				"atCapacity":false,
+				"plusOneNamesRequired":true,
+				"questionnaireEnabled":true,
+				"questionnaireVersions":[{},{}],
+				"ticketing":null,
+				"maxCountPerGuest":3,
+				"maxCapacity":20,
+				"remainingCapacity":1,
+				"enableWaitlist":null
+			}}}}`), nil
+		case 2, 4:
+			assertRSVPRequest(
+				t,
+				request,
+				"getCurrentGuest",
+				`{"data":{"params":{"eventId":"event-example"},"amplitudeDeviceId":"MDEyMzQ1Njc4OWFiY2RlZg"}}`,
+			)
+			return jsonResponse(
+				http.StatusOK,
+				`{"result":{"data":{"currentGuest":{"id":"`+privateGuestID+`","status":"GOING","count":1}}}}`,
+			), nil
+		case 5:
+			assertRSVPRequest(
+				t,
+				request,
+				"addGuest",
+				`{"data":{"params":{"eventId":"event-example","rsvp":{"name":"Example Attendee","count":2,"plusOnes":[{"name":"Guest One"}],"status":"GOING","guestId":"`+privateGuestID+`","timezone":"America/Los_Angeles","questionnaireResponse":{"questionnaireVersion":1,"answers":{"question-example":"Answer"}},"shouldFollowOrgs":false}},"amplitudeDeviceId":"MDEyMzQ1Njc4OWFiY2RlZg"}}`,
+			)
+			return jsonResponse(
+				http.StatusOK,
+				`{"result":{"data":{"privateUnclaimed":"must-not-be-returned"}}}`,
+			), nil
+		default:
+			t.Fatalf("unexpected post-write request %d: %s", call, request.URL)
+			return nil, nil
+		}
+	}}
+	argv := []string{
+		"rsvp", "set", "event-example",
+		"--status", "going",
+		"--display-name", "Example Attendee",
+		"--party-size", "2",
+		"--plus-one", "Guest One",
+		"--timezone", "America/Los_Angeles",
+		"--questionnaire-response",
+		`{"questionnaireVersion":1,"answers":{"question-example":"Answer"}}`,
+	}
+
+	plan := app.Execute(
+		context.Background(),
+		app.Request{Argv: argv},
+		dependencies,
+	)
+	if plan.ExitCode != 0 ||
+		!strings.Contains(plan.Stdout, `"mode":"update"`) ||
+		!strings.Contains(plan.Stdout, `"guestId":"\u003credacted\u003e"`) {
+		t.Fatalf("plan = %#v, want redacted update plan", plan)
+	}
+	if strings.Contains(plan.Stdout+plan.Stderr, privateGuestID) {
+		t.Fatal("public plan exposed the private guest ID")
+	}
+	token := rsvpPlanToken(t, plan)
+	applyArgv := append(append([]string{}, argv...), "--apply", "--plan", token)
+	applied := app.Execute(
+		context.Background(),
+		app.Request{Argv: applyArgv},
+		dependencies,
+	)
+
+	if applied.ExitCode != 0 ||
+		!strings.Contains(
+			applied.Stdout,
+			`"data":{"eventId":"event-example","intent":"going","submitted":true}`,
+		) ||
+		applied.Stderr != "" {
+		t.Fatalf("applied = %#v, want minimal submitted result", applied)
+	}
+	if call != 5 {
+		t.Fatalf("request count = %d, want four pre-reads and one mutation", call)
+	}
+	if files.atomicWrites != 2 {
+		t.Fatalf("atomic writes = %d, want plan save and pre-dispatch consume", files.atomicWrites)
+	}
+	for _, privateValue := range []string{
+		privateGuestID,
+		"private-account",
+		"private-access-token",
+		"privateUnclaimed",
+		"Example Attendee",
+		"Guest One",
+		"question-example",
+		"Answer",
+	} {
+		if strings.Contains(applied.Stdout+applied.Stderr, privateValue) {
+			t.Fatalf("applied output exposed private submitted value %q", privateValue)
+		}
+	}
+}
+
+func TestExecuteRSVPSetSubmitsInterestWithoutDisplayNameOrSource(t *testing.T) {
+	files := &memoryFilesystem{files: map[string][]byte{
+		rsvpCredentialsPath: []byte(rsvpCredentials),
+	}}
+	dependencies := rsvpTestDependencies(files)
+	dependencies.MutationRandom = strings.NewReader(strings.Repeat("i", 32))
+	call := 0
+	dependencies.HTTP = scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+		call++
+		switch call {
+		case 1, 3:
+			return jsonResponse(http.StatusOK, compatibleRSVPEventResponse), nil
+		case 2, 4:
+			return jsonResponse(
+				http.StatusOK,
+				`{"result":{"data":{"currentGuest":null}}}`,
+			), nil
+		case 5:
+			assertRSVPRequest(
+				t,
+				request,
+				"markEventInterest",
+				`{"data":{"params":{"eventId":"event-example","interested":true},"amplitudeDeviceId":"MDEyMzQ1Njc4OWFiY2RlZg"}}`,
+			)
+			return jsonResponse(
+				http.StatusOK,
+				`{"result":{"data":{"success":1e999999999,"interested":true,"privateValue":"ignored"}}}`,
+			), nil
+		default:
+			t.Fatalf("unexpected request %d: %s", call, request.URL)
+			return nil, nil
+		}
+	}}
+	argv := []string{
+		"rsvp", "set", "event-example",
+		"--status", "interested",
+	}
+
+	plan := app.Execute(context.Background(), app.Request{Argv: argv}, dependencies)
+	if plan.ExitCode != 0 ||
+		!strings.Contains(plan.Stdout, `"operation":"markEventInterest"`) ||
+		!strings.Contains(plan.Stdout, `"input":{"status":"interested"}`) ||
+		strings.Contains(plan.Stdout, "displayName") ||
+		strings.Contains(plan.Stdout, "source") {
+		t.Fatalf("plan = %#v, want narrow direct-interest request", plan)
+	}
+	token := rsvpPlanToken(t, plan)
+	applied := app.Execute(context.Background(), app.Request{
+		Argv: append(append([]string{}, argv...), "--apply", "--plan", token),
+	}, dependencies)
+	if applied.ExitCode != 0 ||
+		!strings.Contains(
+			applied.Stdout,
+			`"data":{"eventId":"event-example","intent":"interested","submitted":true}`,
+		) ||
+		call != 5 {
+		t.Fatalf("applied = %#v, calls = %d, want one accepted interest submission", applied, call)
+	}
+}
+
+func TestExecuteRSVPSetAcceptsStructuredDeclineAndRequiresNoCompletionFields(t *testing.T) {
+	const input = `{
+		"status":"not-going",
+		"displayName":"  Example  ",
+		"partySize":1,
+		"plusOnes":[],
+		"message":"   ",
+		"timezone":"America/Los_Angeles",
+		"questionnaireResponse":null
+	}`
+	files := &memoryFilesystem{files: map[string][]byte{
+		rsvpCredentialsPath: []byte(rsvpCredentials),
+	}}
+	dependencies := rsvpTestDependencies(files)
+	dependencies.MutationRandom = strings.NewReader(strings.Repeat("d", 32))
+	call := 0
+	dependencies.HTTP = scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+		call++
+		switch call {
+		case 1, 3:
+			return jsonResponse(http.StatusOK, compatibleRSVPEventResponse), nil
+		case 2, 4:
+			return jsonResponse(
+				http.StatusOK,
+				`{"result":{"data":{"currentGuest":null}}}`,
+			), nil
+		case 5:
+			assertRSVPRequest(
+				t,
+				request,
+				"addGuest",
+				`{"data":{"params":{"eventId":"event-example","rsvp":{"name":"Example","count":1,"plusOnes":[],"status":"DECLINED","timezone":"America/Los_Angeles","shouldFollowOrgs":false}},"amplitudeDeviceId":"MDEyMzQ1Njc4OWFiY2RlZg"}}`,
+			)
+			return jsonResponse(http.StatusOK, `{"result":{"data":null}}`), nil
+		default:
+			t.Fatalf("unexpected request %d: %s", call, request.URL)
+			return nil, nil
+		}
+	}}
+	argv := []string{"rsvp", "set", "event-example", "--input", "-"}
+
+	plan := app.Execute(context.Background(), app.Request{
+		Argv:  argv,
+		Stdin: strings.NewReader(input),
+	}, dependencies)
+	if plan.ExitCode != 0 ||
+		!strings.Contains(plan.Stdout, `"status":"not-going"`) ||
+		!strings.Contains(plan.Stdout, `"message":null`) ||
+		strings.Contains(plan.Stdout, "questionnaireVersion") {
+		t.Fatalf("plan = %#v, want normalized decline", plan)
+	}
+	applied := app.Execute(context.Background(), app.Request{
+		Argv: append(
+			append([]string{}, argv...),
+			"--apply",
+			"--plan",
+			rsvpPlanToken(t, plan),
+		),
+		Stdin: strings.NewReader(input),
+	}, dependencies)
+	if applied.ExitCode != 0 ||
+		!strings.Contains(
+			applied.Stdout,
+			`"data":{"eventId":"event-example","intent":"not-going","submitted":true}`,
+		) ||
+		call != 5 {
+		t.Fatalf("applied = %#v, want field-free accepted completion", applied)
+	}
+}
+
+func TestExecuteRSVPSetRejectsInvalidNormalizedInputBeforeAuthenticationOrReads(t *testing.T) {
+	valid := []string{
+		"rsvp", "set", "event-example",
+		"--status", "going",
+		"--display-name", "Example",
+		"--party-size", "1",
+		"--timezone", "America/Los_Angeles",
+	}
+	cases := []struct {
+		name  string
+		argv  []string
+		stdin string
+		code  string
+	}{
+		{
+			name: "display name required",
+			argv: []string{
+				"rsvp", "set", "event-example", "--status", "going",
+				"--party-size", "1", "--timezone", "America/Los_Angeles",
+			},
+			code: "DISPLAY_NAME_INVALID",
+		},
+		{
+			name: "display name length",
+			argv: []string{
+				"rsvp", "set", "event-example", "--status", "going",
+				"--display-name", strings.Repeat("n", 51),
+				"--party-size", "1", "--timezone", "America/Los_Angeles",
+			},
+			code: "DISPLAY_NAME_INVALID",
+		},
+		{
+			name: "party count consistency",
+			argv: append(append([]string{}, valid...), "--plus-one", "Guest"),
+			code: "PARTY_SIZE_MISMATCH",
+		},
+		{
+			name: "empty named plus one",
+			argv: []string{
+				"rsvp", "set", "event-example", "--status", "going",
+				"--display-name", "Example", "--party-size", "2",
+				"--plus-one", "  ", "--timezone", "America/Los_Angeles",
+			},
+			code: "PLUS_ONES_INVALID",
+		},
+		{
+			name: "timezone is exact IANA value",
+			argv: []string{
+				"rsvp", "set", "event-example", "--status", "going",
+				"--display-name", "Example", "--party-size", "1",
+				"--timezone", " America/Los_Angeles ",
+			},
+			code: "TIMEZONE_INVALID",
+		},
+		{
+			name: "message length",
+			argv: append(
+				append([]string{}, valid...),
+				"--message",
+				strings.Repeat("m", 401),
+			),
+			code: "MESSAGE_INVALID",
+		},
+		{
+			name: "declined questionnaire omission",
+			argv: []string{
+				"rsvp", "set", "event-example", "--status", "not-going",
+				"--display-name", "Example", "--party-size", "1",
+				"--timezone", "America/Los_Angeles",
+				"--questionnaire-response",
+				`{"questionnaireVersion":0,"answers":{}}`,
+			},
+			code: "QUESTIONNAIRE_RESPONSE_INVALID",
+		},
+		{
+			name: "interest accepts no profile input",
+			argv: []string{
+				"rsvp", "set", "event-example", "--status", "interested",
+				"--display-name", "Example",
+			},
+			code: "INTEREST_INPUT_INVALID",
+		},
+		{
+			name:  "unknown structured field",
+			argv:  []string{"rsvp", "set", "event-example", "--input", "-"},
+			stdin: `{"status":"interested","privateUnknown":"value"}`,
+			code:  "INPUT_FIELD_UNKNOWN",
+		},
+		{
+			name: "input source conflict",
+			argv: []string{
+				"rsvp", "set", "event-example", "--input", "-",
+				"--status", "interested",
+			},
+			stdin: `{"status":"interested"}`,
+			code:  "INPUT_SOURCE_CONFLICT",
+		},
+		{
+			name: "questionnaire answer type",
+			argv: append(
+				append([]string{}, valid...),
+				"--questionnaire-response",
+				`{"questionnaireVersion":0,"answers":{"question":7}}`,
+			),
+			code: "QUESTIONNAIRE_RESPONSE_INVALID",
+		},
+		{
+			name: "apply requires plan",
+			argv: append(append([]string{}, valid...), "--apply"),
+			code: "PLAN_REQUIRED",
+		},
+		{
+			name: "plan requires apply",
+			argv: append(append([]string{}, valid...), "--plan", "opaque"),
+			code: "APPLY_REQUIRED",
+		},
+		{
+			name: "repeated scalar",
+			argv: append(append([]string{}, valid...), "--status", "going"),
+			code: "FLAG_REPEATED",
+		},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			httpCalled := false
+			result := app.Execute(context.Background(), app.Request{
+				Argv:  testCase.argv,
+				Stdin: strings.NewReader(testCase.stdin),
+			}, app.Dependencies{
+				HTTP: scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
+					httpCalled = true
+					return nil, errors.New("must not call HTTP")
+				}},
+			})
+			if result.ExitCode != 2 ||
+				!strings.Contains(result.Stdout, `"type":"input.invalid"`) ||
+				!strings.Contains(result.Stdout, `"code":"`+testCase.code+`"`) {
+				t.Fatalf("result = %#v, want input failure %s", result, testCase.code)
+			}
+			if httpCalled {
+				t.Fatal("invalid RSVP input caused a remote read")
+			}
+		})
+	}
+}
+
+func TestExecuteRSVPSetEnforcesReviewedEventAndGuestCompatibility(t *testing.T) {
+	going := []string{
+		"rsvp", "set", "event-example",
+		"--status", "going",
+		"--display-name", "Example",
+		"--party-size", "1",
+		"--timezone", "America/Los_Angeles",
+	}
+	withQuestionnaire := append(
+		append([]string{}, going...),
+		"--questionnaire-response",
+		`{"questionnaireVersion":0,"answers":{}}`,
+	)
+	partyTwo := []string{
+		"rsvp", "set", "event-example",
+		"--status", "going",
+		"--display-name", "Example",
+		"--party-size", "2",
+		"--plus-one", "Guest",
+		"--timezone", "America/Los_Angeles",
+	}
+	cases := []struct {
+		name        string
+		change      func(map[string]any)
+		current     string
+		argv        []string
+		failureType string
+		code        string
+	}{
+		{
+			name: "RSVP disabled",
+			change: func(event map[string]any) {
+				event["rsvpsEnabled"] = false
+			},
+			failureType: "state.conflict",
+			code:        "RSVP_EVENT_UNSUPPORTED",
+		},
+		{
+			name: "required capacity flag missing",
+			change: func(event map[string]any) {
+				delete(event, "atCapacity")
+			},
+			failureType: "contract.protocol_changed",
+			code:        "RSVP_PROTOCOL_CHANGED",
+		},
+		{
+			name: "application event",
+			change: func(event map[string]any) {
+				event["guestAction"] = "APPLY"
+			},
+			failureType: "state.conflict",
+			code:        "RSVP_EVENT_UNSUPPORTED",
+		},
+		{
+			name: "ticketed event",
+			change: func(event map[string]any) {
+				event["ticketing"] = map[string]any{"private": "unprojected"}
+			},
+			failureType: "state.conflict",
+			code:        "RSVP_EVENT_UNSUPPORTED",
+		},
+		{
+			name: "unobserved null password",
+			change: func(event map[string]any) {
+				event["password"] = nil
+			},
+			failureType: "contract.protocol_changed",
+			code:        "RSVP_PROTOCOL_CHANGED",
+		},
+		{
+			name: "protected event",
+			change: func(event map[string]any) {
+				event["passwordProtected"] = true
+			},
+			failureType: "state.conflict",
+			code:        "RSVP_EVENT_UNSUPPORTED",
+		},
+		{
+			name: "at capacity does not invent waitlist",
+			change: func(event map[string]any) {
+				event["atCapacity"] = true
+				event["enableWaitlist"] = true
+			},
+			failureType: "state.conflict",
+			code:        "RSVP_EVENT_UNSUPPORTED",
+		},
+		{
+			name: "party maximum",
+			change: func(event map[string]any) {
+				event["maxCountPerGuest"] = 1
+			},
+			argv:        partyTwo,
+			failureType: "state.conflict",
+			code:        "RSVP_EVENT_UNSUPPORTED",
+		},
+		{
+			name: "invalid party maximum evidence",
+			change: func(event map[string]any) {
+				event["maxCountPerGuest"] = 0
+			},
+			failureType: "contract.protocol_changed",
+			code:        "RSVP_PROTOCOL_CHANGED",
+		},
+		{
+			name: "capacity snapshot incomplete",
+			change: func(event map[string]any) {
+				event["maxCapacity"] = 20
+			},
+			failureType: "state.conflict",
+			code:        "RSVP_EVENT_UNSUPPORTED",
+		},
+		{
+			name: "insufficient capacity",
+			change: func(event map[string]any) {
+				event["remainingCapacity"] = 0
+			},
+			failureType: "state.conflict",
+			code:        "RSVP_EVENT_UNSUPPORTED",
+		},
+		{
+			name: "declined current guest does not reduce going capacity delta",
+			change: func(event map[string]any) {
+				event["remainingCapacity"] = 1
+			},
+			current: `{"result":{"data":{"currentGuest":{
+				"id":"private-guest","status":"DECLINED","count":1
+			}}}}`,
+			argv:        partyTwo,
+			failureType: "state.conflict",
+			code:        "RSVP_EVENT_UNSUPPORTED",
+		},
+		{
+			name: "questionnaire required",
+			change: func(event map[string]any) {
+				event["questionnaireEnabled"] = true
+				event["questionnaireVersions"] = []any{map[string]any{}}
+			},
+			failureType: "input.invalid",
+			code:        "QUESTIONNAIRE_RESPONSE_INVALID",
+		},
+		{
+			name: "questionnaire versions unavailable",
+			change: func(event map[string]any) {
+				event["questionnaireEnabled"] = true
+				event["questionnaireVersions"] = nil
+			},
+			argv:        withQuestionnaire,
+			failureType: "state.conflict",
+			code:        "RSVP_EVENT_UNSUPPORTED",
+		},
+		{
+			name: "questionnaire latest version",
+			change: func(event map[string]any) {
+				event["questionnaireEnabled"] = true
+				event["questionnaireVersions"] = []any{
+					map[string]any{},
+					map[string]any{},
+				}
+			},
+			argv:        withQuestionnaire,
+			failureType: "input.invalid",
+			code:        "QUESTIONNAIRE_RESPONSE_INVALID",
+		},
+		{
+			name: "questionnaire omitted when disabled",
+			change: func(event map[string]any) {
+				event["questionnaireEnabled"] = false
+			},
+			argv:        withQuestionnaire,
+			failureType: "input.invalid",
+			code:        "QUESTIONNAIRE_RESPONSE_INVALID",
+		},
+		{
+			name: "existing guest count required",
+			current: `{"result":{"data":{"currentGuest":{
+				"id":"private-guest","status":"GOING"
+			}}}}`,
+			failureType: "contract.protocol_changed",
+			code:        "RSVP_PROTOCOL_CHANGED",
+		},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			event := compatibleRSVPEvent()
+			if testCase.change != nil {
+				testCase.change(event)
+			}
+			current := testCase.current
+			if current == "" {
+				current = `{"result":{"data":{"currentGuest":null}}}`
+			}
+			files := &memoryFilesystem{files: map[string][]byte{
+				rsvpCredentialsPath: []byte(rsvpCredentials),
+			}}
+			dependencies := rsvpTestDependencies(files)
+			dependencies.MutationRandom = strings.NewReader(strings.Repeat("c", 32))
+			call := 0
+			dependencies.HTTP = scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+				call++
+				switch call {
+				case 1:
+					return jsonResponse(
+						http.StatusOK,
+						rsvpEventResponse(t, event),
+					), nil
+				case 2:
+					return jsonResponse(http.StatusOK, current), nil
+				default:
+					t.Fatalf("unexpected mutation request %d: %s", call, request.URL)
+					return nil, nil
+				}
+			}}
+			argv := testCase.argv
+			if argv == nil {
+				argv = going
+			}
+
+			result := app.Execute(
+				context.Background(),
+				app.Request{Argv: argv},
+				dependencies,
+			)
+
+			if result.ExitCode == 0 ||
+				!strings.Contains(result.Stdout, `"type":"`+testCase.failureType+`"`) ||
+				!strings.Contains(result.Stdout, `"code":"`+testCase.code+`"`) {
+				t.Fatalf(
+					"result = %#v, want %s/%s",
+					result,
+					testCase.failureType,
+					testCase.code,
+				)
+			}
+			if files.atomicWrites != 0 {
+				t.Fatalf("atomic writes = %d, want no plan for incompatible event", files.atomicWrites)
+			}
+		})
+	}
+}
+
+func TestExecuteRSVPSetRejectsAnyChangedReviewedPreconditionAsStale(t *testing.T) {
+	cases := []struct {
+		name       string
+		planEvent  map[string]any
+		applyEvent map[string]any
+		planGuest  string
+		applyGuest string
+	}{
+		{
+			name:       "absent to explicit null event field",
+			planEvent:  compatibleRSVPEvent(),
+			applyEvent: rsvpEventWith("ticketing", nil),
+			planGuest:  `{"result":{"data":{"currentGuest":null}}}`,
+			applyGuest: `{"result":{"data":{"currentGuest":null}}}`,
+		},
+		{
+			name:       "no guest to existing guest",
+			planEvent:  compatibleRSVPEvent(),
+			applyEvent: compatibleRSVPEvent(),
+			planGuest:  `{"result":{"data":{"currentGuest":null}}}`,
+			applyGuest: `{"result":{"data":{"currentGuest":{"id":"private-new-guest","status":"GOING","count":1}}}}`,
+		},
+		{
+			name:       "existing guest count",
+			planEvent:  compatibleRSVPEvent(),
+			applyEvent: compatibleRSVPEvent(),
+			planGuest:  `{"result":{"data":{"currentGuest":{"id":"private-guest","status":"GOING","count":1}}}}`,
+			applyGuest: `{"result":{"data":{"currentGuest":{"id":"private-guest","status":"GOING","count":2}}}}`,
+		},
+		{
+			name:       "existing guest count becomes absent",
+			planEvent:  compatibleRSVPEvent(),
+			applyEvent: compatibleRSVPEvent(),
+			planGuest:  `{"result":{"data":{"currentGuest":{"id":"private-guest","status":"GOING","count":1}}}}`,
+			applyGuest: `{"result":{"data":{"currentGuest":{"id":"private-guest","status":"GOING"}}}}`,
+		},
+	}
+	argv := []string{
+		"rsvp", "set", "event-example",
+		"--status", "going",
+		"--display-name", "Example",
+		"--party-size", "1",
+		"--timezone", "America/Los_Angeles",
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			files := &memoryFilesystem{files: map[string][]byte{
+				rsvpCredentialsPath: []byte(rsvpCredentials),
+			}}
+			dependencies := rsvpTestDependencies(files)
+			dependencies.MutationRandom = strings.NewReader(strings.Repeat("s", 32))
+			call := 0
+			dependencies.HTTP = scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+				call++
+				switch call {
+				case 1:
+					return jsonResponse(
+						http.StatusOK,
+						rsvpEventResponse(t, testCase.planEvent),
+					), nil
+				case 2:
+					return jsonResponse(http.StatusOK, testCase.planGuest), nil
+				case 3:
+					return jsonResponse(
+						http.StatusOK,
+						rsvpEventResponse(t, testCase.applyEvent),
+					), nil
+				case 4:
+					return jsonResponse(http.StatusOK, testCase.applyGuest), nil
+				default:
+					t.Fatalf("stale plan dispatched request %d to %s", call, request.URL)
+					return nil, nil
+				}
+			}}
+			plan := app.Execute(
+				context.Background(),
+				app.Request{Argv: argv},
+				dependencies,
+			)
+			if plan.ExitCode != 0 {
+				t.Fatalf("plan = %#v, want success", plan)
+			}
+
+			applied := app.Execute(context.Background(), app.Request{
+				Argv: append(
+					append([]string{}, argv...),
+					"--apply",
+					"--plan",
+					rsvpPlanToken(t, plan),
+				),
+			}, dependencies)
+
+			if applied.ExitCode != 7 ||
+				!strings.Contains(applied.Stdout, `"type":"safety.plan_stale"`) ||
+				call != 4 {
+				t.Fatalf("applied = %#v, calls = %d, want stale before dispatch", applied, call)
+			}
+			if strings.Contains(applied.Stdout+applied.Stderr, "private-guest") ||
+				strings.Contains(applied.Stdout+applied.Stderr, "private-new-guest") {
+				t.Fatal("stale-plan failure exposed a private guest ID")
+			}
+		})
+	}
+}
+
+func TestExecuteRSVPSetTreatsRemovedEventAsStaleBeforeDispatch(t *testing.T) {
+	files := &memoryFilesystem{files: map[string][]byte{
+		rsvpCredentialsPath: []byte(rsvpCredentials),
+	}}
+	dependencies := rsvpTestDependencies(files)
+	dependencies.MutationRandom = strings.NewReader(strings.Repeat("d", 32))
+	call := 0
+	dependencies.HTTP = scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
+		call++
+		switch call {
+		case 1:
+			return jsonResponse(http.StatusOK, compatibleRSVPEventResponse), nil
+		case 2:
+			return jsonResponse(
+				http.StatusOK,
+				`{"result":{"data":{"currentGuest":null}}}`,
+			), nil
+		case 3:
+			return jsonResponse(
+				http.StatusNotFound,
+				`{"error":{"message":"private detail","status":"NOT_FOUND"}}`,
+			), nil
+		default:
+			t.Fatalf("removed event dispatched request %d", call)
+			return nil, nil
+		}
+	}}
+	argv := []string{
+		"rsvp", "set", "event-example",
+		"--status", "interested",
+	}
+	plan := app.Execute(
+		context.Background(),
+		app.Request{Argv: argv},
+		dependencies,
+	)
+	applied := app.Execute(context.Background(), app.Request{
+		Argv: append(
+			append([]string{}, argv...),
+			"--apply",
+			"--plan",
+			rsvpPlanToken(t, plan),
+		),
+	}, dependencies)
+
+	if applied.ExitCode != 7 ||
+		!strings.Contains(applied.Stdout, `"type":"safety.plan_stale"`) ||
+		call != 3 {
+		t.Fatalf("applied = %#v, calls = %d, want stale before dispatch", applied, call)
+	}
+	if strings.Contains(applied.Stdout+applied.Stderr, "private detail") {
+		t.Fatal("stale-plan failure exposed remote detail")
+	}
+}
+
+func TestExecuteRSVPSetBindsPlanToInputAccountAndFiveMinuteLifetime(t *testing.T) {
+	argv := []string{
+		"rsvp", "set", "event-example",
+		"--status", "going",
+		"--display-name", "Example",
+		"--party-size", "1",
+		"--timezone", "America/Los_Angeles",
+	}
+	cases := []struct {
+		name   string
+		before func(*memoryFilesystem)
+		change func(*memoryFilesystem, *time.Time) []string
+	}{
+		{
+			name: "normalized input",
+			change: func(_ *memoryFilesystem, _ *time.Time) []string {
+				changed := append([]string{}, argv...)
+				changed[6] = "Different Example"
+				return changed
+			},
+		},
+		{
+			name: "authenticated account",
+			change: func(files *memoryFilesystem, _ *time.Time) []string {
+				files.files[rsvpCredentialsPath] = []byte(
+					`{"accessToken":"private-access-token","userId":"different-private-account","expiresAt":"2026-08-12T02:00:00Z"}`,
+				)
+				return argv
+			},
+		},
+		{
+			name: "token account overrides stale stored identity",
+			before: func(files *memoryFilesystem) {
+				files.files[rsvpCredentialsPath] = []byte(
+					`{"accessToken":"header.eyJzdWIiOiJwcml2YXRlLWFjY291bnQtYSJ9.signature","userId":"stale-private-account","expiresAt":"2026-08-12T02:00:00Z"}`,
+				)
+			},
+			change: func(files *memoryFilesystem, _ *time.Time) []string {
+				files.files[rsvpCredentialsPath] = []byte(
+					`{"accessToken":"header.eyJzdWIiOiJwcml2YXRlLWFjY291bnQtYiJ9.signature","userId":"stale-private-account","expiresAt":"2026-08-12T02:00:00Z"}`,
+				)
+				return argv
+			},
+		},
+		{
+			name: "five minute expiry",
+			change: func(_ *memoryFilesystem, now *time.Time) []string {
+				*now = now.Add(5 * time.Minute)
+				return argv
+			},
+		},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			files := &memoryFilesystem{files: map[string][]byte{
+				rsvpCredentialsPath: []byte(rsvpCredentials),
+			}}
+			if testCase.before != nil {
+				testCase.before(files)
+			}
+			now := time.Date(2026, time.August, 12, 0, 0, 0, 0, time.UTC)
+			dependencies := rsvpTestDependencies(files)
+			dependencies.Now = func() time.Time { return now }
+			dependencies.MutationRandom = strings.NewReader(strings.Repeat("b", 32))
+			call := 0
+			dependencies.HTTP = scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+				call++
+				switch call {
+				case 1:
+					return jsonResponse(http.StatusOK, compatibleRSVPEventResponse), nil
+				case 2:
+					return jsonResponse(
+						http.StatusOK,
+						`{"result":{"data":{"currentGuest":null}}}`,
+					), nil
+				default:
+					t.Fatalf("invalid binding caused remote request %d to %s", call, request.URL)
+					return nil, nil
+				}
+			}}
+			plan := app.Execute(
+				context.Background(),
+				app.Request{Argv: argv},
+				dependencies,
+			)
+			if plan.ExitCode != 0 {
+				t.Fatalf("plan = %#v, want success", plan)
+			}
+			applyInput := testCase.change(files, &now)
+
+			applied := app.Execute(context.Background(), app.Request{
+				Argv: append(
+					append([]string{}, applyInput...),
+					"--apply",
+					"--plan",
+					rsvpPlanToken(t, plan),
+				),
+			}, dependencies)
+
+			if applied.ExitCode != 7 ||
+				!strings.Contains(applied.Stdout, `"type":"safety.plan_stale"`) ||
+				call != 2 {
+				t.Fatalf("applied = %#v, calls = %d, want stale before reads", applied, call)
+			}
+			for _, privateValue := range []string{
+				"private-account",
+				"different-private-account",
+			} {
+				if strings.Contains(applied.Stdout+applied.Stderr, privateValue) {
+					t.Fatalf("stale plan exposed private account value %q", privateValue)
+				}
+			}
+		})
+	}
+}
+
+func TestExecuteRSVPSetConsumesPlanBeforeOneUncertainAttempt(t *testing.T) {
+	cases := []struct {
+		name        string
+		response    string
+		remoteError error
+		failureType string
+		code        string
+	}{
+		{
+			name:        "ambiguous transport",
+			remoteError: errors.New("private connection lost"),
+			failureType: "remote.unavailable",
+			code:        "RSVP_SUBMISSION_UNCERTAIN",
+		},
+		{
+			name:        "interest completion predicate",
+			response:    `{"result":{"data":{"success":true,"interested":false}}}`,
+			failureType: "contract.protocol_changed",
+			code:        "RSVP_PROTOCOL_CHANGED",
+		},
+		{
+			name:        "JavaScript-falsy underflowed success",
+			response:    `{"result":{"data":{"success":1e-999,"interested":true}}}`,
+			failureType: "contract.protocol_changed",
+			code:        "RSVP_PROTOCOL_CHANGED",
+		},
+	}
+	argv := []string{
+		"rsvp", "set", "event-example",
+		"--status", "interested",
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			files := &memoryFilesystem{files: map[string][]byte{
+				rsvpCredentialsPath: []byte(rsvpCredentials),
+			}}
+			dependencies := rsvpTestDependencies(files)
+			dependencies.MutationRandom = strings.NewReader(strings.Repeat("x", 32))
+			call := 0
+			mutationAttempts := 0
+			dependencies.HTTP = scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+				call++
+				switch call {
+				case 1, 3:
+					return jsonResponse(http.StatusOK, compatibleRSVPEventResponse), nil
+				case 2, 4:
+					return jsonResponse(
+						http.StatusOK,
+						`{"result":{"data":{"currentGuest":null}}}`,
+					), nil
+				case 5:
+					mutationAttempts++
+					if files.atomicWrites != 2 {
+						t.Fatalf(
+							"atomic writes before dispatch = %d, want plan consumed",
+							files.atomicWrites,
+						)
+					}
+					if testCase.remoteError != nil {
+						return nil, testCase.remoteError
+					}
+					return jsonResponse(http.StatusOK, testCase.response), nil
+				default:
+					t.Fatalf("automatic retry or post-read %d: %s", call, request.URL)
+					return nil, nil
+				}
+			}}
+			plan := app.Execute(
+				context.Background(),
+				app.Request{Argv: argv},
+				dependencies,
+			)
+			token := rsvpPlanToken(t, plan)
+			applyArgv := append(
+				append([]string{}, argv...),
+				"--apply",
+				"--plan",
+				token,
+			)
+
+			applied := app.Execute(
+				context.Background(),
+				app.Request{Argv: applyArgv},
+				dependencies,
+			)
+
+			if applied.ExitCode == 0 ||
+				!strings.Contains(applied.Stdout, `"type":"`+testCase.failureType+`"`) ||
+				!strings.Contains(applied.Stdout, `"code":"`+testCase.code+`"`) ||
+				mutationAttempts != 1 ||
+				call != 5 {
+				t.Fatalf(
+					"applied = %#v, attempts = %d, calls = %d",
+					applied,
+					mutationAttempts,
+					call,
+				)
+			}
+			reused := app.Execute(
+				context.Background(),
+				app.Request{Argv: applyArgv},
+				dependencies,
+			)
+			if reused.ExitCode != 7 ||
+				!strings.Contains(reused.Stdout, `"type":"safety.plan_stale"`) ||
+				call != 5 ||
+				mutationAttempts != 1 {
+				t.Fatalf("reused = %#v, want consumed token without retry", reused)
+			}
+			if strings.Contains(applied.Stdout+applied.Stderr, "private connection lost") {
+				t.Fatal("uncertain result exposed private transport details")
+			}
+		})
+	}
+}
+
+func TestExecuteSchemaPublishesCompleteRSVPSurfaceAndSafety(t *testing.T) {
+	type schemaEnvelope struct {
+		Data struct {
+			Command     string `json:"command"`
+			Positionals []struct {
+				Name     string `json:"name"`
+				Required bool   `json:"required"`
+			} `json:"positionals"`
+			Flags []struct {
+				Name string `json:"name"`
+			} `json:"flags"`
+			InputSchema struct {
+				OneOf []struct {
+					Required   []string `json:"required"`
+					Properties map[string]struct {
+						Enum      []string `json:"enum"`
+						MaxLength *int     `json:"maxLength"`
+					} `json:"properties"`
+				} `json:"oneOf"`
+			} `json:"inputSchema"`
+			SuccessSchema struct {
+				OneOf []json.RawMessage `json:"oneOf"`
+			} `json:"successSchema"`
+			FailureTypes []string `json:"failureTypes"`
+			Safety       struct {
+				Kind                 string `json:"kind"`
+				PlanRequired         bool   `json:"planRequired"`
+				ConfirmationRequired bool   `json:"confirmationRequired"`
+			} `json:"safety"`
+		} `json:"data"`
+	}
+	getResult := app.Execute(context.Background(), app.Request{
+		Argv: []string{"schema", "rsvp.get"},
+	}, app.Dependencies{})
+	if getResult.ExitCode != 0 ||
+		!strings.Contains(getResult.Stdout, `"command":"rsvp.get"`) ||
+		!strings.Contains(getResult.Stdout, `"enum":["ready-to-send"`) ||
+		strings.Contains(getResult.Stdout, "guestId") ||
+		strings.Contains(getResult.Stdout, "userId") {
+		t.Fatalf("get schema = %#v, want private-ID-free reviewed RSVP read", getResult)
+	}
+
+	setResult := app.Execute(context.Background(), app.Request{
+		Argv: []string{"schema", "rsvp.set"},
+	}, app.Dependencies{})
+	var set schemaEnvelope
+	if setResult.ExitCode != 0 ||
+		json.Unmarshal([]byte(setResult.Stdout), &set) != nil {
+		t.Fatalf("set schema = %#v, want decodable schema", setResult)
+	}
+	if set.Data.Command != "rsvp.set" ||
+		len(set.Data.Positionals) != 1 ||
+		set.Data.Positionals[0].Name != "event-id" ||
+		!set.Data.Positionals[0].Required {
+		t.Fatalf("set positionals = %#v, want required event ID", set.Data.Positionals)
+	}
+	var flags []string
+	for _, flag := range set.Data.Flags {
+		flags = append(flags, flag.Name)
+	}
+	if !reflect.DeepEqual(flags, []string{
+		"--input",
+		"--status",
+		"--display-name",
+		"--party-size",
+		"--plus-one",
+		"--message",
+		"--timezone",
+		"--questionnaire-response",
+		"--apply",
+		"--plan",
+	}) {
+		t.Fatalf("set flags = %v, want complete RSVP invocation", flags)
+	}
+	if len(set.Data.InputSchema.OneOf) != 3 ||
+		!reflect.DeepEqual(
+			set.Data.InputSchema.OneOf[0].Properties["status"].Enum,
+			[]string{"going"},
+		) ||
+		!reflect.DeepEqual(
+			set.Data.InputSchema.OneOf[1].Properties["status"].Enum,
+			[]string{"not-going"},
+		) ||
+		!reflect.DeepEqual(
+			set.Data.InputSchema.OneOf[2].Properties["status"].Enum,
+			[]string{"interested"},
+		) ||
+		set.Data.InputSchema.OneOf[0].Properties["displayName"].MaxLength == nil ||
+		*set.Data.InputSchema.OneOf[0].Properties["displayName"].MaxLength != 50 {
+		t.Fatalf("set input schema = %#v, want exact three-intent input", set.Data.InputSchema)
+	}
+	if len(set.Data.SuccessSchema.OneOf) != 2 ||
+		set.Data.Safety.Kind != "standard-mutation" ||
+		!set.Data.Safety.PlanRequired ||
+		set.Data.Safety.ConfirmationRequired {
+		t.Fatalf("set success/safety = %#v, want plan-or-submitted standard mutation", set.Data)
+	}
+	for _, failureType := range []string{
+		"input.invalid",
+		"auth.required",
+		"state.conflict",
+		"safety.plan_stale",
+		"remote.unavailable",
+		"contract.protocol_changed",
+	} {
+		if !slices.Contains(set.Data.FailureTypes, failureType) {
+			t.Fatalf("failure types = %v, missing %s", set.Data.FailureTypes, failureType)
+		}
+	}
+}
+
+const (
+	rsvpCredentialsPath         = "/config/partiful/credentials.json"
+	rsvpMutationPath            = "/config/partiful/mutation-plans.json"
+	rsvpCredentials             = `{"accessToken":"private-access-token","userId":"private-account","expiresAt":"2026-08-12T02:00:00Z"}`
+	compatibleRSVPEventResponse = `{"result":{"data":{"event":{
+		"rsvpsEnabled":true,
+		"atCapacity":false,
+		"plusOneNamesRequired":false,
+		"questionnaireVersions":null
+	}}}}`
+)
+
+func compatibleRSVPEvent() map[string]any {
+	return map[string]any{
+		"rsvpsEnabled":          true,
+		"atCapacity":            false,
+		"plusOneNamesRequired":  false,
+		"questionnaireVersions": nil,
+	}
+}
+
+func rsvpEventWith(name string, value any) map[string]any {
+	event := compatibleRSVPEvent()
+	event[name] = value
+	return event
+}
+
+func rsvpEventResponse(t *testing.T, event map[string]any) string {
+	t.Helper()
+	body, err := json.Marshal(map[string]any{
+		"result": map[string]any{
+			"data": map[string]any{
+				"event": event,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("encode event response: %v", err)
+	}
+	return string(body)
+}
+
+func rsvpTestDependencies(files *memoryFilesystem) app.Dependencies {
+	return app.Dependencies{
+		Files:           files,
+		CredentialsPath: rsvpCredentialsPath,
+		MutationPath:    rsvpMutationPath,
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 12, 0, 0, 0, 0, time.UTC)
+		},
+		AuthRandom: strings.NewReader(strings.Repeat("0123456789abcdef", 8)),
+	}
+}
+
+func assertRSVPRequest(t *testing.T, request *http.Request, operation, body string) {
+	t.Helper()
+	if request.Method != http.MethodPost ||
+		request.URL.String() != "https://api.partiful.com/"+operation {
+		t.Fatalf("request = %s %s, want %s", request.Method, request.URL, operation)
+	}
+	document, err := io.ReadAll(request.Body)
+	if err != nil {
+		t.Fatalf("read request body: %v", err)
+	}
+	if string(document) != body {
+		t.Fatalf("request body = %s, want %s", document, body)
+	}
+}
+
+func rsvpPlanToken(t *testing.T, result app.Result) string {
+	t.Helper()
+	var envelope struct {
+		Data struct {
+			PlanToken string `json:"planToken"`
+		} `json:"data"`
+	}
+	if json.Unmarshal([]byte(result.Stdout), &envelope) != nil ||
+		envelope.Data.PlanToken == "" {
+		t.Fatalf("result has no plan token: %#v", result)
+	}
+	return envelope.Data.PlanToken
+}

--- a/internal/app/rsvp_execute_test.go
+++ b/internal/app/rsvp_execute_test.go
@@ -54,6 +54,12 @@ func TestExecuteRSVPGetReturnsExplicitNoRSVPAndFailsClosedOnOtherVariants(t *tes
 			contains: `"type":"contract.protocol_changed"`,
 		},
 		{
+			name:     "null guest count",
+			body:     `{"result":{"data":{"currentGuest":{"id":"private-id","status":"GOING","count":null}}}}`,
+			exitCode: 9,
+			contains: `"type":"contract.protocol_changed"`,
+		},
+		{
 			name:        "transport unavailable",
 			remoteError: errors.New("private transport failure"),
 			exitCode:    8,
@@ -576,6 +582,24 @@ func TestExecuteRSVPSetRejectsInvalidNormalizedInputBeforeAuthenticationOrReads(
 				"--timezone", " America/Los_Angeles ",
 			},
 			code: "TIMEZONE_INVALID",
+		},
+		{
+			name: "local timezone alias is not IANA",
+			argv: []string{
+				"rsvp", "set", "event-example", "--status", "going",
+				"--display-name", "Example", "--party-size", "1",
+				"--timezone", "Local",
+			},
+			code: "TIMEZONE_INVALID",
+		},
+		{
+			name: "party size rejects trailing JSON",
+			argv: []string{
+				"rsvp", "set", "event-example", "--status", "going",
+				"--display-name", "Example", "--party-size", "1 true",
+				"--timezone", "America/Los_Angeles",
+			},
+			code: "PARTY_SIZE_INVALID",
 		},
 		{
 			name: "message length",

--- a/internal/app/rsvp_input.go
+++ b/internal/app/rsvp_input.go
@@ -394,6 +394,10 @@ func requiredRSVPInteger(
 	if decoder.Decode(&decoded) != nil {
 		return 0, false
 	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return 0, false
+	}
 	number, ok := decoded.(json.Number)
 	if !ok {
 		return 0, false
@@ -445,7 +449,7 @@ func optionalQuestionnaire(raw json.RawMessage) (*questionnaireInput, bool) {
 }
 
 func validRSVPTimezone(value string) bool {
-	if strings.TrimSpace(value) != value {
+	if strings.TrimSpace(value) != value || value == "Local" {
 		return false
 	}
 	_, err := time.LoadLocation(value)

--- a/internal/app/rsvp_input.go
+++ b/internal/app/rsvp_input.go
@@ -1,0 +1,700 @@
+package app
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+const maximumRSVPInputBytes = 64 << 10
+
+type questionnaireInput struct {
+	QuestionnaireVersion int               `json:"questionnaireVersion"`
+	Answers              map[string]string `json:"answers"`
+}
+
+type addGuestProductInput struct {
+	Status                string              `json:"status"`
+	DisplayName           string              `json:"displayName"`
+	PartySize             int                 `json:"partySize"`
+	PlusOnes              []string            `json:"plusOnes"`
+	Message               *string             `json:"message"`
+	Timezone              string              `json:"timezone"`
+	QuestionnaireResponse *questionnaireInput `json:"questionnaireResponse"`
+}
+
+type interestProductInput struct {
+	Status string `json:"status"`
+}
+
+type normalizedRSVPInput struct {
+	Intent   string
+	AddGuest *addGuestProductInput
+}
+
+type rsvpSetOptions struct {
+	EventID   string
+	Input     normalizedRSVPInput
+	Apply     bool
+	PlanToken string
+}
+
+func (input normalizedRSVPInput) public() any {
+	if input.AddGuest != nil {
+		return *input.AddGuest
+	}
+	return interestProductInput{Status: input.Intent}
+}
+
+func (input normalizedRSVPInput) document() json.RawMessage {
+	document, _ := json.Marshal(input.public())
+	return document
+}
+
+func parseRSVPSetOptions(
+	request Request,
+	definition commandDefinition,
+	argv []string,
+	dependencies Dependencies,
+) (rsvpSetOptions, *errorBody) {
+	if len(argv) < len(definition.invocation)+1 ||
+		strings.TrimSpace(argv[len(definition.invocation)]) == "" {
+		return rsvpSetOptions{}, rsvpInputFailure(
+			"EVENT_ID_REQUIRED",
+			"Event ID is required.",
+		)
+	}
+	options := rsvpSetOptions{EventID: argv[len(definition.invocation)]}
+	scalars := make(map[string]string)
+	var plusOnes []string
+	for index := len(definition.invocation) + 1; index < len(argv); index++ {
+		name := argv[index]
+		switch name {
+		case "--apply":
+			if _, repeated := scalars[name]; repeated {
+				return rsvpSetOptions{}, repeatedRSVPFlag(name)
+			}
+			scalars[name] = "true"
+		case "--input",
+			"--status",
+			"--display-name",
+			"--party-size",
+			"--plus-one",
+			"--message",
+			"--timezone",
+			"--questionnaire-response",
+			"--plan":
+			if name != "--plus-one" {
+				if _, repeated := scalars[name]; repeated {
+					return rsvpSetOptions{}, repeatedRSVPFlag(name)
+				}
+			}
+			if index+1 >= len(argv) {
+				return rsvpSetOptions{}, rsvpInputFailureWithDetail(
+					"FLAG_VALUE_REQUIRED",
+					"A flag value is required.",
+					"flag",
+					name,
+				)
+			}
+			index++
+			if name == "--plus-one" {
+				plusOnes = append(plusOnes, argv[index])
+			} else {
+				scalars[name] = argv[index]
+			}
+		default:
+			return rsvpSetOptions{}, rsvpInputFailure(
+				"FLAG_UNKNOWN",
+				"The command contains an unknown flag.",
+			)
+		}
+	}
+	_, options.Apply = scalars["--apply"]
+	options.PlanToken = scalars["--plan"]
+	if options.Apply && options.PlanToken == "" {
+		return rsvpSetOptions{}, rsvpInputFailure(
+			"PLAN_REQUIRED",
+			"--apply requires --plan.",
+		)
+	}
+	if !options.Apply && options.PlanToken != "" {
+		return rsvpSetOptions{}, rsvpInputFailure(
+			"APPLY_REQUIRED",
+			"--plan requires --apply.",
+		)
+	}
+
+	var document map[string]json.RawMessage
+	inputPath, hasInput := scalars["--input"]
+	hasFieldFlags := len(plusOnes) != 0
+	for _, name := range []string{
+		"--status",
+		"--display-name",
+		"--party-size",
+		"--message",
+		"--timezone",
+		"--questionnaire-response",
+	} {
+		_, hasField := scalars[name]
+		hasFieldFlags = hasFieldFlags || hasField
+	}
+	if hasInput && hasFieldFlags {
+		return rsvpSetOptions{}, rsvpInputFailure(
+			"INPUT_SOURCE_CONFLICT",
+			"--input cannot be combined with RSVP field flags.",
+		)
+	}
+	if hasInput {
+		raw, ok := readRSVPInput(request.Stdin, dependencies.Files, inputPath)
+		if !ok || decodeRSVPObject(raw, &document) != nil {
+			return rsvpSetOptions{}, rsvpInputFailure(
+				"INPUT_DOCUMENT_INVALID",
+				"RSVP input must be one valid JSON object.",
+			)
+		}
+	} else {
+		document = rsvpFlagsDocument(scalars, plusOnes)
+	}
+	input, inputError := normalizeRSVPInput(document)
+	if inputError != nil {
+		return rsvpSetOptions{}, inputError
+	}
+	options.Input = input
+	return options, nil
+}
+
+func readRSVPInput(
+	stdin io.Reader,
+	files interface {
+		ReadFile(string) ([]byte, error)
+	},
+	path string,
+) ([]byte, bool) {
+	if path == "-" {
+		if stdin == nil {
+			return nil, false
+		}
+		raw, err := io.ReadAll(io.LimitReader(stdin, maximumRSVPInputBytes+1))
+		return raw, err == nil && len(raw) <= maximumRSVPInputBytes && utf8.Valid(raw)
+	}
+	if path == "" || files == nil {
+		return nil, false
+	}
+	raw, err := files.ReadFile(path)
+	return raw, err == nil && len(raw) <= maximumRSVPInputBytes && utf8.Valid(raw)
+}
+
+func decodeRSVPObject(raw []byte, destination *map[string]json.RawMessage) error {
+	if !utf8.Valid(raw) {
+		return errors.New("input is not UTF-8")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	if decoder.Decode(destination) != nil || *destination == nil {
+		return errors.New("input is not an object")
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return errors.New("input has trailing JSON")
+	}
+	return nil
+}
+
+func rsvpFlagsDocument(
+	values map[string]string,
+	plusOnes []string,
+) map[string]json.RawMessage {
+	document := make(map[string]json.RawMessage)
+	copyString := func(flag, field string) {
+		if value, ok := values[flag]; ok {
+			raw, _ := json.Marshal(value)
+			document[field] = raw
+		}
+	}
+	copyString("--status", "status")
+	copyString("--display-name", "displayName")
+	copyString("--timezone", "timezone")
+	copyString("--message", "message")
+	if value, ok := values["--party-size"]; ok {
+		document["partySize"] = json.RawMessage(value)
+	}
+	if plusOnes != nil {
+		raw, _ := json.Marshal(plusOnes)
+		document["plusOnes"] = raw
+	}
+	if value, ok := values["--questionnaire-response"]; ok {
+		document["questionnaireResponse"] = json.RawMessage(value)
+	}
+	return document
+}
+
+func normalizeRSVPInput(
+	document map[string]json.RawMessage,
+) (normalizedRSVPInput, *errorBody) {
+	allowed := map[string]bool{
+		"status":                true,
+		"displayName":           true,
+		"partySize":             true,
+		"plusOnes":              true,
+		"message":               true,
+		"timezone":              true,
+		"questionnaireResponse": true,
+	}
+	for name := range document {
+		if !allowed[name] {
+			return normalizedRSVPInput{}, rsvpInputFailure(
+				"INPUT_FIELD_UNKNOWN",
+				"RSVP input contains an unknown field.",
+			)
+		}
+	}
+	status, ok := requiredRSVPString(document, "status")
+	if !ok {
+		return normalizedRSVPInput{}, rsvpInputFailure(
+			"RSVP_STATUS_INVALID",
+			"RSVP status must be going, not-going, or interested.",
+		)
+	}
+	status = strings.ToLower(strings.TrimSpace(status))
+	if status != "going" && status != "not-going" && status != "interested" {
+		return normalizedRSVPInput{}, rsvpInputFailure(
+			"RSVP_STATUS_INVALID",
+			"RSVP status must be going, not-going, or interested.",
+		)
+	}
+	if status == "interested" {
+		if len(document) != 1 {
+			return normalizedRSVPInput{}, rsvpInputFailure(
+				"INTEREST_INPUT_INVALID",
+				"Interested accepts only the status field.",
+			)
+		}
+		return normalizedRSVPInput{Intent: status}, nil
+	}
+
+	displayName, ok := requiredRSVPString(document, "displayName")
+	if !ok || !utf8.ValidString(displayName) {
+		return normalizedRSVPInput{}, rsvpInputFailure(
+			"DISPLAY_NAME_INVALID",
+			"Display name must contain 1 to 50 characters.",
+		)
+	}
+	displayName = strings.TrimSpace(displayName)
+	if countCharacters(displayName) < 1 || countCharacters(displayName) > 50 {
+		return normalizedRSVPInput{}, rsvpInputFailure(
+			"DISPLAY_NAME_INVALID",
+			"Display name must contain 1 to 50 characters.",
+		)
+	}
+	partySize, ok := requiredRSVPInteger(document, "partySize")
+	if !ok || partySize < 1 {
+		return normalizedRSVPInput{}, rsvpInputFailure(
+			"PARTY_SIZE_INVALID",
+			"Party size must be a positive integer.",
+		)
+	}
+	var plusOnes []string
+	if raw, present := document["plusOnes"]; present {
+		if json.Unmarshal(raw, &plusOnes) != nil || plusOnes == nil {
+			return normalizedRSVPInput{}, rsvpInputFailure(
+				"PLUS_ONES_INVALID",
+				"Plus ones must be an array of nonempty names.",
+			)
+		}
+	} else {
+		plusOnes = []string{}
+	}
+	for index, name := range plusOnes {
+		if !utf8.ValidString(name) {
+			return normalizedRSVPInput{}, rsvpInputFailure(
+				"PLUS_ONES_INVALID",
+				"Plus ones must be an array of nonempty names.",
+			)
+		}
+		plusOnes[index] = strings.TrimSpace(name)
+		if plusOnes[index] == "" {
+			return normalizedRSVPInput{}, rsvpInputFailure(
+				"PLUS_ONES_INVALID",
+				"Plus ones must be an array of nonempty names.",
+			)
+		}
+	}
+	if partySize != 1+len(plusOnes) {
+		return normalizedRSVPInput{}, rsvpInputFailure(
+			"PARTY_SIZE_MISMATCH",
+			"Party size must equal one plus the number of named plus ones.",
+		)
+	}
+	timezone, ok := requiredRSVPString(document, "timezone")
+	if !ok || timezone == "" || !validRSVPTimezone(timezone) {
+		return normalizedRSVPInput{}, rsvpInputFailure(
+			"TIMEZONE_INVALID",
+			"Timezone must be a valid IANA timezone.",
+		)
+	}
+	message, valid := optionalRSVPMessage(document["message"])
+	if !valid {
+		return normalizedRSVPInput{}, rsvpInputFailure(
+			"MESSAGE_INVALID",
+			"Message must contain at most 400 characters.",
+		)
+	}
+	questionnaire, valid := optionalQuestionnaire(document["questionnaireResponse"])
+	if !valid || status == "not-going" && questionnaire != nil {
+		return normalizedRSVPInput{}, rsvpInputFailure(
+			"QUESTIONNAIRE_RESPONSE_INVALID",
+			"Questionnaire response is invalid for this RSVP.",
+		)
+	}
+	return normalizedRSVPInput{
+		Intent: status,
+		AddGuest: &addGuestProductInput{
+			Status:                status,
+			DisplayName:           displayName,
+			PartySize:             partySize,
+			PlusOnes:              plusOnes,
+			Message:               message,
+			Timezone:              timezone,
+			QuestionnaireResponse: questionnaire,
+		},
+	}, nil
+}
+
+func requiredRSVPString(
+	document map[string]json.RawMessage,
+	name string,
+) (string, bool) {
+	raw, ok := document[name]
+	if !ok {
+		return "", false
+	}
+	var value string
+	if json.Unmarshal(raw, &value) != nil {
+		return "", false
+	}
+	return value, true
+}
+
+func requiredRSVPInteger(
+	document map[string]json.RawMessage,
+	name string,
+) (int, bool) {
+	raw, ok := document[name]
+	if !ok {
+		return 0, false
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var decoded any
+	if decoder.Decode(&decoded) != nil {
+		return 0, false
+	}
+	number, ok := decoded.(json.Number)
+	if !ok {
+		return 0, false
+	}
+	value, err := strconv.ParseInt(number.String(), 10, 0)
+	return int(value), err == nil
+}
+
+func optionalRSVPMessage(raw json.RawMessage) (*string, bool) {
+	if len(raw) == 0 || bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return nil, true
+	}
+	var value string
+	if json.Unmarshal(raw, &value) != nil || !utf8.ValidString(value) {
+		return nil, false
+	}
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil, true
+	}
+	if countCharacters(value) > 400 {
+		return nil, false
+	}
+	return &value, true
+}
+
+func optionalQuestionnaire(raw json.RawMessage) (*questionnaireInput, bool) {
+	if len(raw) == 0 || bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return nil, true
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	var response questionnaireInput
+	if decoder.Decode(&response) != nil ||
+		response.QuestionnaireVersion < 0 ||
+		response.Answers == nil {
+		return nil, false
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return nil, false
+	}
+	for questionID, answer := range response.Answers {
+		if questionID == "" || !utf8.ValidString(questionID) || !utf8.ValidString(answer) {
+			return nil, false
+		}
+	}
+	return &response, true
+}
+
+func validRSVPTimezone(value string) bool {
+	if strings.TrimSpace(value) != value {
+		return false
+	}
+	_, err := time.LoadLocation(value)
+	return err == nil
+}
+
+func countCharacters(value string) int {
+	return utf8.RuneCountInString(value)
+}
+
+func repeatedRSVPFlag(name string) *errorBody {
+	return rsvpInputFailureWithDetail(
+		"FLAG_REPEATED",
+		"A scalar flag cannot be repeated.",
+		"flag",
+		name,
+	)
+}
+
+func rsvpInputFailure(code, message string) *errorBody {
+	return &errorBody{
+		Type:      "input.invalid",
+		Code:      code,
+		Message:   message,
+		Retryable: false,
+		Details:   map[string]any{},
+	}
+}
+
+func rsvpInputFailureWithDetail(
+	code string,
+	message string,
+	name string,
+	value string,
+) *errorBody {
+	failure := rsvpInputFailure(code, message)
+	failure.Details[name] = value
+	return failure
+}
+
+func rsvpSetInputSchema() jsonSchema {
+	zero := 0
+	one := 1
+	fifty := 50
+	fourHundred := 400
+	stringItem := jsonSchema{Type: "string", MinLength: &one, Pattern: `\S`}
+	answers := jsonSchema{
+		Type:                 "object",
+		AdditionalProperties: jsonSchema{Type: "string"},
+	}
+	questionnaire := objectSchema(
+		[]string{"questionnaireVersion", "answers"},
+		map[string]jsonSchema{
+			"questionnaireVersion": {Type: "integer", Minimum: &zero},
+			"answers":              answers,
+		},
+	)
+	commonProperties := func(status string) map[string]jsonSchema {
+		return map[string]jsonSchema{
+			"eventId": {Type: "string", MinLength: &one},
+			"status":  {Type: "string", Enum: []string{status}},
+			"apply":   {Type: "boolean"},
+			"plan":    {Type: "string", MinLength: &one},
+		}
+	}
+	addGuestVariant := func(status string) jsonSchema {
+		properties := commonProperties(status)
+		properties["displayName"] = jsonSchema{
+			Type:      "string",
+			MinLength: &one,
+			MaxLength: &fifty,
+			Pattern:   `\S`,
+		}
+		properties["partySize"] = jsonSchema{Type: "integer", Minimum: &one}
+		properties["plusOnes"] = jsonSchema{Type: "array", Items: &stringItem}
+		properties["message"] = jsonSchema{
+			Type:      []string{"string", "null"},
+			MaxLength: &fourHundred,
+		}
+		properties["timezone"] = jsonSchema{Type: "string", MinLength: &one}
+		properties["questionnaireResponse"] = jsonSchema{Type: "null"}
+		if status == "going" {
+			properties["questionnaireResponse"] = jsonSchema{
+				OneOf: []jsonSchema{questionnaire, {Type: "null"}},
+			}
+		}
+		schema := objectSchema(
+			[]string{"eventId", "status", "displayName", "partySize", "timezone"},
+			properties,
+		)
+		schema.DependentRequired = map[string][]string{
+			"apply": {"plan"},
+			"plan":  {"apply"},
+		}
+		return schema
+	}
+	interest := objectSchema(
+		[]string{"eventId", "status"},
+		commonProperties("interested"),
+	)
+	interest.DependentRequired = map[string][]string{
+		"apply": {"plan"},
+		"plan":  {"apply"},
+	}
+	return jsonSchema{Type: "object", OneOf: []jsonSchema{
+		addGuestVariant("going"),
+		addGuestVariant("not-going"),
+		interest,
+	}}
+}
+
+func rsvpSetSuccessSchema() jsonSchema {
+	zero := 0
+	one := 1
+	fifty := 50
+	fourHundred := 400
+	threeHundred := 300
+	stringItem := jsonSchema{Type: "string", MinLength: &one, Pattern: `\S`}
+	answers := jsonSchema{
+		Type:                 "object",
+		AdditionalProperties: jsonSchema{Type: "string"},
+	}
+	questionnaire := objectSchema(
+		[]string{"questionnaireVersion", "answers"},
+		map[string]jsonSchema{
+			"questionnaireVersion": {Type: "integer", Minimum: &zero},
+			"answers":              answers,
+		},
+	)
+	productInput := func(status string) jsonSchema {
+		if status == "interested" {
+			return objectSchema(
+				[]string{"status"},
+				map[string]jsonSchema{
+					"status": {Type: "string", Enum: []string{"interested"}},
+				},
+			)
+		}
+		properties := map[string]jsonSchema{
+			"status":                {Type: "string", Enum: []string{status}},
+			"displayName":           {Type: "string", MinLength: &one, MaxLength: &fifty, Pattern: `\S`},
+			"partySize":             {Type: "integer", Minimum: &one},
+			"plusOnes":              {Type: "array", Items: &stringItem},
+			"message":               {Type: []string{"string", "null"}, MaxLength: &fourHundred},
+			"timezone":              {Type: "string", MinLength: &one},
+			"questionnaireResponse": {Type: "null"},
+		}
+		if status == "going" {
+			properties["questionnaireResponse"] = jsonSchema{
+				OneOf: []jsonSchema{questionnaire, {Type: "null"}},
+			}
+		}
+		return objectSchema(
+			[]string{
+				"status",
+				"displayName",
+				"partySize",
+				"plusOnes",
+				"message",
+				"timezone",
+				"questionnaireResponse",
+			},
+			properties,
+		)
+	}
+	submitted := objectSchema(
+		[]string{"eventId", "intent", "submitted"},
+		map[string]jsonSchema{
+			"eventId":   {Type: "string", MinLength: &one},
+			"intent":    {Type: "string", Enum: []string{"going", "not-going", "interested"}},
+			"submitted": {Type: "boolean", Const: true},
+		},
+	)
+	plusOne := objectSchema(
+		[]string{"name"},
+		map[string]jsonSchema{
+			"name": {Type: "string", MinLength: &one, Pattern: `\S`},
+		},
+	)
+	draft := objectSchema(
+		[]string{"name", "count", "plusOnes", "status", "timezone", "shouldFollowOrgs"},
+		map[string]jsonSchema{
+			"name":                  {Type: "string", MinLength: &one, MaxLength: &fifty},
+			"count":                 {Type: "integer", Minimum: &one},
+			"plusOnes":              {Type: "array", Items: &plusOne},
+			"message":               {Type: "string", MaxLength: &fourHundred},
+			"status":                {Type: "string", Enum: []string{"GOING", "DECLINED"}},
+			"guestId":               {Type: "string", Enum: []string{"<redacted>"}},
+			"timezone":              {Type: "string", MinLength: &one},
+			"questionnaireResponse": questionnaire,
+			"shouldFollowOrgs":      {Type: "boolean", Const: false},
+		},
+	)
+	addGuestRequest := objectSchema(
+		[]string{"eventId", "rsvp"},
+		map[string]jsonSchema{
+			"eventId": {Type: "string", MinLength: &one},
+			"rsvp":    draft,
+		},
+	)
+	interestRequest := objectSchema(
+		[]string{"eventId", "interested"},
+		map[string]jsonSchema{
+			"eventId":    {Type: "string", MinLength: &one},
+			"interested": {Type: "boolean", Const: true},
+		},
+	)
+	preconditions := objectSchema(
+		[]string{"currentGuest", "eventSafeguards"},
+		map[string]jsonSchema{
+			"currentGuest":    {Type: "string", Enum: []string{"absent", "present"}},
+			"eventSafeguards": {Type: "string", Enum: []string{"bound"}},
+		},
+	)
+	plan := objectSchema(
+		[]string{
+			"operation",
+			"mode",
+			"input",
+			"request",
+			"preconditions",
+			"expiresInSeconds",
+			"planToken",
+		},
+		map[string]jsonSchema{
+			"operation": {Type: "string", Enum: []string{"addGuest", "markEventInterest"}},
+			"mode":      {Type: "string", Enum: []string{"create", "update"}},
+			"input": {
+				OneOf: []jsonSchema{
+					productInput("going"),
+					productInput("not-going"),
+					productInput("interested"),
+				},
+			},
+			"request": {
+				OneOf: []jsonSchema{addGuestRequest, interestRequest},
+			},
+			"preconditions":    preconditions,
+			"expiresInSeconds": {Type: "integer", Minimum: &threeHundred, Maximum: &threeHundred},
+			"planToken":        {Type: "string", MinLength: &one},
+		},
+	)
+	return jsonSchema{Type: "object", OneOf: []jsonSchema{plan, submitted}}
+}
+
+func standardMutationSafety() safetyDefinition {
+	return safetyDefinition{
+		Kind:                 "standard-mutation",
+		PlanRequired:         true,
+		ConfirmationRequired: false,
+	}
+}

--- a/internal/app/rsvp_set.go
+++ b/internal/app/rsvp_set.go
@@ -1,0 +1,518 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"math"
+	"strings"
+	"time"
+
+	"github.com/KalebCole/partiful-cli/internal/mutation"
+	"github.com/KalebCole/partiful-cli/internal/remote"
+)
+
+type rsvpPlan struct {
+	Operation        string                  `json:"operation"`
+	Mode             string                  `json:"mode"`
+	Input            any                     `json:"input"`
+	Request          any                     `json:"request"`
+	Preconditions    rsvpPublicPreconditions `json:"preconditions"`
+	ExpiresInSeconds int                     `json:"expiresInSeconds"`
+	PlanToken        string                  `json:"planToken"`
+}
+
+type rsvpPublicPreconditions struct {
+	CurrentGuest    string `json:"currentGuest"`
+	EventSafeguards string `json:"eventSafeguards"`
+}
+
+type rsvpSubmitted struct {
+	EventID   string `json:"eventId"`
+	Intent    string `json:"intent"`
+	Submitted bool   `json:"submitted"`
+}
+
+type rsvpPrivatePreconditions struct {
+	CurrentGuest rsvpPrivateCurrentGuest `json:"currentGuest"`
+	Event        remote.EventSafeguards  `json:"event"`
+}
+
+type rsvpPrivateCurrentGuest struct {
+	Marker  string `json:"marker"`
+	GuestID string `json:"guestId,omitempty"`
+	Status  string `json:"status,omitempty"`
+	Count   *int   `json:"count,omitempty"`
+}
+
+type rsvpPreparedRequest struct {
+	Operation     string
+	Mode          string
+	Private       any
+	Public        any
+	Preconditions rsvpPrivatePreconditions
+}
+
+type rsvpCompatibilityError uint8
+
+const (
+	rsvpProtocolError rsvpCompatibilityError = iota + 1
+	rsvpStateError
+	rsvpQuestionnaireInputError
+)
+
+func executeRSVPSet(
+	ctx context.Context,
+	request Request,
+	definition commandDefinition,
+	argv []string,
+	dependencies Dependencies,
+	pretty bool,
+) Result {
+	options, inputError := parseRSVPSetOptions(
+		request,
+		definition,
+		argv,
+		dependencies,
+	)
+	if inputError != nil {
+		return failure(definition.path, 2, *inputError, pretty)
+	}
+	session, sessionFailure := acquireProtectedSession(
+		ctx,
+		definition.path,
+		dependencies,
+		pretty,
+	)
+	if sessionFailure != nil {
+		return *sessionFailure
+	}
+	if session.AccountFingerprint == "" {
+		return internalFailure(definition.path, pretty)
+	}
+	clock := time.Now
+	if dependencies.Now != nil {
+		clock = dependencies.Now
+	}
+	authority := mutation.Authority{
+		Files:  dependencies.Files,
+		Path:   mutationPath(dependencies),
+		Now:    clock,
+		Random: dependencies.MutationRandom,
+	}
+	inputDocument := options.Input.document()
+	var inspected mutation.Record
+	if options.Apply {
+		var err error
+		inspected, err = authority.Inspect(
+			options.PlanToken,
+			definition.path,
+			rsvpOperation(options.Input),
+			session.AccountFingerprint,
+			inputDocument,
+		)
+		if err != nil {
+			if errors.Is(err, mutation.ErrStale) {
+				return rsvpPlanStaleFailure(definition.path, pretty)
+			}
+			return internalFailure(definition.path, pretty)
+		}
+	}
+	deviceID, err := randomDeviceID(dependencies.AuthRandom)
+	if err != nil {
+		return internalFailure(definition.path, pretty)
+	}
+	client := remote.Client{HTTP: dependencies.HTTP}
+	event, err := client.GetEventInfo(
+		ctx,
+		session.AccessToken,
+		deviceID,
+		options.EventID,
+	)
+	if err != nil {
+		switch {
+		case errors.Is(err, remote.ErrEventNotFound):
+			if options.Apply {
+				return rsvpPlanStaleFailure(definition.path, pretty)
+			}
+			return eventNotFoundFailure(definition.path, pretty)
+		case errors.Is(err, remote.ErrUnavailable):
+			return rsvpUnavailableFailure(definition.path, pretty)
+		default:
+			return rsvpProtocolChangedFailure(definition.path, pretty)
+		}
+	}
+	currentGuest, err := client.GetCurrentGuest(
+		ctx,
+		session.AccessToken,
+		deviceID,
+		options.EventID,
+	)
+	if err != nil {
+		if errors.Is(err, remote.ErrUnavailable) {
+			return rsvpUnavailableFailure(definition.path, pretty)
+		}
+		return rsvpProtocolChangedFailure(definition.path, pretty)
+	}
+	privateCurrentGuest, currentGuestError := normalizeRSVPCurrentGuest(currentGuest)
+	preconditions := rsvpPrivatePreconditions{
+		CurrentGuest: privateCurrentGuest,
+		Event:        event.Safeguards,
+	}
+	preconditionDocument, _ := json.Marshal(preconditions)
+	if options.Apply &&
+		!bytes.Equal(inspected.Binding.Preconditions, preconditionDocument) {
+		return rsvpPlanStaleFailure(definition.path, pretty)
+	}
+	if currentGuestError != 0 {
+		return rsvpCompatibilityFailure(
+			definition.path,
+			currentGuestError,
+			pretty,
+		)
+	}
+	prepared, compatibilityError := prepareRSVPRequest(
+		options.EventID,
+		options.Input,
+		event.Safeguards,
+		privateCurrentGuest,
+	)
+	if compatibilityError != 0 {
+		return rsvpCompatibilityFailure(
+			definition.path,
+			compatibilityError,
+			pretty,
+		)
+	}
+	requestDocument, _ := json.Marshal(prepared.Private)
+	binding := mutation.Binding{
+		Command:            definition.path,
+		Operation:          prepared.Operation,
+		AccountFingerprint: session.AccountFingerprint,
+		Input:              inputDocument,
+		Request:            requestDocument,
+		Preconditions:      preconditionDocument,
+	}
+	if options.Apply {
+		if !bytes.Equal(inspected.Binding.Request, requestDocument) {
+			return rsvpPlanStaleFailure(definition.path, pretty)
+		}
+		if err := authority.Consume(options.PlanToken, binding); err != nil {
+			if errors.Is(err, mutation.ErrStale) {
+				return rsvpPlanStaleFailure(definition.path, pretty)
+			}
+			return internalFailure(definition.path, pretty)
+		}
+		switch params := prepared.Private.(type) {
+		case remote.AddGuestParams:
+			err = client.AddGuest(
+				ctx,
+				session.AccessToken,
+				deviceID,
+				params,
+			)
+		case remote.MarkEventInterestParams:
+			err = client.MarkEventInterest(
+				ctx,
+				session.AccessToken,
+				deviceID,
+				params,
+			)
+		default:
+			return internalFailure(definition.path, pretty)
+		}
+		if err != nil {
+			if errors.Is(err, remote.ErrUnavailable) {
+				return rsvpSubmitUnavailableFailure(definition.path, pretty)
+			}
+			return rsvpProtocolChangedFailure(definition.path, pretty)
+		}
+		return success(definition.path, rsvpSubmitted{
+			EventID:   options.EventID,
+			Intent:    options.Input.Intent,
+			Submitted: true,
+		}, pretty)
+	}
+
+	token, err := authority.Create(binding)
+	if err != nil {
+		return internalFailure(definition.path, pretty)
+	}
+	return success(definition.path, rsvpPlan{
+		Operation: prepared.Operation,
+		Mode:      prepared.Mode,
+		Input:     options.Input.public(),
+		Request:   prepared.Public,
+		Preconditions: rsvpPublicPreconditions{
+			CurrentGuest:    prepared.Preconditions.CurrentGuest.Marker,
+			EventSafeguards: "bound",
+		},
+		ExpiresInSeconds: 300,
+		PlanToken:        token,
+	}, pretty)
+}
+
+func rsvpOperation(input normalizedRSVPInput) string {
+	if input.Intent == "interested" {
+		return "markEventInterest"
+	}
+	return "addGuest"
+}
+
+func prepareRSVPRequest(
+	eventID string,
+	input normalizedRSVPInput,
+	event remote.EventSafeguards,
+	currentGuest rsvpPrivateCurrentGuest,
+) (rsvpPreparedRequest, rsvpCompatibilityError) {
+	if errKind := validateRSVPEvent(event, input, currentGuest); errKind != 0 {
+		return rsvpPreparedRequest{}, errKind
+	}
+	mode := "create"
+	if currentGuest.Marker == "present" {
+		mode = "update"
+	}
+	preconditions := rsvpPrivatePreconditions{
+		CurrentGuest: currentGuest,
+		Event:        event,
+	}
+	if input.Intent == "interested" {
+		params := remote.MarkEventInterestParams{
+			EventID:    eventID,
+			Interested: true,
+		}
+		return rsvpPreparedRequest{
+			Operation:     "markEventInterest",
+			Mode:          mode,
+			Private:       params,
+			Public:        params,
+			Preconditions: preconditions,
+		}, 0
+	}
+	product := input.AddGuest
+	plusOnes := make([]remote.NamedPlusOne, len(product.PlusOnes))
+	for index, name := range product.PlusOnes {
+		plusOnes[index] = remote.NamedPlusOne{Name: name}
+	}
+	var questionnaire *remote.QuestionnaireResponse
+	if product.QuestionnaireResponse != nil {
+		questionnaire = &remote.QuestionnaireResponse{
+			QuestionnaireVersion: product.QuestionnaireResponse.QuestionnaireVersion,
+			Answers:              cloneRSVPAnswers(product.QuestionnaireResponse.Answers),
+		}
+	}
+	status := "GOING"
+	if input.Intent == "not-going" {
+		status = "DECLINED"
+	}
+	var guestID *string
+	if currentGuest.Marker == "present" {
+		guestID = &currentGuest.GuestID
+	}
+	privateParams := remote.AddGuestParams{
+		EventID: eventID,
+		RSVP: remote.RSVPDraft{
+			Name:                  product.DisplayName,
+			Count:                 product.PartySize,
+			PlusOnes:              plusOnes,
+			Message:               product.Message,
+			Status:                status,
+			GuestID:               guestID,
+			Timezone:              product.Timezone,
+			QuestionnaireResponse: questionnaire,
+			ShouldFollowOrgs:      false,
+		},
+	}
+	publicParams := privateParams
+	if publicParams.RSVP.GuestID != nil {
+		redacted := "<redacted>"
+		publicParams.RSVP.GuestID = &redacted
+	}
+	return rsvpPreparedRequest{
+		Operation:     "addGuest",
+		Mode:          mode,
+		Private:       privateParams,
+		Public:        publicParams,
+		Preconditions: preconditions,
+	}, 0
+}
+
+func normalizeRSVPCurrentGuest(
+	current remote.CurrentGuest,
+) (rsvpPrivateCurrentGuest, rsvpCompatibilityError) {
+	if !current.Present {
+		return rsvpPrivateCurrentGuest{Marker: "absent"}, 0
+	}
+	snapshot := rsvpPrivateCurrentGuest{
+		Marker:  "present",
+		GuestID: current.ID,
+		Status:  current.Status,
+	}
+	if strings.TrimSpace(current.ID) == "" ||
+		current.Status == "" ||
+		current.Count == nil ||
+		*current.Count < 0 ||
+		math.Trunc(*current.Count) != *current.Count ||
+		*current.Count > float64(maxInt()) {
+		return snapshot, rsvpProtocolError
+	}
+	count := int(*current.Count)
+	snapshot.Count = &count
+	return snapshot, 0
+}
+
+func maxInt() int {
+	return int(^uint(0) >> 1)
+}
+
+func validateRSVPEvent(
+	event remote.EventSafeguards,
+	input normalizedRSVPInput,
+	current rsvpPrivateCurrentGuest,
+) rsvpCompatibilityError {
+	if event.RSVPsEnabled.State != remote.FieldValue ||
+		event.AtCapacity.State != remote.FieldValue ||
+		event.PlusOneNamesRequired.State != remote.FieldValue ||
+		event.QuestionnaireVersions.State == remote.FieldAbsent ||
+		event.MaxCountPerGuest.State == remote.FieldNull ||
+		event.RemainingCapacity.State == remote.FieldNull {
+		return rsvpProtocolError
+	}
+	if event.MaxCountPerGuest.State == remote.FieldValue &&
+		event.MaxCountPerGuest.Value < 1 {
+		return rsvpProtocolError
+	}
+	if event.GuestAction.State != remote.FieldAbsent &&
+		(event.GuestAction.State != remote.FieldValue ||
+			event.GuestAction.Value != "RSVP" &&
+				event.GuestAction.Value != "APPLY") {
+		return rsvpProtocolError
+	}
+	if event.Password.State == remote.FieldNull ||
+		event.PasswordProtected.State == remote.FieldNull ||
+		event.QuestionnaireEnabled.State == remote.FieldNull {
+		return rsvpProtocolError
+	}
+	if !event.RSVPsEnabled.Value ||
+		event.GuestAction.State == remote.FieldValue &&
+			event.GuestAction.Value == "APPLY" ||
+		event.Ticketing.State == remote.FieldValue ||
+		event.Password.State == remote.FieldValue ||
+		event.PasswordProtected.State == remote.FieldValue {
+		return rsvpStateError
+	}
+	if input.Intent == "interested" {
+		return 0
+	}
+	product := input.AddGuest
+	if event.MaxCountPerGuest.State == remote.FieldValue &&
+		product.PartySize > event.MaxCountPerGuest.Value {
+		return rsvpStateError
+	}
+	if event.MaxCapacity.State == remote.FieldValue &&
+		event.RemainingCapacity.State != remote.FieldValue {
+		return rsvpStateError
+	}
+	if input.Intent == "going" {
+		if event.AtCapacity.Value {
+			return rsvpStateError
+		}
+		currentCapacityCount := 0
+		if current.Marker == "present" &&
+			(current.Status == "GOING" || current.Status == "APPROVED") {
+			currentCapacityCount = *current.Count
+		}
+		additionalCount := max(0, product.PartySize-currentCapacityCount)
+		if event.RemainingCapacity.State == remote.FieldValue &&
+			additionalCount > event.RemainingCapacity.Value {
+			return rsvpStateError
+		}
+		if event.QuestionnaireEnabled.State == remote.FieldValue &&
+			event.QuestionnaireEnabled.Value {
+			if event.QuestionnaireVersions.State != remote.FieldValue ||
+				event.QuestionnaireVersions.Length == 0 {
+				return rsvpStateError
+			}
+			if product.QuestionnaireResponse == nil ||
+				product.QuestionnaireResponse.QuestionnaireVersion !=
+					event.QuestionnaireVersions.Length-1 {
+				return rsvpQuestionnaireInputError
+			}
+		} else if product.QuestionnaireResponse != nil {
+			return rsvpQuestionnaireInputError
+		}
+	}
+	return 0
+}
+
+func cloneRSVPAnswers(source map[string]string) map[string]string {
+	result := make(map[string]string, len(source))
+	for key, value := range source {
+		result[key] = value
+	}
+	return result
+}
+
+func mutationPath(dependencies Dependencies) string {
+	if dependencies.MutationPath != "" {
+		return dependencies.MutationPath
+	}
+	if dependencies.CredentialsPath == "" {
+		return ""
+	}
+	return dependencies.CredentialsPath + ".mutation-plans"
+}
+
+func rsvpCompatibilityFailure(
+	command string,
+	kind rsvpCompatibilityError,
+	pretty bool,
+) Result {
+	switch kind {
+	case rsvpStateError:
+		result := failure(command, 6, errorBody{
+			Type:      "state.conflict",
+			Code:      "RSVP_EVENT_UNSUPPORTED",
+			Message:   "The event does not support this RSVP safely.",
+			Retryable: false,
+			Details:   map[string]any{},
+		}, pretty)
+		result.Stderr = "partiful: RSVP event unsupported\n"
+		return result
+	case rsvpQuestionnaireInputError:
+		return failure(command, 2, errorBody{
+			Type:      "input.invalid",
+			Code:      "QUESTIONNAIRE_RESPONSE_INVALID",
+			Message:   "Questionnaire response does not match the event.",
+			Retryable: false,
+			Details:   map[string]any{},
+		}, pretty)
+	default:
+		return rsvpProtocolChangedFailure(command, pretty)
+	}
+}
+
+func rsvpPlanStaleFailure(command string, pretty bool) Result {
+	result := failure(command, 7, errorBody{
+		Type:      "safety.plan_stale",
+		Code:      "PLAN_STALE",
+		Message:   "The mutation plan is expired, used, or no longer matches.",
+		Retryable: false,
+		Details:   map[string]any{},
+	}, pretty)
+	result.Stderr = "partiful: mutation plan stale\n"
+	return result
+}
+
+func rsvpSubmitUnavailableFailure(command string, pretty bool) Result {
+	result := failure(command, 8, errorBody{
+		Type:      "remote.unavailable",
+		Code:      "RSVP_SUBMISSION_UNCERTAIN",
+		Message:   "RSVP submission could not be confirmed. Create a new plan before another attempt.",
+		Retryable: false,
+		Details:   map[string]any{},
+	}, pretty)
+	result.Stderr = "partiful: RSVP submission uncertain\n"
+	return result
+}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -44,8 +45,9 @@ type State struct {
 }
 
 type Session struct {
-	AccessToken string
-	UserID      string
+	AccessToken        string
+	UserID             string
+	AccountFingerprint string
 }
 
 type credentialRecord struct {
@@ -193,14 +195,15 @@ func AcquireSession(
 			return
 		}
 		state := stateFromCredentials(credentials, now())
-		userID := credentials.UserID
+		userID := tokenUserID(credentials.AccessToken)
 		if userID == "" {
-			userID = tokenUserID(credentials.AccessToken)
+			userID = credentials.UserID
 		}
 		if state.TokenState == "healthy" {
 			session = Session{
-				AccessToken: credentials.AccessToken,
-				UserID:      userID,
+				AccessToken:        credentials.AccessToken,
+				UserID:             userID,
+				AccountFingerprint: accountFingerprint(userID),
 			}
 			return
 		}
@@ -210,8 +213,9 @@ func AcquireSession(
 				return
 			}
 			session = Session{
-				AccessToken: credentials.AccessToken,
-				UserID:      userID,
+				AccessToken:        credentials.AccessToken,
+				UserID:             userID,
+				AccountFingerprint: accountFingerprint(userID),
 			}
 			return
 		}
@@ -235,8 +239,9 @@ func AcquireSession(
 			return
 		}
 		session = Session{
-			AccessToken: credentials.AccessToken,
-			UserID:      credentials.UserID,
+			AccessToken:        credentials.AccessToken,
+			UserID:             credentials.UserID,
+			AccountFingerprint: accountFingerprint(credentials.UserID),
 		}
 	}); err != nil {
 		return Session{}, ErrUnavailable
@@ -371,6 +376,14 @@ func tokenUserID(token string) string {
 		return ""
 	}
 	return claims.Subject
+}
+
+func accountFingerprint(userID string) string {
+	if userID == "" {
+		return ""
+	}
+	digest := sha256.Sum256([]byte("partiful-account-v1\x00" + userID))
+	return base64.RawURLEncoding.EncodeToString(digest[:])
 }
 
 func missingState() State {

--- a/internal/mutation/mutation.go
+++ b/internal/mutation/mutation.go
@@ -1,0 +1,243 @@
+package mutation
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"io/fs"
+	"time"
+)
+
+const (
+	recordVersion = 1
+	tokenBytes    = 32
+)
+
+var (
+	ErrStale       = errors.New("mutation plan is stale")
+	ErrUnavailable = errors.New("mutation plan storage is unavailable")
+)
+
+type FileSystem interface {
+	ReadFile(string) ([]byte, error)
+	WriteFileAtomic(string, []byte) error
+	WithLock(string, func()) error
+}
+
+type Binding struct {
+	Command            string          `json:"command"`
+	Operation          string          `json:"operation"`
+	AccountFingerprint string          `json:"accountFingerprint"`
+	Input              json.RawMessage `json:"input"`
+	Request            json.RawMessage `json:"request"`
+	Preconditions      json.RawMessage `json:"preconditions"`
+}
+
+type Record struct {
+	Binding   Binding   `json:"binding"`
+	CreatedAt time.Time `json:"createdAt"`
+	ExpiresAt time.Time `json:"expiresAt"`
+}
+
+type Authority struct {
+	Files  FileSystem
+	Path   string
+	Now    func() time.Time
+	Random io.Reader
+}
+
+type document struct {
+	Version int               `json:"version"`
+	Records map[string]Record `json:"records"`
+}
+
+func (authority Authority) Create(binding Binding) (string, error) {
+	if !authority.configured() || authority.Random == nil || !validBinding(binding) {
+		return "", ErrUnavailable
+	}
+	var (
+		token        string
+		operationErr error
+	)
+	if err := authority.Files.WithLock(authority.Path, func() {
+		stored, err := authority.load()
+		if err != nil {
+			operationErr = err
+			return
+		}
+		now := authority.Now().UTC()
+		for candidate, record := range stored.Records {
+			if !record.ExpiresAt.After(now) {
+				delete(stored.Records, candidate)
+			}
+		}
+		random := make([]byte, tokenBytes)
+		if _, err := io.ReadFull(authority.Random, random); err != nil {
+			operationErr = ErrUnavailable
+			return
+		}
+		token = base64.RawURLEncoding.EncodeToString(random)
+		if _, exists := stored.Records[token]; exists {
+			operationErr = ErrUnavailable
+			return
+		}
+		stored.Records[token] = Record{
+			Binding:   cloneBinding(binding),
+			CreatedAt: now,
+			ExpiresAt: now.Add(5 * time.Minute),
+		}
+		operationErr = authority.save(stored)
+	}); err != nil {
+		return "", ErrUnavailable
+	}
+	if operationErr != nil {
+		return "", operationErr
+	}
+	return token, nil
+}
+
+func (authority Authority) Inspect(
+	token string,
+	command string,
+	operation string,
+	accountFingerprint string,
+	input json.RawMessage,
+) (Record, error) {
+	if !authority.configured() || token == "" {
+		return Record{}, ErrStale
+	}
+	var (
+		record       Record
+		operationErr error
+	)
+	if err := authority.Files.WithLock(authority.Path, func() {
+		stored, err := authority.load()
+		if err != nil {
+			operationErr = err
+			return
+		}
+		candidate, ok := stored.Records[token]
+		if !ok ||
+			!candidate.ExpiresAt.After(authority.Now().UTC()) ||
+			candidate.Binding.Command != command ||
+			candidate.Binding.Operation != operation ||
+			candidate.Binding.AccountFingerprint != accountFingerprint ||
+			!bytes.Equal(candidate.Binding.Input, input) {
+			operationErr = ErrStale
+			return
+		}
+		record = cloneRecord(candidate)
+	}); err != nil {
+		return Record{}, ErrUnavailable
+	}
+	if operationErr != nil {
+		return Record{}, operationErr
+	}
+	return record, nil
+}
+
+func (authority Authority) Consume(
+	token string,
+	binding Binding,
+) error {
+	if !authority.configured() || token == "" || !validBinding(binding) {
+		return ErrStale
+	}
+	var operationErr error
+	if err := authority.Files.WithLock(authority.Path, func() {
+		stored, err := authority.load()
+		if err != nil {
+			operationErr = err
+			return
+		}
+		record, ok := stored.Records[token]
+		if !ok ||
+			!record.ExpiresAt.After(authority.Now().UTC()) ||
+			!equalBinding(record.Binding, binding) {
+			operationErr = ErrStale
+			return
+		}
+		delete(stored.Records, token)
+		operationErr = authority.save(stored)
+	}); err != nil {
+		return ErrUnavailable
+	}
+	return operationErr
+}
+
+func (authority Authority) configured() bool {
+	return authority.Files != nil && authority.Path != "" && authority.Now != nil
+}
+
+func (authority Authority) load() (document, error) {
+	raw, err := authority.Files.ReadFile(authority.Path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return document{Version: recordVersion, Records: make(map[string]Record)}, nil
+	}
+	if err != nil {
+		return document{}, ErrUnavailable
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	var stored document
+	if decoder.Decode(&stored) != nil ||
+		stored.Version != recordVersion ||
+		stored.Records == nil {
+		return document{}, ErrUnavailable
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return document{}, ErrUnavailable
+	}
+	for token, record := range stored.Records {
+		decoded, err := base64.RawURLEncoding.DecodeString(token)
+		if err != nil ||
+			len(decoded) != tokenBytes ||
+			record.CreatedAt.IsZero() ||
+			record.ExpiresAt.IsZero() ||
+			!validBinding(record.Binding) {
+			return document{}, ErrUnavailable
+		}
+	}
+	return stored, nil
+}
+
+func (authority Authority) save(stored document) error {
+	raw, err := json.Marshal(stored)
+	if err != nil || authority.Files.WriteFileAtomic(authority.Path, raw) != nil {
+		return ErrUnavailable
+	}
+	return nil
+}
+
+func validBinding(binding Binding) bool {
+	return binding.Command != "" &&
+		binding.Operation != "" &&
+		binding.AccountFingerprint != "" &&
+		json.Valid(binding.Input) &&
+		json.Valid(binding.Request) &&
+		json.Valid(binding.Preconditions)
+}
+
+func equalBinding(left, right Binding) bool {
+	return left.Command == right.Command &&
+		left.Operation == right.Operation &&
+		left.AccountFingerprint == right.AccountFingerprint &&
+		bytes.Equal(left.Input, right.Input) &&
+		bytes.Equal(left.Request, right.Request) &&
+		bytes.Equal(left.Preconditions, right.Preconditions)
+}
+
+func cloneBinding(binding Binding) Binding {
+	binding.Input = bytes.Clone(binding.Input)
+	binding.Request = bytes.Clone(binding.Request)
+	binding.Preconditions = bytes.Clone(binding.Preconditions)
+	return binding
+}
+
+func cloneRecord(record Record) Record {
+	record.Binding = cloneBinding(record.Binding)
+	return record
+}

--- a/internal/remote/events.go
+++ b/internal/remote/events.go
@@ -33,6 +33,55 @@ type Event struct {
 	OwnerIDsPresent bool
 	GuestPresent    bool
 	GuestStatus     *string
+	Safeguards      EventSafeguards
+}
+
+type FieldState string
+
+const (
+	FieldAbsent FieldState = "absent"
+	FieldNull   FieldState = "null"
+	FieldValue  FieldState = "value"
+)
+
+type BooleanField struct {
+	State FieldState `json:"state"`
+	Value bool       `json:"value,omitempty"`
+}
+
+type IntegerField struct {
+	State FieldState `json:"state"`
+	Value int        `json:"value,omitempty"`
+}
+
+type StringField struct {
+	State FieldState `json:"state"`
+	Value string     `json:"value,omitempty"`
+}
+
+type PresenceField struct {
+	State FieldState `json:"state"`
+}
+
+type ArrayField struct {
+	State  FieldState `json:"state"`
+	Length int        `json:"length,omitempty"`
+}
+
+type EventSafeguards struct {
+	RSVPsEnabled          BooleanField  `json:"rsvpsEnabled"`
+	AtCapacity            BooleanField  `json:"atCapacity"`
+	PlusOneNamesRequired  BooleanField  `json:"plusOneNamesRequired"`
+	GuestAction           StringField   `json:"guestAction"`
+	Ticketing             PresenceField `json:"ticketing"`
+	Password              PresenceField `json:"password"`
+	PasswordProtected     PresenceField `json:"passwordProtected"`
+	QuestionnaireEnabled  BooleanField  `json:"questionnaireEnabled"`
+	QuestionnaireVersions ArrayField    `json:"questionnaireVersions"`
+	MaxCountPerGuest      IntegerField  `json:"maxCountPerGuest"`
+	MaxCapacity           IntegerField  `json:"maxCapacity"`
+	RemainingCapacity     IntegerField  `json:"remainingCapacity"`
+	EnableWaitlist        BooleanField  `json:"enableWaitlist"`
 }
 
 type EventCatalog struct {
@@ -371,13 +420,223 @@ func decodeEventInfo(raw json.RawMessage) (Event, error) {
 	if err := validateEventObjectOrNull(object, "displaySettings", false); err != nil {
 		return Event{}, err
 	}
+	safeguards, err := decodeEventSafeguards(object)
+	if err != nil {
+		return Event{}, err
+	}
 	return Event{
-		Title:    title,
-		Start:    start,
-		End:      end,
-		Timezone: timezone,
-		Status:   status,
+		Title:      title,
+		Start:      start,
+		End:        end,
+		Timezone:   timezone,
+		Status:     status,
+		Safeguards: safeguards,
 	}, nil
+}
+
+func decodeEventSafeguards(
+	object map[string]json.RawMessage,
+) (EventSafeguards, error) {
+	rsvpsEnabled, err := eventBooleanField(object, "rsvpsEnabled", false)
+	if err != nil {
+		return EventSafeguards{}, err
+	}
+	atCapacity, err := eventBooleanField(object, "atCapacity", false)
+	if err != nil {
+		return EventSafeguards{}, err
+	}
+	plusOneNamesRequired, err := eventBooleanField(
+		object,
+		"plusOneNamesRequired",
+		false,
+	)
+	if err != nil {
+		return EventSafeguards{}, err
+	}
+	guestAction, err := eventStringSafeguard(object, "guestAction")
+	if err != nil ||
+		guestAction.State == FieldValue &&
+			guestAction.Value != "APPLY" &&
+			guestAction.Value != "RSVP" {
+		return EventSafeguards{}, errors.New("guest action is invalid")
+	}
+	ticketing, err := eventObjectPresence(object, "ticketing")
+	if err != nil {
+		return EventSafeguards{}, err
+	}
+	questionnaireEnabled, err := eventBooleanField(
+		object,
+		"questionnaireEnabled",
+		false,
+	)
+	if err != nil {
+		return EventSafeguards{}, err
+	}
+	questionnaireVersions, err := eventArrayField(object, "questionnaireVersions")
+	if err != nil {
+		return EventSafeguards{}, err
+	}
+	maxCountPerGuest, err := eventIntegerField(
+		object,
+		"maxCountPerGuest",
+		false,
+	)
+	if err != nil {
+		return EventSafeguards{}, err
+	}
+	maxCapacity, err := eventIntegerField(object, "maxCapacity", true)
+	if err != nil {
+		return EventSafeguards{}, err
+	}
+	remainingCapacity, err := eventIntegerField(
+		object,
+		"remainingCapacity",
+		false,
+	)
+	if err != nil {
+		return EventSafeguards{}, err
+	}
+	enableWaitlist, err := eventBooleanField(object, "enableWaitlist", true)
+	if err != nil {
+		return EventSafeguards{}, err
+	}
+	password := eventUntypedPresence(object, "password")
+	passwordProtected := eventUntypedPresence(object, "passwordProtected")
+	return EventSafeguards{
+		RSVPsEnabled:          rsvpsEnabled,
+		AtCapacity:            atCapacity,
+		PlusOneNamesRequired:  plusOneNamesRequired,
+		GuestAction:           guestAction,
+		Ticketing:             ticketing,
+		Password:              password,
+		PasswordProtected:     passwordProtected,
+		QuestionnaireEnabled:  questionnaireEnabled,
+		QuestionnaireVersions: questionnaireVersions,
+		MaxCountPerGuest:      maxCountPerGuest,
+		MaxCapacity:           maxCapacity,
+		RemainingCapacity:     remainingCapacity,
+		EnableWaitlist:        enableWaitlist,
+	}, nil
+}
+
+func eventBooleanField(
+	object map[string]json.RawMessage,
+	name string,
+	nullAllowed bool,
+) (BooleanField, error) {
+	raw, ok := object[name]
+	if !ok {
+		return BooleanField{State: FieldAbsent}, nil
+	}
+	if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		if nullAllowed {
+			return BooleanField{State: FieldNull}, nil
+		}
+		return BooleanField{}, errors.New("boolean is null")
+	}
+	var value bool
+	if json.Unmarshal(raw, &value) != nil {
+		return BooleanField{}, errors.New("boolean is invalid")
+	}
+	return BooleanField{State: FieldValue, Value: value}, nil
+}
+
+func eventStringSafeguard(
+	object map[string]json.RawMessage,
+	name string,
+) (StringField, error) {
+	value, present, err := eventStringField(object, name, false)
+	if err != nil {
+		return StringField{}, err
+	}
+	if !present {
+		return StringField{State: FieldAbsent}, nil
+	}
+	return StringField{State: FieldValue, Value: *value}, nil
+}
+
+func eventObjectPresence(
+	object map[string]json.RawMessage,
+	name string,
+) (PresenceField, error) {
+	raw, ok := object[name]
+	if !ok {
+		return PresenceField{State: FieldAbsent}, nil
+	}
+	if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return PresenceField{State: FieldNull}, nil
+	}
+	if _, err := decodeEventObject(raw); err != nil {
+		return PresenceField{}, err
+	}
+	return PresenceField{State: FieldValue}, nil
+}
+
+func eventUntypedPresence(
+	object map[string]json.RawMessage,
+	name string,
+) PresenceField {
+	raw, ok := object[name]
+	if !ok {
+		return PresenceField{State: FieldAbsent}
+	}
+	if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return PresenceField{State: FieldNull}
+	}
+	return PresenceField{State: FieldValue}
+}
+
+func eventArrayField(
+	object map[string]json.RawMessage,
+	name string,
+) (ArrayField, error) {
+	raw, ok := object[name]
+	if !ok {
+		return ArrayField{State: FieldAbsent}, nil
+	}
+	if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return ArrayField{State: FieldNull}, nil
+	}
+	if !isEventJSONKind(raw, '[') {
+		return ArrayField{}, errors.New("array is invalid")
+	}
+	var values []json.RawMessage
+	if json.Unmarshal(raw, &values) != nil || values == nil {
+		return ArrayField{}, errors.New("array is invalid")
+	}
+	return ArrayField{State: FieldValue, Length: len(values)}, nil
+}
+
+func eventIntegerField(
+	object map[string]json.RawMessage,
+	name string,
+	nullAllowed bool,
+) (IntegerField, error) {
+	raw, ok := object[name]
+	if !ok {
+		return IntegerField{State: FieldAbsent}, nil
+	}
+	if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		if nullAllowed {
+			return IntegerField{State: FieldNull}, nil
+		}
+		return IntegerField{}, errors.New("integer is null")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value any
+	if decoder.Decode(&value) != nil {
+		return IntegerField{}, errors.New("integer is invalid")
+	}
+	number, ok := value.(json.Number)
+	if !ok {
+		return IntegerField{}, errors.New("integer is invalid")
+	}
+	parsed, err := number.Int64()
+	if err != nil || int64(int(parsed)) != parsed {
+		return IntegerField{}, errors.New("integer is invalid")
+	}
+	return IntegerField{State: FieldValue, Value: int(parsed)}, nil
 }
 
 func validEventNotFound(body []byte) bool {

--- a/internal/remote/rsvp.go
+++ b/internal/remote/rsvp.go
@@ -1,0 +1,323 @@
+package remote
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+const maximumRSVPResponseBytes = 1 << 20
+
+type CurrentGuest struct {
+	Present bool
+	ID      string
+	Status  string
+	Count   *float64
+}
+
+type currentGuestRequest struct {
+	Data currentGuestRequestData `json:"data"`
+}
+
+type currentGuestRequestData struct {
+	Params            currentGuestParams `json:"params"`
+	AmplitudeDeviceID string             `json:"amplitudeDeviceId"`
+}
+
+type currentGuestParams struct {
+	EventID string `json:"eventId"`
+}
+
+type NamedPlusOne struct {
+	Name string `json:"name"`
+}
+
+type QuestionnaireResponse struct {
+	QuestionnaireVersion int               `json:"questionnaireVersion"`
+	Answers              map[string]string `json:"answers"`
+}
+
+type RSVPDraft struct {
+	Name                  string                 `json:"name"`
+	Count                 int                    `json:"count"`
+	PlusOnes              []NamedPlusOne         `json:"plusOnes"`
+	Message               *string                `json:"message,omitempty"`
+	Status                string                 `json:"status"`
+	GuestID               *string                `json:"guestId,omitempty"`
+	Timezone              string                 `json:"timezone"`
+	QuestionnaireResponse *QuestionnaireResponse `json:"questionnaireResponse,omitempty"`
+	ShouldFollowOrgs      bool                   `json:"shouldFollowOrgs"`
+}
+
+type AddGuestParams struct {
+	EventID string    `json:"eventId"`
+	RSVP    RSVPDraft `json:"rsvp"`
+}
+
+type MarkEventInterestParams struct {
+	EventID    string `json:"eventId"`
+	Interested bool   `json:"interested"`
+}
+
+type rsvpMutationRequest[T any] struct {
+	Data rsvpMutationRequestData[T] `json:"data"`
+}
+
+type rsvpMutationRequestData[T any] struct {
+	Params            T      `json:"params"`
+	AmplitudeDeviceID string `json:"amplitudeDeviceId"`
+}
+
+func (client Client) GetCurrentGuest(
+	ctx context.Context,
+	accessToken string,
+	amplitudeDeviceID string,
+	eventID string,
+) (CurrentGuest, error) {
+	if client.HTTP == nil {
+		return CurrentGuest{}, fmt.Errorf("%w: current guest transport", ErrUnavailable)
+	}
+	payload, _ := json.Marshal(currentGuestRequest{Data: currentGuestRequestData{
+		Params:            currentGuestParams{EventID: eventID},
+		AmplitudeDeviceID: amplitudeDeviceID,
+	}})
+	request, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		partifulCallableHost+"/getCurrentGuest",
+		bytes.NewReader(payload),
+	)
+	if err != nil {
+		return CurrentGuest{}, fmt.Errorf("%w: current guest request", ErrUnavailable)
+	}
+	request.Header.Set("Authorization", "Bearer "+accessToken)
+	request.Header.Set("Content-Type", "application/json")
+	response, err := client.HTTP.Do(request)
+	if err != nil {
+		return CurrentGuest{}, fmt.Errorf("%w: current guest request failed", ErrUnavailable)
+	}
+	if response == nil || response.Body == nil {
+		return CurrentGuest{}, fmt.Errorf("%w: current guest response", ErrProtocolChanged)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return CurrentGuest{}, fmt.Errorf("%w: current guest status", ErrProtocolChanged)
+	}
+	if !eventJSONContentType(response.Header.Get("Content-Type")) {
+		return CurrentGuest{}, fmt.Errorf("%w: current guest content type", ErrProtocolChanged)
+	}
+	body, err := io.ReadAll(io.LimitReader(response.Body, maximumRSVPResponseBytes+1))
+	if err != nil {
+		return CurrentGuest{}, fmt.Errorf("%w: current guest response read", ErrUnavailable)
+	}
+	if len(body) > maximumRSVPResponseBytes || !utf8.Valid(body) {
+		return CurrentGuest{}, fmt.Errorf("%w: current guest response body", ErrProtocolChanged)
+	}
+	root, err := decodeEventObject(body)
+	if err != nil {
+		return CurrentGuest{}, fmt.Errorf("%w: current guest response body", ErrProtocolChanged)
+	}
+	result, err := eventObjectField(root, "result")
+	if err != nil {
+		return CurrentGuest{}, fmt.Errorf("%w: current guest result", ErrProtocolChanged)
+	}
+	data, err := eventObjectField(result, "data")
+	if err != nil {
+		return CurrentGuest{}, fmt.Errorf("%w: current guest data", ErrProtocolChanged)
+	}
+	rawGuest, ok := data["currentGuest"]
+	if !ok {
+		return CurrentGuest{}, fmt.Errorf("%w: current guest value", ErrProtocolChanged)
+	}
+	if bytes.Equal(bytes.TrimSpace(rawGuest), []byte("null")) {
+		return CurrentGuest{}, nil
+	}
+	guest, err := decodeEventObject(rawGuest)
+	if err != nil {
+		return CurrentGuest{}, fmt.Errorf("%w: current guest value", ErrProtocolChanged)
+	}
+	id, idPresent, idErr := eventStringField(guest, "id", false)
+	status, statusPresent, statusErr := eventStringField(guest, "status", false)
+	if idErr != nil ||
+		!idPresent ||
+		strings.TrimSpace(*id) == "" ||
+		statusErr != nil ||
+		!statusPresent ||
+		!validGuestStatus(*status) {
+		return CurrentGuest{}, fmt.Errorf("%w: current guest identity", ErrProtocolChanged)
+	}
+	if _, _, err := eventStringField(guest, "name", false); err != nil {
+		return CurrentGuest{}, fmt.Errorf("%w: current guest name", ErrProtocolChanged)
+	}
+	count, err := optionalNumber(guest, "count")
+	if err != nil {
+		return CurrentGuest{}, fmt.Errorf("%w: current guest count", ErrProtocolChanged)
+	}
+	return CurrentGuest{
+		Present: true,
+		ID:      *id,
+		Status:  *status,
+		Count:   count,
+	}, nil
+}
+
+func (client Client) AddGuest(
+	ctx context.Context,
+	accessToken string,
+	amplitudeDeviceID string,
+	params AddGuestParams,
+) error {
+	data, err := callRSVPMutation(
+		client,
+		ctx,
+		accessToken,
+		amplitudeDeviceID,
+		"addGuest",
+		params,
+	)
+	if err != nil {
+		return err
+	}
+	if len(data) == 0 {
+		return fmt.Errorf("%w: add guest data", ErrProtocolChanged)
+	}
+	return nil
+}
+
+func (client Client) MarkEventInterest(
+	ctx context.Context,
+	accessToken string,
+	amplitudeDeviceID string,
+	params MarkEventInterestParams,
+) error {
+	rawData, err := callRSVPMutation(
+		client,
+		ctx,
+		accessToken,
+		amplitudeDeviceID,
+		"markEventInterest",
+		params,
+	)
+	if err != nil {
+		return err
+	}
+	data, err := decodeEventObject(rawData)
+	if err != nil {
+		return fmt.Errorf("%w: event interest data", ErrProtocolChanged)
+	}
+	success, successPresent := data["success"]
+	interested, interestedPresent := data["interested"]
+	var returnedInterested bool
+	if !successPresent ||
+		!jsonTruthy(success) ||
+		!interestedPresent ||
+		json.Unmarshal(interested, &returnedInterested) != nil ||
+		returnedInterested != params.Interested {
+		return fmt.Errorf("%w: event interest completion", ErrProtocolChanged)
+	}
+	return nil
+}
+
+func callRSVPMutation[T any](
+	client Client,
+	ctx context.Context,
+	accessToken string,
+	amplitudeDeviceID string,
+	operation string,
+	params T,
+) (json.RawMessage, error) {
+	if client.HTTP == nil {
+		return nil, fmt.Errorf("%w: RSVP transport", ErrUnavailable)
+	}
+	payload, _ := json.Marshal(rsvpMutationRequest[T]{
+		Data: rsvpMutationRequestData[T]{
+			Params:            params,
+			AmplitudeDeviceID: amplitudeDeviceID,
+		},
+	})
+	request, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		partifulCallableHost+"/"+operation,
+		bytes.NewReader(payload),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("%w: RSVP mutation request", ErrUnavailable)
+	}
+	request.Header.Set("Authorization", "Bearer "+accessToken)
+	request.Header.Set("Content-Type", "application/json")
+	response, err := client.HTTP.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("%w: RSVP mutation request failed", ErrUnavailable)
+	}
+	if response == nil || response.Body == nil {
+		return nil, fmt.Errorf("%w: RSVP mutation response", ErrProtocolChanged)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%w: RSVP mutation status", ErrProtocolChanged)
+	}
+	if !eventJSONContentType(response.Header.Get("Content-Type")) {
+		return nil, fmt.Errorf("%w: RSVP mutation content type", ErrProtocolChanged)
+	}
+	body, err := io.ReadAll(io.LimitReader(response.Body, maximumRSVPResponseBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("%w: RSVP mutation response read", ErrUnavailable)
+	}
+	if len(body) > maximumRSVPResponseBytes || !utf8.Valid(body) {
+		return nil, fmt.Errorf("%w: RSVP mutation response body", ErrProtocolChanged)
+	}
+	root, err := decodeEventObject(body)
+	if err != nil {
+		return nil, fmt.Errorf("%w: RSVP mutation response body", ErrProtocolChanged)
+	}
+	result, err := eventObjectField(root, "result")
+	if err != nil {
+		return nil, fmt.Errorf("%w: RSVP mutation result", ErrProtocolChanged)
+	}
+	data, ok := result["data"]
+	if !ok {
+		return nil, fmt.Errorf("%w: RSVP mutation data", ErrProtocolChanged)
+	}
+	return bytes.Clone(data), nil
+}
+
+func jsonTruthy(raw json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 ||
+		bytes.Equal(trimmed, []byte("null")) ||
+		bytes.Equal(trimmed, []byte("false")) ||
+		bytes.Equal(trimmed, []byte(`""`)) {
+		return false
+	}
+	if trimmed[0] == '"' {
+		var value string
+		return json.Unmarshal(trimmed, &value) == nil && value != ""
+	}
+	if trimmed[0] == '-' || trimmed[0] >= '0' && trimmed[0] <= '9' {
+		value, _ := strconv.ParseFloat(string(trimmed), 64)
+		return value != 0
+	}
+	return trimmed[0] == '{' || trimmed[0] == '[' || bytes.Equal(trimmed, []byte("true"))
+}
+
+func optionalNumber(
+	object map[string]json.RawMessage,
+	name string,
+) (*float64, error) {
+	raw, ok := object[name]
+	if !ok {
+		return nil, nil
+	}
+	var value float64
+	if json.Unmarshal(raw, &value) != nil {
+		return nil, fmt.Errorf("number is invalid")
+	}
+	return &value, nil
+}

--- a/internal/remote/rsvp.go
+++ b/internal/remote/rsvp.go
@@ -315,6 +315,9 @@ func optionalNumber(
 	if !ok {
 		return nil, nil
 	}
+	if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return nil, fmt.Errorf("number is invalid")
+	}
 	var value float64
 	if json.Unmarshal(raw, &value) != nil {
 		return nil, fmt.Errorf("number is invalid")

--- a/skills/partiful/references/rsvps-and-interest.md
+++ b/skills/partiful/references/rsvps-and-interest.md
@@ -1,23 +1,29 @@
 # RSVPs and Interest
 
 ```bash
-partiful events rsvp get <event-id>
-partiful events rsvp set <event-id> --dry-run
-partiful events rsvp set <event-id> --status going
-partiful events rsvp set <event-id> --status going --plus-one "Alex Smith"
-partiful events rsvp set <event-id> --status maybe --message "I may be late"
-partiful events rsvp set <event-id> --status declined
-partiful events interested <event-id>
-partiful events interested <event-id> --remove
+partiful rsvp get <event-id>
+partiful rsvp set <event-id> --status going --display-name "Example" \
+  --party-size 1 --timezone America/Los_Angeles
+partiful rsvp set <event-id> --status going --display-name "Example" \
+  --party-size 2 --plus-one "Guest One" --timezone America/Los_Angeles
+partiful rsvp set <event-id> --status not-going --display-name "Example" \
+  --party-size 1 --timezone America/Los_Angeles
+partiful rsvp set <event-id> --status interested
 ```
 
-`events rsvp get` reads your saved status and questionnaire answers without changing the RSVP. `explore rsvp get`, `explore rsvp set`, and `explore interested` are equivalent aliases under the discovery command group.
+`rsvp get` returns the current reviewed RSVP status or `null`. It does not
+return guest or account IDs.
 
-For questionnaire events, pass one repeatable answer per question. Keys may be the question ID or its exact text:
+`rsvp set` returns a five-minute, single-use plan by default. Review the plan,
+then repeat the same normalized input with its token:
 
 ```bash
-partiful events rsvp set <event-id> --answer "<question-id>=<value>"
-partiful events rsvp set <event-id> --answer "Dietary restrictions?=None" --answer "Song request?=Anything"
+partiful rsvp set <event-id> --status interested \
+  --apply --plan "$PLAN_TOKEN"
 ```
 
-Required answers are validated before submission. Successful writes read the Firestore guest document back to verify the saved status and questionnaire answers. Plain `--dry-run` remains offline; combining `--answer` with `--dry-run` performs read-only guest and event lookups to validate the live questionnaire preview. Ticketed or paid events remain unsupported because the CLI cannot purchase tickets.
+For a structured questionnaire response or larger input, use
+`--input <path-or->`. Run `partiful schema rsvp.set` for its exact shape.
+Ticketed, application, protected, at-capacity going, and unsupported
+questionnaire flows fail closed. Applied success confirms only one submitted
+request. It does not confirm persisted RSVP state.

--- a/tests/remote-api-contract.test.js
+++ b/tests/remote-api-contract.test.js
@@ -493,8 +493,8 @@ describe('remote API contract', () => {
       .toBe(`${rsvpReadObservationPath}#scope-and-provenance`);
     expect(citationResolves(evidence.sources.rsvpReadObservation20260812)).toBe(true);
     const appSource = fs.readFileSync('internal/app/app.go', 'utf8');
-    expect(appSource).toContain('ProductContractRevision = "2026-08-12.1"');
-    expect(appSource).toContain('RemoteContractRevision  = "2026-08-12.1"');
+    expect(appSource).toContain('ProductContractRevision = "2026-08-12.3"');
+    expect(appSource).toContain('RemoteContractRevision  = "2026-08-12.3"');
     const ids = operations().map(({ operation }) => operation.operationId);
     expect(ids).toHaveLength(27);
     expect(new Set(ids).size).toBe(ids.length);
@@ -1343,7 +1343,7 @@ describe('remote API contract', () => {
       '**Status:** Approved product contract',
       '**Product contract revision:** `2026-08-12.3`',
       '**Remote API contract revision:** `2026-08-12.3`',
-      '**Currently shipped Go revisions:** product and remote `2026-08-12.1`',
+      '**Currently shipped Go revisions:** product and remote `2026-08-12.3`',
       '`PUBLISHED` → `active`',
       '`CANCELED` → `cancelled`',
       '`UNSAVED` exists in the current first-party client vocabulary',
@@ -1388,8 +1388,8 @@ describe('remote API contract', () => {
     );
 
     const appSource = fs.readFileSync('internal/app/app.go', 'utf8');
-    expect(appSource).toContain('ProductContractRevision = "2026-08-12.1"');
-    expect(appSource).toContain('RemoteContractRevision  = "2026-08-12.1"');
+    expect(appSource).toContain('ProductContractRevision = "2026-08-12.3"');
+    expect(appSource).toContain('RemoteContractRevision  = "2026-08-12.3"');
   });
 
   it('defines evidence-backed RSVP planning and submitted-only completion', () => {
@@ -1897,7 +1897,7 @@ describe('remote API contract', () => {
       .toBe(rsvpReadEvidencePath);
   });
 
-  it('keeps shipped Go revisions on the reviewed baseline while RSVP is proposed', () => {
+  it('ships the approved RSVP product and remote revisions together', () => {
     const productContract = fs.readFileSync(
       'docs/CLI-PRODUCT-CONTRACT.md',
       'utf8',
@@ -1920,14 +1920,14 @@ describe('remote API contract', () => {
       /"remoteContractRevision": "([^"]+)"/g,
     )].map((match) => match[1]);
 
-    expect(shippedRevision).toBe('2026-08-12.1');
+    expect(shippedRevision).toBe('2026-08-12.3');
     expect(documentedRevision).toBe('2026-08-12.3');
     expect(documentedProductRevision).toBe('2026-08-12.3');
     expect(new Set(envelopeRevisions)).toEqual(new Set([documentedRevision]));
     expect(spec.info.version).toBe(documentedRevision);
     expect(evidence.status).toBe('owner-reviewed');
-    expect(spec.info.version).not.toBe(shippedRevision);
-    expect(appSource).toContain('ProductContractRevision = "2026-08-12.1"');
+    expect(spec.info.version).toBe(shippedRevision);
+    expect(appSource).toContain('ProductContractRevision = "2026-08-12.3"');
     expect(productContract)
       .not.toContain('currently leaves every operation response status and body unknown');
     expect(contactResearch)


### PR DESCRIPTION
## Summary
- ship reviewed RSVP reads for object and explicit-null current-guest variants
- add compatible-event safeguards and exact going, not-going, and interested request mappings
- persist five-minute account-bound plans with atomic single-use consumption before one apply attempt
- redact private identities and return submitted-only mutation results without post-write reads
- ship product and remote contract revision `2026-08-12.3`

## Validation
- `go test -race ./...`
- `go vet ./...`
- `go build ./...`
- `go mod verify`
- `TZ=America/Los_Angeles npm test -- --reporter=dot` (356 passed, 6 skipped)
- `npm run typecheck`
- `scripts/pii-guard.sh`
- `git diff --cached --check`

Closes #166

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `rsvp get` to retrieve reviewed RSVP status.
  * Added `rsvp set` for going, not-going, and interested responses.
  * Added support for guest details, plus-ones, time zones, messages, and questionnaires.
  * Added reviewable, single-use plans that expire after five minutes and require confirmation before submission.
  * Added schema discovery for RSVP inputs.

* **Documentation**
  * Updated RSVP command guidance, supported options, and fail-closed behavior.
  * Updated shipped contract revision documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->