### PR TITLE
spec: close event-write contract evidence for #167

### DIFF
--- a/docs/CLI-PRODUCT-CONTRACT.md
+++ b/docs/CLI-PRODUCT-CONTRACT.md
@@ -636,6 +636,11 @@ when ticketing is present, or when `hasGuests` is exactly true and the current
 event is past its end plus two hours (start plus eight hours when end is
 absent).
 
+Planning merges proposed `start` and `end` values with the bound current
+values. When both resulting values are present, `end` must be at or after
+`start`. An inverted merged range returns `input.invalid` before a plan is
+issued.
+
 Apply reacquires the account and calls `getEventInfo` once. Any bound change
 returns `safety.plan_stale`. It then consumes the standard plan immediately
 before exactly one `firestorePatchEvent` attempt. HTTP `200` with a Firestore
@@ -662,7 +667,9 @@ the future. Missing, null, or differently typed precondition facts return
 `contract.protocol_changed`; a known non-matching fact returns
 `state.conflict` / `EVENT_PRECONDITION_FAILED` except ownership, which returns
 `permission.denied`. Inaccessible-event permission behavior was not observed
-and is not inferred.
+and is not inferred. The positive-guest gate deliberately preserves the
+reviewed current-client exposure as a conservative product limitation; it is
+not a claim about endpoint authorization.
 
 The public consequential plan states the exact event ID, message,
 `notifyGuests`, and effects. Its private record binds the stable account
@@ -683,10 +690,9 @@ post-write read. Generic callable completion returns only:
 
 It does not claim cancellation, notification delivery, or persisted state.
 Any unrecognized status, endpoint error/body, missing generic completion
-envelope, or malformed Firestore Document is
-`contract.protocol_changed`. A no-response transport failure is
-`remote.unavailable`; because the consumed write may have reached the remote,
-a new plan is required.
+envelope, or malformed completion body is `contract.protocol_changed`. A
+no-response transport failure is `remote.unavailable`; because the consumed
+write may have reached the remote, a new plan is required.
 
 ### Guests
 

--- a/docs/CLI-PRODUCT-CONTRACT.md
+++ b/docs/CLI-PRODUCT-CONTRACT.md
@@ -1,10 +1,10 @@
 # CLI product contract
 
-**Status:** Approved product contract
+**Status:** Proposed; pending delegated review
 
-**Product contract revision:** `2026-08-12.3`
+**Product contract revision:** `2026-08-12.4`
 
-**Remote API contract revision:** `2026-08-12.3`
+**Remote API contract revision:** `2026-08-12.4`
 
 **Owner-reviewed baseline:** product and remote `2026-08-12.3`
 
@@ -83,8 +83,8 @@ Every successful command returns:
   "meta": {
     "command": "events.get",
     "cliVersion": "1.0.0",
-    "productContractRevision": "2026-08-12.3",
-    "remoteContractRevision": "2026-08-12.3",
+    "productContractRevision": "2026-08-12.4",
+    "remoteContractRevision": "2026-08-12.4",
     "warnings": []
   }
 }
@@ -107,8 +107,8 @@ Every failed command returns:
   "meta": {
     "command": "guests.list",
     "cliVersion": "1.0.0",
-    "productContractRevision": "2026-08-12.3",
-    "remoteContractRevision": "2026-08-12.3"
+    "productContractRevision": "2026-08-12.4",
+    "remoteContractRevision": "2026-08-12.4"
   }
 }
 ```
@@ -155,8 +155,8 @@ Collection commands return:
   "meta": {
     "command": "events.list",
     "cliVersion": "1.0.0",
-    "productContractRevision": "2026-08-12.3",
-    "remoteContractRevision": "2026-08-12.3",
+    "productContractRevision": "2026-08-12.4",
+    "remoteContractRevision": "2026-08-12.4",
     "warnings": [],
     "page": {
       "limit": 25,
@@ -228,8 +228,8 @@ remote mutation:
   "meta": {
     "command": "events.update",
     "cliVersion": "1.0.0",
-    "productContractRevision": "2026-08-12.3",
-    "remoteContractRevision": "2026-08-12.3",
+    "productContractRevision": "2026-08-12.4",
+    "remoteContractRevision": "2026-08-12.4",
     "warnings": []
   }
 }
@@ -525,41 +525,168 @@ remain unclaimed.
 
 #### `partiful events create`
 
-Accepts structured input or equivalent flags:
+Required input is non-empty `title`, RFC 3339 `start`, and an IANA
+`timezone`. Optional input is `end`, `description`, `location`, `visibility`,
+`guestLimit`, `links`, and `posterId`. `end` must not be before `start`.
+`visibility` is `private` by default or `public`. `guestLimit` is a positive
+integer. `links` is an array of
+`{"label":"Tickets","url":"https://example.test/"}` objects with an HTTP or
+HTTPS URL. `posterId` is only an exact built-in ID returned by `posters list`
+or `posters search`; a path, upload, or arbitrary URL is invalid. The
+equivalent flags are `--title`, `--start`, `--end`, `--timezone`,
+`--description`, `--location`, `--visibility`, `--guest-limit`, repeated
+`--link <label=url>`, and `--poster-id`.
+For create, null for any optional structured-input property has the same
+meaning as omission: no end, description, location, limit, or links; private
+visibility; and the built-in fallback poster. No optional product null is sent
+inside `event`.
 
-| Field | Required | Meaning |
-| --- | --- | --- |
-| `title` | Yes | Event title. |
-| `start` | Yes | RFC 3339 start time. |
-| `end` | No | RFC 3339 end time. |
-| `timezone` | Yes | IANA timezone. |
-| `description` | No | Event description. |
-| `location` | No | Human location label. |
-| `address` | No | Address text. |
-| `visibility` | No | `public` or `private`; default `private`. |
-| `guestLimit` | No | Positive integer. |
-| `posterId` | No | Poster selected from `posters`. |
-| `links` | No | Array of `{ "label", "url" }`. |
+The narrow current-client projection is exact:
 
-The plan identifies the new event. Applied success returns the complete
-`Event`.
+| Product input | `createEvent.params.event` |
+| --- | --- |
+| `title` | `title` |
+| `start`, `end` | `startDate`, optional `endDate`, normalized to UTC ISO strings |
+| `timezone` | `timezone` |
+| `description` | `description`; omission and null both omit it on create |
+| `location` | `locationInfo: {"type":"freeform","value":<location>}` |
+| `visibility` | `public` sends `isPublic: true`; `private` omits `isPublic`; separate first-party `visibility` is fixed to `"public"` |
+| `guestLimit` | `maxCapacity` and `enableWaitlist: false` |
+| `links` | `customFields` entries with `icon: "link"`, `value: <label>`, and `url` |
+| `posterId` | `image` built from the one exact catalog entry |
+
+An omitted `posterId` selects the exact current first-party fallback ID
+`Let's Party`. Planning resolves the ID against one bounded catalog
+representation. Zero matches return `resource.not_found`; more than one exact
+ID match returns `contract.protocol_changed`. The private plan binds the
+catalog digest and complete selected record. The image request is
+`{"source":"partiful_posters","poster":<record>,...}` with the record's
+`url`, `blurHash`, `contentType`, `name`, `height`, and `width` copied to the
+outer object. Upload remains unregistered.
+
+The caller cannot set `cohostIds`, `displaySettings`, status, guest counters,
+or display/RSVP policy. The request sets `cohostIds: []`,
+`status: "UNSAVED"`, all 16 current guest-status counts to zero,
+`displaySettings:
+{"theme":"cloudflow","effect":"fireflies","titleFont":"display"}`, and these
+booleans to `true`: `showHostList`, `showGuestCount`, `showGuestList`,
+`showActivityTimestamps`, `displayInviteButton`, `allowGuestPhotoUpload`,
+`enableGuestReminders`, `rsvpsEnabled`, and
+`allowGuestsToInviteMutuals`. It also sets
+`rsvpButtonGlyphType: "emojis"`. These are request defaults, not public input.
+Absent optional event properties stay absent; the product never constructs a
+nested `undefined` value that the callable encoder would turn into null.
+
+Create is a standard mutation. Its private five-minute, single-use plan binds
+the stable account fingerprint, normalized input, exact callable request, and
+poster representation. It has no existing-event read or precondition. Apply
+reacquires the same account and poster representation, consumes the plan
+immediately before one `createEvent` attempt, and never retries.
+
+The client requires only generic callable completion data and uses that data
+as an event ID. It does not validate or read a complete Event. The product
+therefore performs no post-write read and returns only:
+
+```json
+{"submitted":true}
+```
+
+It does not claim an event ID, persisted Event, or persisted state.
 
 #### `partiful events update <event-id>`
 
-Accepts one or more mutable `events create` fields through structured input or
-equivalent flags. It does not expose raw Firestore fields or update masks.
-Applied success returns the complete updated `Event`.
+Accepts one or more of `title`, `description`, `start`, `end`, `timezone`,
+`guestLimit`, `links`, and `posterId`, through structured input or the
+matching create flags. This is a closed allowlist. `location`, `visibility`,
+and display settings are rejected because the current client routes them
+through `setEventLocation`, `makeEventPublic` or `unpublishEvent`, and
+`updateDisplaySettings`; no general callable `updateEvent` was found.
+
+Omission means unchanged. Null is allowed only for `description`, `end`,
+`guestLimit`, `links`, and `posterId`, and means delete the mapped field.
+Non-null mapping is:
+
+| Product input | Firestore event field |
+| --- | --- |
+| `title` | `title.stringValue` |
+| `description` | `description.stringValue` |
+| `start` | `startDate.stringValue`, normalized to a UTC ISO string |
+| `end` | `endDate.stringValue`, normalized to a UTC ISO string |
+| `timezone` | `timezone.stringValue` |
+| `guestLimit` | `maxCapacity.integerValue` and `enableWaitlist.booleanValue: false` |
+| `links` | `customFields.arrayValue` of map values with `icon`, `value`, and `url` string values |
+| `posterId` | `image.mapValue` using the exact built-in poster representation |
+
+Every update also writes private `updatedBy.referenceValue` for the current
+account. It is never printed. The exact PATCH is bearer-authorized at
+`/v1/projects/getpartiful/databases/(default)/documents/events/{eventId}`.
+It sends sorted, percent-encoded, repeated `updateMask.fieldPaths`, includes
+every mapped path and `updatedBy`, and sends
+`currentDocument.exists=true`. A delete path remains in the update mask and
+is absent from `fields`.
+
+Planning calls `getEventInfo` once. `ownerIds` must be present and contain the
+private current account ID; otherwise the command returns
+`permission.denied` / `HOST_PERMISSION_REQUIRED`. No general first-party
+update status guard was found. The plan nevertheless binds raw status,
+owner-list presence and digest, and the absent/null/value state and value of
+every target field. For a date or timezone change it also binds current
+`startDate`, `endDate`, `hasGuests`, and `ticketing`. Date changes are rejected
+when ticketing is present, or when `hasGuests` is exactly true and the current
+event is past its end plus two hours (start plus eight hours when end is
+absent).
+
+Apply reacquires the account and calls `getEventInfo` once. Any bound change
+returns `safety.plan_stale`. It then consumes the standard plan immediately
+before exactly one `firestorePatchEvent` attempt. HTTP `200` with a Firestore
+Document is protocol completion, not a complete product Event or proven
+Partiful business state. There is no post-write read. Success is:
+
+```json
+{"eventId":"evt_example","fields":["start","title"],"submitted":true}
+```
+
+`fields` is the sorted product-field list, not raw Firestore field paths.
 
 #### `partiful events cancel <event-id>`
 
-This is a consequential action. Applied success returns:
+Accepts optional `message` and `notifyGuests`; the matching flags are
+`--message <text>` and `--notify-guests <boolean>`. Defaults are `message: ""`
+and `notifyGuests: true`. The exact callable parameters are `eventId`,
+`cancellationMessage`, and `shouldSkipNotifyGuests: !notifyGuests`.
+
+Planning calls `getEventInfo` once. `ownerIds` must be present and contain the
+current private account ID, `status` must be exactly `PUBLISHED`, the observed
+guest count must be a positive integer, and the current `startDate` must be in
+the future. Missing, null, or differently typed precondition facts return
+`contract.protocol_changed`; a known non-matching fact returns
+`state.conflict` / `EVENT_PRECONDITION_FAILED` except ownership, which returns
+`permission.denied`. Inaccessible-event permission behavior was not observed
+and is not inferred.
+
+The public consequential plan states the exact event ID, message,
+`notifyGuests`, and effects. Its private record binds the stable account
+fingerprint, normalized input, exact `cancelEvent` request, raw status, start,
+guest-count facts, and owner-list presence and digest. Apply must repeat the
+same input and provide that exact plan's `--confirm <token>`; `--apply`
+without it returns `safety.confirmation_required`. Apply reacquires the
+account, calls `getEventInfo` once, and compares every bound fact. It consumes
+the plan immediately before one attempt and never retries. There is no
+`--yes` bypass.
+
+The current client inspects no endpoint business field and performs no
+post-write read. Generic callable completion returns only:
 
 ```json
-{
-  "eventId": "evt_example",
-  "state": "cancelled"
-}
+{"eventId":"evt_example","notifyGuests":true,"submitted":true}
 ```
+
+It does not claim cancellation, notification delivery, or persisted state.
+Any unrecognized status, endpoint error/body, missing generic completion
+envelope, or malformed Firestore Document is
+`contract.protocol_changed`. A no-response transport failure is
+`remote.unavailable`; because the consumed write may have reached the remote,
+a new plan is required.
 
 ### Guests
 
@@ -854,8 +981,9 @@ reviewed callable and client completion condition. It does not prove
 persisted RSVP state, delivery, notification, or another business side
 effect.
 
-This `2026-08-12.3` contract is owner-reviewed under the issue #114
-delegation and is shipped by the Go implementation.
+This `2026-08-12.4` contract is proposed under issue #167 and is pending one
+delegated review. The Go implementation continues to ship the owner-reviewed
+`2026-08-12.3` revisions until this proposal is reviewed and merged.
 
 ### Contacts
 

--- a/docs/REMOTE-API-CONTRACT.md
+++ b/docs/REMOTE-API-CONTRACT.md
@@ -215,11 +215,12 @@ records.
 The current callable wrapper requires `params`, but it adds analytics and
 device metadata only when available. Its final wrapper always contains
 `userId`, encoded as string or null. `amplitudeDeviceId` is therefore optional
-for `createEvent` and `cancelEvent`. The Firebase callable SDK requires
-generic success data, while the create caller uses that data as an event ID
-and the cancel caller inspects no business property. Neither flow reads a
-post-write Event. Their HTTP `200`/result schemas mean protocol completion
-only, not persisted Partiful state.
+for `createEvent` and `cancelEvent`. The Firebase callable SDK accepts generic
+completion under top-level `data` or legacy top-level `result`. The create
+caller uses the decoded value as an event ID without validating a nested
+business shape; the cancel caller inspects no business property. Neither flow
+reads a post-write Event. Their HTTP `200` completion alternatives mean
+protocol completion only, not persisted Partiful state.
 
 The current general event update uses the Firestore SDK, deletes top-level
 null or undefined values, adds an `updatedBy` reference, and removes derived
@@ -252,6 +253,11 @@ ticketing and old events with guests. The observed cancel choice uses an
 owned `PUBLISHED` event, a positive guest count, and a future start. These are
 current-client preconditions, not endpoint permission claims. No
 inaccessible-event response was observed.
+
+The supporting conditional EventInfo fields are `ownerIds`,
+`guestCount`, `guestStatusCounts`, `hasGuests`, and `customFields`. Their
+presence remains conditional; product planning rejects a missing or invalid
+field when the selected operation requires it.
 
 `cancelEvent` parameters are `eventId`, `cancellationMessage`, and
 `shouldSkipNotifyGuests`. The current defaults are an empty message and guest

--- a/docs/REMOTE-API-CONTRACT.md
+++ b/docs/REMOTE-API-CONTRACT.md
@@ -1,8 +1,8 @@
 # Remote API contract
 
-`spec/partiful.openapi.json` is owner-reviewed revision `2026-08-12.3` of the
-remote transport snapshot. Its owner-reviewed baseline is
-`2026-08-12.2`, which is based on owner-reviewed revision `2026-08-12.1`. It
+`spec/partiful.openapi.json` is proposed revision `2026-08-12.4` of the remote
+transport snapshot, pending one delegated review. Its owner-reviewed baseline
+is `2026-08-12.3`. It
 describes only network operations and wire shapes. It does not prescribe
 commands, output, credentials, mutation safeguards, or implementation
 architecture.
@@ -195,6 +195,70 @@ unchanged. This read evidence adds no `addGuest` or `markEventInterest`
 business-success claim. Every server rejection, unobserved status or body,
 persisted state, post-write read, delivery, waitlist, ticketing, application,
 and protected-event behavior remains explicit unknown.
+
+## Event-write proposal
+
+Revision `2026-08-12.4` adds unauthenticated current-client evidence from
+`docs/research/2026-08-12-event-write-mapping-public-assets.md` and the
+official Firebase callable and Firestore REST protocols. No live event write
+or credential was used.
+
+The current `/create` client sends callable `params.event` and `cohostIds`.
+Its broad Event draft contains required new-event defaults, optional product
+and unrelated subsystem values, and sanitized nested data. OpenAPI records
+the current required default surface and stays open to unrelated current
+event properties. This broad remote schema is not the product input
+allowlist. The product fixes current display, RSVP, status, counter, and
+cohost defaults, maps only its documented inputs, and uses built-in poster
+records.
+
+The current callable wrapper requires `params`, but it adds analytics and
+device metadata only when available. Its final wrapper always contains
+`userId`, encoded as string or null. `amplitudeDeviceId` is therefore optional
+for `createEvent` and `cancelEvent`. The Firebase callable SDK requires
+generic success data, while the create caller uses that data as an event ID
+and the cancel caller inspects no business property. Neither flow reads a
+post-write Event. Their HTTP `200`/result schemas mean protocol completion
+only, not persisted Partiful state.
+
+The current general event update uses the Firestore SDK, deletes top-level
+null or undefined values, adds an `updatedBy` reference, and removes derived
+fields. It routes `locationInfo`, public visibility, and `displaySettings`
+through field-specific callables. No general callable `updateEvent` was
+found. The product's `firestorePatchEvent` projection is therefore narrower
+than the broad official Firestore Document grammar and excludes those three
+areas.
+
+The official Firestore REST contract establishes:
+
+- bearer authorization and the exact
+  `/v1/projects/getpartiful/databases/(default)/documents/events/{eventId}`
+  path;
+- repeated `updateMask.fieldPaths` query values;
+- `currentDocument.exists` and `currentDocument.updateTime`;
+- the complete Firestore typed-value grammar; and
+- HTTP `200` with a Document as PATCH protocol completion.
+
+The product uses `currentDocument.exists=true`, sorted repeated update-mask
+paths, and only `title`, `description`, `startDate`, `endDate`, `timezone`,
+`maxCapacity`, `enableWaitlist`, `customFields`, `image`, and the private
+`updatedBy` reference. A masked field absent from `fields` is a deletion.
+OpenAPI retains the broad official `FirestoreDocument` and `FirestoreValue`
+schemas; product documentation owns this closed projection.
+
+Current editor ownership is membership in `ownerIds`. There is no general
+update status predicate. Date editing has separate current-event guards for
+ticketing and old events with guests. The observed cancel choice uses an
+owned `PUBLISHED` event, a positive guest count, and a future start. These are
+current-client preconditions, not endpoint permission claims. No
+inaccessible-event response was observed.
+
+`cancelEvent` parameters are `eventId`, `cancellationMessage`, and
+`shouldSkipNotifyGuests`. The current defaults are an empty message and guest
+notification enabled. Every endpoint-specific error, other status or body,
+authorization rule, persisted state, post-write complete Event, delivery,
+and retry meaning remains unknown and fails closed. The proposal does not
+register upload.
 
 ## Historical provenance
 

--- a/docs/adr/0001-greenfield-go-module-seams.md
+++ b/docs/adr/0001-greenfield-go-module-seams.md
@@ -53,3 +53,26 @@ submitted request projection: event ID, intent, and `submitted: true`. It
 performs no post-write read. RSVP enters the releasable catalog only with the
 approved dated object/null current-guest variants, event safeguard boundary,
 and matching product and remote revision constants.
+
+Event creation follows the same submitted-only boundary. Its standard plan
+has no existing-event precondition. It binds the exact callable request and
+the complete, digest-bound built-in poster record. The current create client
+uses callable completion data as an event ID but does not validate or re-read
+a complete Event, so the application returns only `submitted: true`.
+
+Event update keeps the broad official Firestore Document grammar private to
+the remote seam. The application owns a closed product-to-field projection
+and never accepts a raw field path, update mask, typed value, or document
+reference. Its standard plan binds current ownership, raw status, each target
+field's presence/null/value state, and date safeguards when relevant. Apply
+re-reads `getEventInfo` once before consuming the plan. A successful PATCH
+Document is protocol completion only; the result contains the event ID,
+sorted submitted product fields, and `submitted: true`.
+
+Event cancellation uses a consequential plan. Its public form states the
+exact event, message, guest-notification choice, and effects. Its private form
+also binds ownership, status, start, guest-count facts, the exact callable
+request, and the account fingerprint. Apply must re-read those facts and
+receive the exact confirmation token. Callable completion returns only the
+event ID, notification choice, and `submitted: true`; it does not claim
+cancellation or notification delivery.

--- a/docs/research/2026-08-10-contract-evidence-sources.md
+++ b/docs/research/2026-08-10-contract-evidence-sources.md
@@ -14,9 +14,10 @@ only and are not part of `spec/partiful.openapi.json`.
 
 ## Unknown status decision
 
-No safe live observation in this reconstruction establishes an HTTP success
-status for every operation. The proposal therefore uses OpenAPI `default`
-responses and records each response-status claim as `explicit-unknown`.
+No safe live observation or applicable official protocol in this
+reconstruction establishes an HTTP success status for every operation. The
+proposal therefore keeps OpenAPI `default` responses and records each
+unsupported response-status claim as `explicit-unknown`.
 This decision supports both the response **status key** and the explicit
 unknown response/body classification. The proposal deliberately attaches no
 content schema to `default`; reusable response shapes remain unattached
@@ -24,11 +25,13 @@ research evidence until an applicable status/class is observed.
 
 ## Update-mask serialization
 
-The historical draft's `firestorePatchEvent` parameter is an array of strings,
-and `9e6ed15:src/lib/http.ts#L132-L134` repeats
-`updateMask.fieldPaths` once for every field. The proposal represents it as a
-form-style, exploded query array; this is a TypeScript-derived transport
-inference, not a live observation.
+The official Firestore
+[documents.patch](https://firebase.google.com/docs/firestore/reference/rest/v1/projects.databases.documents/patch)
+reference and
+[v1 discovery document](https://firestore.googleapis.com/$discovery/rest?version=v1)
+define repeated `updateMask.fieldPaths` values. The proposal represents them
+as a form-style, exploded query array. This is generic protocol behavior, not
+a Partiful business-success claim.
 
 ## Dated text-blast observation
 
@@ -170,6 +173,34 @@ top-level `data` member, HTTP `200` for a successful callable trigger, and a
 JSON response containing `result`. It also states that an `error` member means
 failure. This source supports only generic callable status and envelope facts.
 It does not establish endpoint-specific Partiful business success.
+
+## Official Firestore REST protocol
+
+The official
+[Firestore REST guide](https://firebase.google.com/docs/firestore/use-rest-api),
+[documents.patch reference](https://firebase.google.com/docs/firestore/reference/rest/v1/projects.databases.documents/patch),
+and
+[v1 discovery document](https://firestore.googleapis.com/$discovery/rest?version=v1)
+define Firebase ID-token bearer authorization, the PATCH path, repeated
+update-mask paths, current-document preconditions, the Firestore Document and
+Value grammar, and HTTP `200` Document completion. They do not establish
+Partiful authorization, field policy, endpoint errors, or persisted product
+business state.
+
+## Current public event-write mapping assets
+
+The unauthenticated first-party asset research in
+`docs/research/2026-08-12-event-write-mapping-public-assets.md`, under “Scope
+and provenance,” records build `2KXQa2wzQWzlyvnJPIrVj`, deployment
+`dpl_D9bWXWUaTVfWyHiJz1RT7qdjuzUC`, exact asset URLs, hashes, and module IDs.
+Its operation sections record `createEvent`, current Firestore event-update,
+`cancelEvent`, poster mapping, completion use, and observed client
+preconditions. The note contains no credentials, private identifiers, or
+live write data.
+
+The assets support current client request and completion behavior. They do
+not establish endpoint business success, inaccessible-event permission
+behavior, unobserved errors, or persisted post-write state.
 
 ## Current public RSVP mapping assets
 

--- a/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
+++ b/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
@@ -82,7 +82,7 @@ completion, and one official Firestore PATCH completion have typed response
 bodies. The schema-free send-code `200` and OpenAPI `default` responses do not
 claim a body.
 
-The 1640 material claims are audited by
+The 1639 material claims are audited by
 `tests/remote-api-contract.test.js`. Each ledger citation resolves either to a
 JSON Pointer in the committed non-authoritative historical artifact or to a
 heading in the committed stable source index. This keeps the audit independent
@@ -370,7 +370,7 @@ by the Go implementation's Firebase requests:
 Origin is unmodelled and remains unknown because the reviewed evidence
 establishes no Origin request fact.
 
-The 1640 material claims are audited by `tests/remote-api-contract.test.js`.
+The 1639 material claims are audited by `tests/remote-api-contract.test.js`.
 
 ## Resolved conflict
 

--- a/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
+++ b/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
@@ -82,7 +82,7 @@ completion, and one official Firestore PATCH completion have typed response
 bodies. The schema-free send-code `200` and OpenAPI `default` responses do not
 claim a body.
 
-The 1625 material claims are audited by
+The 1640 material claims are audited by
 `tests/remote-api-contract.test.js`. Each ledger citation resolves either to a
 JSON Pointer in the committed non-authoritative historical artifact or to a
 heading in the committed stable source index. This keeps the audit independent
@@ -370,7 +370,7 @@ by the Go implementation's Firebase requests:
 Origin is unmodelled and remains unknown because the reviewed evidence
 establishes no Origin request fact.
 
-The 1625 material claims are audited by `tests/remote-api-contract.test.js`.
+The 1640 material claims are audited by `tests/remote-api-contract.test.js`.
 
 ## Resolved conflict
 

--- a/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
+++ b/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
@@ -1,8 +1,8 @@
 # Partiful remote API contract evidence ledger
 
-**Owner-reviewed contract revision:** `2026-08-12.3`
-**Owner-reviewed baseline:** `2026-08-12.2`
-**Status:** Owner-reviewed under the issue #114 delegation
+**Proposed contract revision:** `2026-08-12.4`
+**Owner-reviewed baseline:** `2026-08-12.3`
+**Status:** Pending one delegated review under issue #167
 **Contract:** `spec/partiful.openapi.json`
 **Machine-readable ledger:** `spec/partiful.api-evidence.json`
 **Stable citation sources:** `docs/research/2026-08-10-contract-evidence-sources.md`
@@ -43,23 +43,33 @@ retains an unknown response. The Firestore event read has an observed typed
 
 ### Current public-asset operations
 
-`addGuest` and `markEventInterest` now have current first-party public-asset
-request and completion mappings. Their errors and all non-`200` statuses
-remain unknown.
+`addGuest`, `markEventInterest`, `createEvent`, and `cancelEvent` have current
+first-party public-asset request and completion mappings. Their endpoint
+business meanings, errors, and all non-`200` statuses remain unknown.
 
-Two additional callable operations have protocol-specified HTTP `200` completion responses.
-`addGuest` and `markEventInterest` use the official Firebase callable
-status/result envelope plus current first-party client completion behavior.
-Neither is a live business-success observation.
+Four callable operations have protocol-specified HTTP `200` completion
+responses. `addGuest`, `markEventInterest`, `createEvent`, and `cancelEvent`
+use the official Firebase callable status/result envelope plus current
+first-party client completion behavior. None is a live business-success
+observation.
+
+### Official-protocol operations
+
+`firestorePatchEvent` uses the official Firestore PATCH path, bearer
+authorization, update mask, current-document preconditions, typed Value
+grammar, and HTTP `200` Document completion. Current first-party assets supply
+the event-field mapping, but the remote operation remains broad. The closed
+field projection is product policy. No Partiful authorization or business
+success is inferred.
 
 ### TypeScript-derived operations
 
-The other 11 operations remain TypeScript-derived inferences:
+The other 8 operations remain TypeScript-derived inferences:
 
-- callable: `createEvent`, `cancelEvent`, `addInvitedGuestsAsHost`,
-  `createCohostRequest`, `deleteCohostRequest`, `removeCohost`,
-  `generateEventCohostLink`, and `revokeEventCohostLink`;
-- Firestore: `firestorePatchEvent` and `firestoreListDocuments`;
+- callable: `addInvitedGuestsAsHost`, `createCohostRequest`,
+  `deleteCohostRequest`, `removeCohost`, `generateEventCohostLink`, and
+  `revokeEventCohostLink`;
+- Firestore: `firestoreListDocuments`;
 - Firebase auxiliary: `uploadEventPhoto`.
 
 Every operation's request and response claim is enumerated by JSON Pointer in
@@ -67,11 +77,12 @@ the JSON ledger, including operation, parameter, content-type, security,
 schema, constraint, and response claims. Unless a claim is specifically
 observed, callable result payloads, status codes, error bodies, permission
 rules, and limits are **explicit unknown**. Eleven operations with an observed
-HTTP `200` status and two operations with protocol-specified callable
-completion have typed response bodies. The schema-free send-code `200` and
-OpenAPI `default` responses do not claim a body.
+HTTP `200` status, four operations with protocol-specified callable
+completion, and one official Firestore PATCH completion have typed response
+bodies. The schema-free send-code `200` and OpenAPI `default` responses do not
+claim a body.
 
-The 1316 material claims are audited by
+The 1625 material claims are audited by
 `tests/remote-api-contract.test.js`. Each ledger citation resolves either to a
 JSON Pointer in the committed non-authoritative historical artifact or to a
 heading in the committed stable source index. This keeps the audit independent
@@ -98,6 +109,36 @@ The observed array contained 2,114 entries and one repeated ID. Local
 pagination must preserve response order and duplicates. Exact resumption can
 bind a cursor to the full payload digest, normalized filters, and next offset;
 it cannot rely on `If-Match`, which was not enforced by the observed endpoint.
+
+## Event-write public-asset and protocol evidence
+
+The August 12 event-write note records public build
+`2KXQa2wzQWzlyvnJPIrVj`, deployment
+`dpl_D9bWXWUaTVfWyHiJz1RT7qdjuzUC`, exact URLs, module IDs, and hashes. The
+research used no credential and made no mutation. It establishes current
+client request construction and completion use for `createEvent`,
+Firestore-backed event updates, and `cancelEvent`.
+
+Create always sends `event` and `cohostIds`. The current event state supplies
+status, zero counters, display settings, poster image, and display/RSVP
+defaults. The caller uses decoded callable completion data as an event ID but
+does not validate or re-read a complete Event. Cancel sends event ID, message,
+and skip-notification boolean. Its caller awaits decoded completion but does
+not inspect any business property or perform a post-write read.
+
+The generic current update removes derived fields, adds a private `updatedBy`
+reference, and converts top-level null or undefined to deletion. Location,
+public visibility, and display settings use separate callable operations. No
+general callable `updateEvent` was found. The product therefore owns a closed
+projection while OpenAPI keeps the official Firestore Value and Document
+grammar broad.
+
+Official Firebase protocols supply only generic callable HTTP `200`/result
+completion and Firestore bearer/PATCH/mask/precondition/typed-Document
+completion. They do not supply endpoint business success. Complete
+post-write Event state, Partiful authorization, inaccessible-event behavior,
+unobserved statuses and errors, cancellation or notification delivery, and
+retry safety remain unknown.
 
 ## Authentication evidence
 
@@ -329,7 +370,7 @@ by the Go implementation's Firebase requests:
 Origin is unmodelled and remains unknown because the reviewed evidence
 establishes no Origin request fact.
 
-The 1316 material claims are audited by `tests/remote-api-contract.test.js`.
+The 1625 material claims are audited by `tests/remote-api-contract.test.js`.
 
 ## Resolved conflict
 
@@ -343,6 +384,6 @@ nested `message` object with `text`, `to`, `showOnEventPage`, and optional
 
 Future safe observations must update both ledgers, preserve privacy-safe
 evidence, and receive owner review before changing the revision. The remaining
-11 TypeScript-derived operations have no observed response status or shape.
-The read-specific unknowns above remain explicit and must not become inferred
-implementation behavior.
+8 TypeScript-derived operations have no observed response status or shape.
+The read-specific and event-write business-state unknowns above remain
+explicit and must not become inferred implementation behavior.

--- a/docs/research/2026-08-12-event-write-mapping-public-assets.md
+++ b/docs/research/2026-08-12-event-write-mapping-public-assets.md
@@ -22,6 +22,7 @@ Relevant deployment assets were:
 | <https://partiful.com/_next/static/chunks/1585-2532983fb5eac8e0.js?dpl=dpl_D9bWXWUaTVfWyHiJz1RT7qdjuzUC> | `48f1fc96f0aa318eea09d99a89e0f51e1eaf3863bee7e4c43ea045641aa3ac63` | `52630`, location editor |
 | <https://partiful.com/_next/static/chunks/6652-bc845eb80e835b16.js?dpl=dpl_D9bWXWUaTVfWyHiJz1RT7qdjuzUC> | `d6b57ad394646129f4702bb7d74aea214d7c43750c3a9898367fb9d4541a71b4` | `30067` |
 | <https://partiful.com/_next/static/chunks/2248-0ec69126f468d508.js?dpl=dpl_D9bWXWUaTVfWyHiJz1RT7qdjuzUC> | `c70b07cd5d86f1d6ce8f0e1e02d12fd4a3dbcf6d52a7e023ed01c3dd1f96cde7` | `22248` |
+| <https://partiful.com/_next/static/chunks/9580-feaa5337a786edee.js?dpl=dpl_D9bWXWUaTVfWyHiJz1RT7qdjuzUC> | `34f838947de6118a45e388074ee083a2a9a9451f9115d8a08f0ce734c6d19eb7` | `24441` |
 | <https://partiful.com/_next/static/chunks/8317-f3e4abcc21cc60c3.js?dpl=dpl_D9bWXWUaTVfWyHiJz1RT7qdjuzUC> | `b0d9c7bd12cdbe021df80f2c990319af85638e2d6499580aeca79f5fcdbbc5e4` | current event editor |
 | <https://partiful.com/_next/static/chunks/8290-fee201d02665178a.js?dpl=dpl_D9bWXWUaTVfWyHiJz1RT7qdjuzUC> | `a16edfddf6c6bf48d7e758f578e5fde09733a5c51dfbb4ce8a06d7aa0686d17d` | `95074` |
 
@@ -129,6 +130,12 @@ resolve an exact built-in poster ID to exactly one catalog entry and bind that
 entry's digest into its plan. A missing or duplicate match fails closed.
 Uploaded images are not registered by this revision.
 
+The registered catalog permits an omitted `blurHash` and null dimensions.
+The callable encoder turns the constructed outer `blurHash: undefined` into
+JSON null. Outer `blurHash`, `height`, and `width` are therefore nullable in
+the write request; the complete selected catalog record remains bound
+unchanged in `poster`.
+
 On 2026-08-12, privacy-safe public GETs to
 <https://assets.partiful.com/posters.json> and the already registered
 <https://assets.getpartiful.com/posters.json> each returned 1,125,932 bytes
@@ -233,12 +240,25 @@ decoded callable value but does not inspect a business field and performs no
 post-write read. Generic callable completion can therefore support only a
 submitted-only product result.
 
-The observed UI cancel choice is for an owned `PUBLISHED` event with a
-positive guest count and a future start. UI exposure also has an unrelated
-employee-tag branch; it is not promoted to endpoint authorization. The
-product re-reads `getEventInfo` and binds ownership, status, start, guest-count
-facts, exact message, and notification choice. It must not dispatch without
-the exact consequential confirmation value.
+Module `24441` exports this cancel/delete predicate:
+
+```js
+function canCancel(event) {
+  return event.status === EventStatus.LIVE &&
+    event.guestCount != null &&
+    event.guestCount > 0 &&
+    !isPast(event.startDate);
+}
+```
+
+The `/events` page separately computes ownership with
+`event.ownerIds.some(id => id === currentUserId)` before it adds host-only menu
+actions. Thus the observed UI cancel choice requires owner membership, wire
+status `PUBLISHED`, a positive guest count, and a future start. UI exposure
+also has an unrelated employee-tag branch; it is not promoted to endpoint
+authorization. The product re-reads `getEventInfo` and binds ownership,
+status, start, guest-count facts, exact message, and notification choice. It
+must not dispatch without the exact consequential confirmation value.
 
 ## Mutation boundary and remaining unknowns
 

--- a/docs/research/2026-08-12-event-write-mapping-public-assets.md
+++ b/docs/research/2026-08-12-event-write-mapping-public-assets.md
@@ -1,0 +1,255 @@
+# Event-write mapping from current public assets
+
+## Scope and provenance
+
+This note records only unauthenticated, first-party public Partiful assets and
+official Firebase protocol documents. No account, credential, event ID, guest
+ID, request body, or live Partiful write was used. In particular, this research
+did not call `createEvent`, `cancelEvent`, any Firestore write, or any upload.
+
+The entry point was <https://partiful.com/login>. On 2026-08-12 it named Next.js
+build `2KXQa2wzQWzlyvnJPIrVj` and deployment
+`dpl_D9bWXWUaTVfWyHiJz1RT7qdjuzUC`. The exact manifest URL was
+<https://partiful.com/_next/static/2KXQa2wzQWzlyvnJPIrVj/_buildManifest.js?dpl=dpl_D9bWXWUaTVfWyHiJz1RT7qdjuzUC>
+(SHA-256
+`71b824c18ccb5779d024fde62431a302f26f2c0d9ffaafd3640d02d9c86880f3`).
+Relevant deployment assets were:
+
+| Asset | SHA-256 | Relevant modules |
+|---|---|---|
+| <https://partiful.com/_next/static/chunks/pages/create-27dc07c14b6ce0ff.js?dpl=dpl_D9bWXWUaTVfWyHiJz1RT7qdjuzUC> | `a74bf14e957b8c6a70267d519a8973ef6b4d70fac1b90a703b15226f62e3bc19` | `23552`, `25231`, `79372` |
+| <https://partiful.com/_next/static/chunks/pages/_app-6d18e4a563898a0d.js?dpl=dpl_D9bWXWUaTVfWyHiJz1RT7qdjuzUC> | `bc5ae6516170e0331b2bac59af77bc92d93f4970a090acbc1e318ac41bc87499` | `18539`, `42919`, `48144`, `50218`, `54257`, `68997`, `92793`, `95722` |
+| <https://partiful.com/_next/static/chunks/1585-2532983fb5eac8e0.js?dpl=dpl_D9bWXWUaTVfWyHiJz1RT7qdjuzUC> | `48f1fc96f0aa318eea09d99a89e0f51e1eaf3863bee7e4c43ea045641aa3ac63` | `52630`, location editor |
+| <https://partiful.com/_next/static/chunks/6652-bc845eb80e835b16.js?dpl=dpl_D9bWXWUaTVfWyHiJz1RT7qdjuzUC> | `d6b57ad394646129f4702bb7d74aea214d7c43750c3a9898367fb9d4541a71b4` | `30067` |
+| <https://partiful.com/_next/static/chunks/2248-0ec69126f468d508.js?dpl=dpl_D9bWXWUaTVfWyHiJz1RT7qdjuzUC> | `c70b07cd5d86f1d6ce8f0e1e02d12fd4a3dbcf6d52a7e023ed01c3dd1f96cde7` | `22248` |
+| <https://partiful.com/_next/static/chunks/8317-f3e4abcc21cc60c3.js?dpl=dpl_D9bWXWUaTVfWyHiJz1RT7qdjuzUC> | `b0d9c7bd12cdbe021df80f2c990319af85638e2d6499580aeca79f5fcdbbc5e4` | current event editor |
+| <https://partiful.com/_next/static/chunks/8290-fee201d02665178a.js?dpl=dpl_D9bWXWUaTVfWyHiJz1RT7qdjuzUC> | `a16edfddf6c6bf48d7e758f578e5fde09733a5c51dfbb4ce8a06d7aa0686d17d` | `95074` |
+
+The current default configuration was
+<https://assets.partiful.com/newEventDefaultsConfig.json> (SHA-256
+`29bdacdf84365583c4014f3f52d12e94821f9dbcba6e189c085085ebabf59dbc`).
+Its selected poster, theme, and reduced-motion effect vary by date, locale, and
+motion preference. They are not stable CLI defaults.
+Module `79372` also contains the stable non-international fallback
+`theme: "cloudflow"`, `effect: "fireflies"`, `titleFont: "display"`, and
+the `Let's Party` poster. The narrow product fixes those exact reviewed values
+instead of reproducing environment-dependent selection.
+
+## Callable wrapper and serialization
+
+Module `95722` invokes Firebase callable functions with an object containing
+`params`. Its final object always has a `userId` property; the encoder sends
+null when that value is unavailable. It can add `deviceInfo`,
+`amplitudeDeviceId`, `amplitudeSessionId`, and
+`adminAccessRequested: true` when those values apply. It removes direct
+`params` properties whose value is `undefined`; therefore analytics and
+device properties are not invariant wrapper requirements.
+
+Firebase Functions SDK module `68997` wraps the argument in top-level `data`,
+encodes a JavaScript `Date` with `toISOString()`, recursively encodes
+`undefined` as `null`, sends bearer authorization when available, and rejects
+a success body that has neither top-level `data` nor legacy top-level
+`result`. This is generic callable protocol behavior, not a Partiful
+business-success predicate.
+
+## createEvent request
+
+Module `23552` constructs a new event. Module `50218` supplies `title`,
+`startDate`, `timezone`, all-zero `guestStatusCounts`, `displaySettings`, and
+`status: "UNSAVED"`. The create page adds:
+
+- `showHostList`, `showGuestCount`, `showGuestList`,
+  `showActivityTimestamps`, `displayInviteButton`,
+  `allowGuestPhotoUpload`, `enableGuestReminders`, `rsvpsEnabled`, and
+  `allowGuestsToInviteMutuals`, all `true`;
+- `visibility: "public"`;
+- `rsvpButtonGlyphType: "emojis"`;
+- `image` from the selected built-in poster; and
+- a browser IANA timezone, replacing the base default.
+
+The current `guestStatusCounts` keys in module `54257` are
+`READY_TO_SEND`, `SENDING`, `SENT`, `SEND_ERROR`, `DELIVERY_ERROR`,
+`INTERESTED`, `MAYBE`, `GOING`, `DECLINED`, `WAITLIST`,
+`PENDING_APPROVAL`, `APPROVED`, `WITHDRAWN`,
+`RESPONDED_TO_FIND_A_TIME`, `WAITLISTED_FOR_APPROVAL`, and `REJECTED`.
+Every new-event value is zero.
+
+Module `25231` sends
+`createEvent({params:{event,cohostIds,...optionalTicketingValues}})`.
+`event` and `cohostIds` are always present in this call. Ticket types,
+promotion codes, and affiliate values are separate product areas and are
+omitted when absent. Before sending, it removes `canceledBy`,
+`_lastInvitedBy`, and `questionnaire`; it also removes private author or
+selector properties inside questionnaire-version and find-a-time values.
+
+Current create representations relevant to the narrow product are:
+
+| Product concept | Current event property |
+|---|---|
+| title | `title` |
+| start/end | `startDate` and optional `endDate`, encoded as UTC ISO strings |
+| timezone | IANA string in `timezone` |
+| description | `description` |
+| discoverability | public creation adds `isPublic: true`; the default private flow leaves it absent; fixed `visibility: "public"` is separate |
+| free-form address | `locationInfo: {type:"freeform",value:<address>}` |
+| guest limit | `maxCapacity`; the editor sends `enableWaitlist` with it |
+| links | `customFields` entries with `icon`, `value`, and, for link entries, `url` |
+| built-in poster | `image` as described below |
+
+The create product projection sets `cohostIds: []`; public cohost input is not
+part of issue #167. Optional product values are omitted when not supplied;
+product null has the same meaning as omission on create.
+The current callable serializer would turn an explicitly nested `undefined`
+into `null`, so the product must construct the event without such properties.
+
+## createEvent completion
+
+Module `25231` returns decoded callable `.data`. The caller uses that value as
+an event ID in analytics and in `/e/<value>` navigation. It does not validate a
+complete Event, and it does not perform a post-write event read. The only
+runtime completion requirement below the caller is the callable SDK's generic
+successful HTTP/result-or-data envelope. Consequently, the reviewed product
+can report only the normalized submitted input. It cannot report a persisted
+Event or claim persisted state.
+
+## Built-in poster representation
+
+Module `42919` maps one current poster-catalog entry to:
+
+```text
+{
+  source: "partiful_posters",
+  poster: <the complete selected catalog entry>,
+  url, blurHash, contentType, name, height, width
+}
+```
+
+The last six properties are copied from the selected entry. The product must
+resolve an exact built-in poster ID to exactly one catalog entry and bind that
+entry's digest into its plan. A missing or duplicate match fails closed.
+Uploaded images are not registered by this revision.
+
+On 2026-08-12, privacy-safe public GETs to
+<https://assets.partiful.com/posters.json> and the already registered
+<https://assets.getpartiful.com/posters.json> each returned 1,125,932 bytes
+with SHA-256
+`35e22005b19dd5795cecf582dee4c4fe4ddc5349e3142f0aae8014f4e471cc6e`.
+The current representations are byte-identical. This revision does not change
+the registered catalog operation or host.
+
+Module `95074` contains the exact built-in fallback entry with ID and name
+`Let's Party`, JPEG content type, 2000 by 2000 dimensions, and the public
+catalog URL ending in `/posters/Let's%20Party`. The stable product default can
+select this exact current first-party ID instead of reproducing the
+date/locale/motion-dependent configuration.
+
+## Firestore event update
+
+Module `52630` is the generic event update helper. It uses the Firebase
+Firestore client to update the `events/{eventId}` document and adds
+`updatedBy` as a document reference to the current user. It removes derived
+event fields and top-level `id`, `createdAt`, and `ref`. A top-level
+`null` or `undefined` update value becomes Firestore field deletion.
+
+Module `30067` applies the candidate values to local event state before the
+remote calls. It awaits the field-specific calls and module `52630`, calls the
+success callback without remote data, and restores the previous local fields
+on an exception. It performs no event post-read and consumes no update
+response body.
+
+The current event editor does **not** use that generic update for every field.
+Module `30067` routes `locationInfo` through `setEventLocation`, public
+visibility through `makeEventPublic` or `unpublishEvent`, and
+`displaySettings` through `updateDisplaySettings`. No general callable
+`updateEvent` path was found. Therefore, a `firestorePatchEvent`-only product
+must exclude address/location, visibility, and display settings. Its closed
+projection is:
+
+| Product field | Firestore field paths and typed values |
+|---|---|
+| `title` | `title` / `stringValue` |
+| `description` | `description` / `stringValue`; null deletes |
+| `start` | `startDate` / UTC ISO `stringValue` |
+| `end` | `endDate` / UTC ISO `stringValue`; null deletes |
+| `timezone` | `timezone` / `stringValue` |
+| `guestLimit` | `maxCapacity` / `integerValue`, plus `enableWaitlist` / `booleanValue:false`; null deletes both |
+| `links` | `customFields` / `arrayValue` of maps containing `icon:"link"`, `value`, and `url`; null deletes |
+| `posterId` | `image` / the built-in poster map as Firestore map/array/scalar values; null deletes |
+
+`updatedBy` is a `referenceValue` to
+`projects/getpartiful/databases/(default)/documents/users/{currentUserId}`.
+This is private request data and must never be printed.
+
+## Official Firestore PATCH protocol
+
+The official sources are:
+
+- <https://firebase.google.com/docs/firestore/use-rest-api>
+- <https://firebase.google.com/docs/firestore/reference/rest/v1/projects.databases.documents/patch>
+- <https://firestore.googleapis.com/$discovery/rest?version=v1>
+
+They define bearer Firebase ID-token authorization, the request path
+`/v1/projects/getpartiful/databases/(default)/documents/events/{eventId}`,
+repeated `updateMask.fieldPaths` query values, `currentDocument.exists` or
+`currentDocument.updateTime`, Firestore `Document` input/output, and the
+typed-value grammar. The narrow product sends sorted, percent-encoded repeated
+field paths, `currentDocument.exists=true`, and only the allowlist above.
+A masked field omitted from `Document.fields` is deleted. HTTP `200` with a
+Document is protocol completion only; it is not proof of Partiful business
+state or a complete product Event.
+
+## Update preconditions
+
+The current EventInfo provider permits editing for a current user in
+`ownerIds` (or a separate administrator path that is outside this product).
+It has no general event-status check. The date editor additionally prevents a
+date change when ticketing is present, and prevents it for an event with
+`hasGuests: true` after its end plus two hours (or start plus eight hours when
+there is no end). No other endpoint permission is inferred.
+
+A product plan must read `getEventInfo`, bind raw presence/null distinctions,
+ownership, status, the current values of every target path, and the date
+safeguards when date fields are targeted. Apply re-reads once and rejects any
+change as stale before it consumes and dispatches the single attempt.
+The current client does not perform that stale comparison; it uses its current
+local event and live Firestore subscription. The explicit re-read is product
+mutation safety, not an endpoint guarantee.
+
+## cancelEvent request and completion
+
+Module `22248` sends:
+
+```text
+{
+  eventId,
+  cancellationMessage,
+  shouldSkipNotifyGuests
+}
+```
+
+The modal starts with `cancellationMessage: ""` and notifications selected, so
+the default is `shouldSkipNotifyGuests: false`. The current client awaits the
+decoded callable value but does not inspect a business field and performs no
+post-write read. Generic callable completion can therefore support only a
+submitted-only product result.
+
+The observed UI cancel choice is for an owned `PUBLISHED` event with a
+positive guest count and a future start. UI exposure also has an unrelated
+employee-tag branch; it is not promoted to endpoint authorization. The
+product re-reads `getEventInfo` and binds ownership, status, start, guest-count
+facts, exact message, and notification choice. It must not dispatch without
+the exact consequential confirmation value.
+
+## Mutation boundary and remaining unknowns
+
+Create has no existing-event precondition. Create and update use standard
+five-minute, account-bound, single-use plans. Cancel uses the same binding plus
+exact consequential confirmation. Each plan binds normalized input, exact
+request projection, private account fingerprint, and pre-read facts where
+applicable. Apply consumes immediately before one attempt and never retries an
+ambiguous write.
+
+Partiful endpoint authorization rules, endpoint-specific success meanings,
+unobserved response bodies, business errors, and unknown status codes remain
+protocol drift. No inaccessible-event permission response was observed or
+claimed. This evidence does not establish post-write Event state.

--- a/spec/partiful.api-evidence.json
+++ b/spec/partiful.api-evidence.json
@@ -4307,10 +4307,6 @@
       "classification": "official-protocol-specification",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
-    "#/components/schemas/FirestoreValue/oneOf/0/properties/nullValue/const": {
-      "classification": "official-protocol-specification",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
-    },
     "#/components/schemas/FirestoreValue/oneOf/0/additionalProperties": {
       "classification": "official-protocol-specification",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"

--- a/spec/partiful.api-evidence.json
+++ b/spec/partiful.api-evidence.json
@@ -1,6 +1,6 @@
 {
-  "contractRevision": "2026-08-12.3",
-  "ownerReviewedBaseline": "2026-08-12.2",
+  "contractRevision": "2026-08-12.4",
+  "ownerReviewedBaseline": "2026-08-12.3",
   "contractPath": "spec/partiful.openapi.json",
   "allowedClassifications": [
     "dated-live-observation",
@@ -53,16 +53,24 @@
     "rsvpReadObservation20260812": "docs/research/2026-08-12-rsvp-read-observation.md#scope-and-provenance",
     "rsvpReadCurrentGuest20260812": "docs/research/2026-08-12-rsvp-read-observation.md#current-guest-variants",
     "rsvpReadSafeguards20260812": "docs/research/2026-08-12-rsvp-read-observation.md#event-safeguard-observations",
-    "rsvpReadPrivacy20260812": "docs/research/2026-08-12-rsvp-read-observation.md#privacy-boundary"
+    "rsvpReadPrivacy20260812": "docs/research/2026-08-12-rsvp-read-observation.md#privacy-boundary",
+    "publicEventWriteMapping20260812": "docs/research/2026-08-12-event-write-mapping-public-assets.md#scope-and-provenance",
+    "publicCreateEventRequest20260812": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request",
+    "publicCreateEventCompletion20260812": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-completion",
+    "publicFirestoreEventUpdate20260812": "docs/research/2026-08-12-event-write-mapping-public-assets.md#firestore-event-update",
+    "publicCancelEvent20260812": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion",
+    "publicEventPosterMapping20260812": "docs/research/2026-08-12-event-write-mapping-public-assets.md#built-in-poster-representation",
+    "publicEventWritePreconditions20260812": "docs/research/2026-08-12-event-write-mapping-public-assets.md#update-preconditions",
+    "officialFirestoreProtocol": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
   },
   "operations": {
     "createEvent": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
     },
     "cancelEvent": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
     },
     "getEventInfo": {
       "classification": "dated-live-observation",
@@ -125,8 +133,8 @@
       "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
     },
     "firestorePatchEvent": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch"
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
     "firestoreGetGuest": {
       "classification": "dated-live-observation",
@@ -167,20 +175,20 @@
   },
   "operationClaims": {
     "createEvent": {
-      "request": "typescript-derived-inference",
-      "requestCitation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post",
-      "response": "explicit-unknown",
-      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
-      "status": "explicit-unknown",
-      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+      "request": "current-first-party-public-asset-research",
+      "requestCitation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request",
+      "response": "current-first-party-public-asset-research",
+      "responseCitation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-completion",
+      "status": "official-protocol-specification",
+      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firebase-callable-protocol"
     },
     "cancelEvent": {
-      "request": "typescript-derived-inference",
-      "requestCitation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post",
-      "response": "explicit-unknown",
-      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
-      "status": "explicit-unknown",
-      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+      "request": "current-first-party-public-asset-research",
+      "requestCitation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion",
+      "response": "current-first-party-public-asset-research",
+      "responseCitation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion",
+      "status": "official-protocol-specification",
+      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firebase-callable-protocol"
     },
     "getEventInfo": {
       "request": "typescript-derived-inference",
@@ -303,12 +311,12 @@
       "statusCitation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
     },
     "firestorePatchEvent": {
-      "request": "typescript-derived-inference",
-      "requestCitation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch",
-      "response": "explicit-unknown",
-      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
-      "status": "explicit-unknown",
-      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+      "request": "official-protocol-specification",
+      "requestCitation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol",
+      "response": "official-protocol-specification",
+      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol",
+      "status": "official-protocol-specification",
+      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
     "firestoreGetGuest": {
       "request": "typescript-derived-inference",
@@ -400,11 +408,11 @@
     }
   ],
   "unresolvedUncertainty": [
-    "Callable-specific parameter sets and result payloads outside createTextBlast, addGuest, markEventInterest, and documented auth calls.",
-    "Complete Firestore typed-value grammar, authorization rules, pagination limits, and update-mask semantics.",
+    "Callable-specific parameter sets and result payloads outside createEvent, cancelEvent, createTextBlast, addGuest, markEventInterest, and documented auth calls remain unknown.",
+    "Partiful Firestore authorization and field policy, endpoint-specific errors, concurrent-write behavior, and pagination limits remain unknown; only the generic official Value, Document, PATCH, mask, precondition, and bearer protocol is claimed.",
     "Upload accepted media types, size limits, response variants, and whether uploadType values remain stable.",
     "Poster catalog membership and order can change; exhaustiveness beyond the complete observed endpoint representation is unknown.",
-    "Status codes and error bodies for operations without dated observations.",
+    "Status codes and error bodies without a dated observation or applicable official protocol remain unknown.",
     "Unconditional poster-catalog failure statuses and bodies remain unknown; only HTTP 200 is an accepted catalog success.",
     "The full set of Referer values accepted by the Firebase API-key restriction remains unknown; https://partiful.com/ is the only observed accepted value.",
     "Origin is unmodelled and remains unknown because the reviewed evidence establishes no Origin request fact.",
@@ -414,245 +422,358 @@
     "One CurrentGuest null and one object variant are observed; operation-wide object field presence, non-null plus-one shapes, unsupported statuses, other variants, and failure bodies remain unknown.",
     "Firestore event GET returned PERMISSION_DENIED for selected readable and synthetic IDs with one credential; success, not-found, attendee-denial, and other credential behavior remain unknown.",
     "Contact invalid-cursor behavior, cursor lifetime and reuse, ordering key, snapshot behavior, useAuthUser, rate limiting, unsupported statuses, future catalog completeness, server duplicate behavior, and duplicates outside two traversals remain unknown.",
-    "RSVP mutation failures, server-side rejection mappings, ticketing, application, waitlist, protected-event submission, and post-write RSVP business state remain unknown."
+    "RSVP mutation failures, server-side rejection mappings, ticketing, application, waitlist, protected-event submission, and post-write RSVP business state remain unknown.",
+    "Event-write endpoint business success, persisted Event state, post-write reads, unobserved errors and statuses, inaccessible-event permissions, cancellation delivery, and automatic retry safety remain unknown."
   ],
-  "status": "owner-reviewed",
+  "status": "pending-delegated-review",
   "claims": {
     "#/servers/0/url": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/servers/0/url"
     },
     "#/paths/~1createEvent/post/operationId": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/operationId"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
     },
     "#/paths/~1createEvent/post/requestBody/required": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/required"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
     },
     "#/paths/~1createEvent/post/requestBody/content/application~1json": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
     },
     "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/type"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
     },
     "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/required/0": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/required/0"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
     },
     "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
     },
     "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/type"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
     },
     "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/required/0": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/required/0"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
     },
     "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/required/1": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/required/1"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
     },
     "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
     },
     "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/type"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
     },
     "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/event": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/event"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
     },
     "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/event/$ref": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/event/$ref"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
     },
     "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/cohostIds": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/cohostIds"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
     },
     "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/cohostIds/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/cohostIds/type"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
     },
     "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/cohostIds/items/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/cohostIds/items/type"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/ticketTypes": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/promoCodes": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/affiliateId": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/affiliateId/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
     },
     "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
     },
     "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
     },
     "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/1": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/1"
-    },
-    "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId"
-    },
-    "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type"
-    },
-    "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId"
-    },
-    "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type"
-    },
-    "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
     },
     "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/userId": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/userId"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
     },
     "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
     },
     "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/deviceInfo": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/deviceInfo/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/deviceInfo/additionalProperties": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/adminAccessRequested": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/adminAccessRequested/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/properties/adminAccessRequested/const": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
     },
     "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/additionalProperties": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/properties/data/additionalProperties"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
     },
     "#/paths/~1createEvent/post/requestBody/content/application~1json/schema/additionalProperties": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/requestBody/content/application~1json/schema/additionalProperties"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/paths/~1createEvent/post/responses/200": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-completion"
+    },
+    "#/paths/~1createEvent/post/responses/200/content/application~1json": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-completion"
+    },
+    "#/paths/~1createEvent/post/responses/200/content/application~1json/schema/$ref": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-completion"
     },
     "#/paths/~1createEvent/post/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1createEvent/post/security/0/firebaseBearer": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createEvent/post/security/0/firebaseBearer"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
     },
     "#/paths/~1cancelEvent/post/operationId": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/operationId"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
     },
     "#/paths/~1cancelEvent/post/requestBody/required": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/required"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
     },
     "#/paths/~1cancelEvent/post/requestBody/content/application~1json": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/content/application~1json"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
     },
     "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/type"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
     },
     "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/required/0": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/required/0"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
     },
     "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
     },
     "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/type"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
     },
     "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/required/0": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/required/0"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
     },
     "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/required/1": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/required/1"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
     },
     "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
     },
     "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/type"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
     },
     "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
     },
     "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId/type"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
+    },
+    "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/cancellationMessage": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
+    },
+    "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/cancellationMessage/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
+    },
+    "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/shouldSkipNotifyGuests": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
+    },
+    "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/shouldSkipNotifyGuests/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
     },
     "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
     },
     "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
     },
-    "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId"
+    "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/1": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
     },
-    "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type"
-    },
-    "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId"
-    },
-    "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type"
-    },
-    "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format"
+    "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/2": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
     },
     "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/userId": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/userId"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
     },
     "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
     },
     "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
+    },
+    "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/deviceInfo": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
+    },
+    "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/deviceInfo/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
+    },
+    "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/deviceInfo/additionalProperties": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
+    },
+    "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
+    },
+    "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
+    },
+    "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
+    },
+    "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
+    },
+    "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
+    },
+    "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/adminAccessRequested": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
+    },
+    "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/adminAccessRequested/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
+    },
+    "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/properties/adminAccessRequested/const": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
     },
     "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/additionalProperties": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/properties/data/additionalProperties"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
     },
     "#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/additionalProperties": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/requestBody/content/application~1json/schema/additionalProperties"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
+    },
+    "#/paths/~1cancelEvent/post/responses/200": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
+    },
+    "#/paths/~1cancelEvent/post/responses/200/content/application~1json": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
+    },
+    "#/paths/~1cancelEvent/post/responses/200/content/application~1json/schema/$ref": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
     },
     "#/paths/~1cancelEvent/post/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1cancelEvent/post/security/0/firebaseBearer": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1cancelEvent/post/security/0/firebaseBearer"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
     },
     "#/paths/~1getEventInfo/post/operationId": {
       "classification": "typescript-derived-inference",
@@ -2258,6 +2379,18 @@
       "classification": "current-first-party-public-asset-research",
       "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
     },
+    "#/paths/~1addGuest/post/responses/200": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firebase-callable-protocol"
+    },
+    "#/paths/~1addGuest/post/responses/200/content/application~1json": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-completion"
+    },
+    "#/paths/~1addGuest/post/responses/200/content/application~1json/schema/$ref": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-completion"
+    },
     "#/paths/~1addGuest/post/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
@@ -2387,6 +2520,18 @@
       "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#markeventinterest-request-and-completion"
     },
     "#/paths/~1markEventInterest/post/requestBody/content/application~1json/schema/additionalProperties": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#markeventinterest-request-and-completion"
+    },
+    "#/paths/~1markEventInterest/post/responses/200": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firebase-callable-protocol"
+    },
+    "#/paths/~1markEventInterest/post/responses/200/content/application~1json": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#markeventinterest-request-and-completion"
+    },
+    "#/paths/~1markEventInterest/post/responses/200/content/application~1json/schema/$ref": {
       "classification": "current-first-party-public-asset-research",
       "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#markeventinterest-request-and-completion"
     },
@@ -2559,76 +2704,124 @@
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/get/servers/0/url"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/operationId": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/operationId"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#firestore-event-update"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/0/name": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/0/name"
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/0/in": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/0/in"
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/0/required": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/0/required"
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/0/schema/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/0/schema/type"
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/1/name": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/1/name"
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/1/in": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/1/in"
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/1/required": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/1/required"
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/1/schema/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/1/schema/type"
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/1/schema/items/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/1/schema/items/type"
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/1/style": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#update-mask-serialization"
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/1/explode": {
-      "classification": "typescript-derived-inference",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#update-mask-serialization"
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/2/name": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/2/in": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/2/required": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/2/schema/type": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/3/name": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/3/in": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/3/required": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/3/schema/type": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/parameters/3/schema/format": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/requestBody/required": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/requestBody/required"
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/requestBody/content/application~1json": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/requestBody/content/application~1json"
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/requestBody/content/application~1json/schema/$ref": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/requestBody/content/application~1json/schema/$ref"
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/responses/200": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/responses/200/content/application~1json": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/responses/200/content/application~1json/schema/$ref": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/responses/default": {
       "classification": "explicit-unknown",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/security/0/firebaseBearer": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/security/0/firebaseBearer"
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/servers/0/url": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}/patch/servers/0/url"
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
     "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1events~1{eventId}~1guests~1{guestId}/get/operationId": {
       "classification": "typescript-derived-inference",
@@ -2814,10 +3007,6 @@
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
     },
-    "#/paths/~1v1~1token/post/responses/default": {
-      "classification": "explicit-unknown",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
-    },
     "#/paths/~1v1~1token/post/responses/400": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
@@ -2829,6 +3018,10 @@
     "#/paths/~1v1~1token/post/responses/400/content/application~1json/schema/$ref": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-auth-observation.md#refreshtoken"
+    },
+    "#/paths/~1v1~1token/post/responses/default": {
+      "classification": "explicit-unknown",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1v1~1token/post/security/0/firebaseApiKey": {
       "classification": "typescript-derived-inference",
@@ -3166,10 +3359,6 @@
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
     },
-    "#/paths/~1getLoginToken/post/responses/default": {
-      "classification": "explicit-unknown",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
-    },
     "#/paths/~1getLoginToken/post/responses/403": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
@@ -3181,6 +3370,10 @@
     "#/paths/~1getLoginToken/post/responses/403/content/application~1json/schema/$ref": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-auth-observation.md#getlogintoken"
+    },
+    "#/paths/~1getLoginToken/post/responses/default": {
+      "classification": "explicit-unknown",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1v1~1accounts:signInWithCustomToken/post/operationId": {
       "classification": "typescript-derived-inference",
@@ -3238,10 +3431,6 @@
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
     },
-    "#/paths/~1v1~1accounts:signInWithCustomToken/post/responses/default": {
-      "classification": "explicit-unknown",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
-    },
     "#/paths/~1v1~1accounts:signInWithCustomToken/post/responses/400": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
@@ -3253,6 +3442,10 @@
     "#/paths/~1v1~1accounts:signInWithCustomToken/post/responses/400/content/application~1json/schema/$ref": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-auth-observation.md#signinwithcustomtoken"
+    },
+    "#/paths/~1v1~1accounts:signInWithCustomToken/post/responses/default": {
+      "classification": "explicit-unknown",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1v1~1accounts:signInWithCustomToken/post/security/0/firebaseApiKey": {
       "classification": "typescript-derived-inference",
@@ -3326,10 +3519,6 @@
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
     },
-    "#/paths/~1v1~1accounts:lookup/post/responses/default": {
-      "classification": "explicit-unknown",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
-    },
     "#/paths/~1v1~1accounts:lookup/post/responses/400": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
@@ -3341,6 +3530,10 @@
     "#/paths/~1v1~1accounts:lookup/post/responses/400/content/application~1json/schema/$ref": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-auth-observation.md#lookupfirebaseuser"
+    },
+    "#/paths/~1v1~1accounts:lookup/post/responses/default": {
+      "classification": "explicit-unknown",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "#/paths/~1v1~1accounts:lookup/post/security/0/firebaseApiKey": {
       "classification": "typescript-derived-inference",
@@ -3491,140 +3684,332 @@
       "citation": "docs/research/2026-08-11-firebase-public-api-key-redacted.md#firebase-public-api-key"
     },
     "#/components/schemas/EventDraft/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/type"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
     },
     "#/components/schemas/EventDraft/required/0": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/required/0"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
     },
     "#/components/schemas/EventDraft/required/1": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/required/1"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
     },
     "#/components/schemas/EventDraft/required/2": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/required/2"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
     },
     "#/components/schemas/EventDraft/required/3": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/required/3"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/required/4": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/required/5": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/required/6": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/required/7": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/required/8": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/required/9": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/required/10": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/required/11": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/required/12": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/required/13": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/required/14": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/required/15": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/required/16": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/required/17": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
     },
     "#/components/schemas/EventDraft/properties/title": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/title"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
     },
     "#/components/schemas/EventDraft/properties/startDate": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/startDate"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
     },
     "#/components/schemas/EventDraft/properties/startDate/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/startDate/type"
-    },
-    "#/components/schemas/EventDraft/properties/startDate/format": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/startDate/format"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
     },
     "#/components/schemas/EventDraft/properties/endDate": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/endDate"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
     },
     "#/components/schemas/EventDraft/properties/endDate/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/endDate/type"
-    },
-    "#/components/schemas/EventDraft/properties/endDate/format": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/endDate/format"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
     },
     "#/components/schemas/EventDraft/properties/timezone": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/timezone"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
     },
     "#/components/schemas/EventDraft/properties/timezone/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/timezone/type"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/properties/guestStatusCounts": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/properties/guestStatusCounts/$ref": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
     },
     "#/components/schemas/EventDraft/properties/displaySettings": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/displaySettings"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
     },
-    "#/components/schemas/EventDraft/properties/displaySettings/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/displaySettings/type"
+    "#/components/schemas/EventDraft/properties/displaySettings/$ref": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
     },
-    "#/components/schemas/EventDraft/properties/displaySettings/additionalProperties": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/displaySettings/additionalProperties"
+    "#/components/schemas/EventDraft/properties/status": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
     },
-    "#/components/schemas/EventDraft/properties/visibility": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/visibility"
+    "#/components/schemas/EventDraft/properties/status/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
     },
-    "#/components/schemas/EventDraft/properties/visibility/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/visibility/type"
+    "#/components/schemas/EventDraft/properties/status/const": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
     },
-    "#/components/schemas/EventDraft/properties/visibility/enum/0": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/visibility/enum/0"
+    "#/components/schemas/EventDraft/properties/rsvpButtonGlyphType": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
     },
-    "#/components/schemas/EventDraft/properties/visibility/enum/1": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/visibility/enum/1"
+    "#/components/schemas/EventDraft/properties/rsvpButtonGlyphType/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
     },
-    "#/components/schemas/EventDraft/properties/location": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/location"
-    },
-    "#/components/schemas/EventDraft/properties/location/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/location/type"
-    },
-    "#/components/schemas/EventDraft/properties/address": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/address"
-    },
-    "#/components/schemas/EventDraft/properties/address/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/address/type"
-    },
-    "#/components/schemas/EventDraft/properties/description": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/description"
-    },
-    "#/components/schemas/EventDraft/properties/guestLimit": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/guestLimit"
-    },
-    "#/components/schemas/EventDraft/properties/guestLimit/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/guestLimit/type"
-    },
-    "#/components/schemas/EventDraft/properties/links": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/links"
-    },
-    "#/components/schemas/EventDraft/properties/links/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/links/type"
-    },
-    "#/components/schemas/EventDraft/properties/links/items/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/links/items/type"
-    },
-    "#/components/schemas/EventDraft/properties/links/items/additionalProperties": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/links/items/additionalProperties"
+    "#/components/schemas/EventDraft/properties/rsvpButtonGlyphType/const": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
     },
     "#/components/schemas/EventDraft/properties/image": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/properties/image"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/properties/image/$ref": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/properties/showHostList": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/properties/showHostList/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/properties/showHostList/const": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/properties/showGuestCount": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/properties/showGuestCount/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/properties/showGuestCount/const": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/properties/showGuestList": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/properties/showGuestList/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/properties/showGuestList/const": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/properties/showActivityTimestamps": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/properties/showActivityTimestamps/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/properties/showActivityTimestamps/const": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/properties/displayInviteButton": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/properties/displayInviteButton/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/properties/displayInviteButton/const": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/properties/visibility": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/properties/visibility/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/properties/visibility/const": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/properties/allowGuestPhotoUpload": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/properties/allowGuestPhotoUpload/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/properties/allowGuestPhotoUpload/const": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/properties/enableGuestReminders": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/properties/enableGuestReminders/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/properties/enableGuestReminders/const": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/properties/rsvpsEnabled": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/properties/rsvpsEnabled/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/properties/rsvpsEnabled/const": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/properties/allowGuestsToInviteMutuals": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/properties/allowGuestsToInviteMutuals/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/properties/allowGuestsToInviteMutuals/const": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/properties/description": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/properties/locationInfo": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/properties/locationInfo/$ref": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/properties/isPublic": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/properties/isPublic/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/properties/maxCapacity": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/properties/maxCapacity/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/properties/maxCapacity/minimum": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/properties/enableWaitlist": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/properties/enableWaitlist/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/properties/customFields": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/properties/customFields/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDraft/properties/customFields/items/$ref": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
     },
     "#/components/schemas/EventDraft/additionalProperties": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/EventDraft/additionalProperties"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
     },
     "#/components/schemas/RsvpDraft/type": {
       "classification": "current-first-party-public-asset-research",
@@ -3650,6 +4035,10 @@
       "classification": "current-first-party-public-asset-research",
       "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
     },
+    "#/components/schemas/RsvpDraft/required/5": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
+    },
     "#/components/schemas/RsvpDraft/properties/name": {
       "classification": "current-first-party-public-asset-research",
       "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
@@ -3658,11 +4047,23 @@
       "classification": "current-first-party-public-asset-research",
       "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
     },
+    "#/components/schemas/RsvpDraft/properties/name/minLength": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
+    },
+    "#/components/schemas/RsvpDraft/properties/name/maxLength": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
+    },
     "#/components/schemas/RsvpDraft/properties/count": {
       "classification": "current-first-party-public-asset-research",
       "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
     },
     "#/components/schemas/RsvpDraft/properties/count/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
+    },
+    "#/components/schemas/RsvpDraft/properties/count/minimum": {
       "classification": "current-first-party-public-asset-research",
       "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
     },
@@ -3678,7 +4079,19 @@
       "classification": "current-first-party-public-asset-research",
       "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
     },
+    "#/components/schemas/RsvpDraft/properties/message/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
+    },
+    "#/components/schemas/RsvpDraft/properties/message/maxLength": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
+    },
     "#/components/schemas/RsvpDraft/properties/emailInvitationId": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
+    },
+    "#/components/schemas/RsvpDraft/properties/emailInvitationId/type": {
       "classification": "current-first-party-public-asset-research",
       "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
     },
@@ -3690,7 +4103,23 @@
       "classification": "current-first-party-public-asset-research",
       "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
     },
+    "#/components/schemas/RsvpDraft/properties/status/enum/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
+    },
+    "#/components/schemas/RsvpDraft/properties/status/enum/1": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
+    },
+    "#/components/schemas/RsvpDraft/properties/status/enum/2": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#guest-status-and-product-intent"
+    },
     "#/components/schemas/RsvpDraft/properties/guestId": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
+    },
+    "#/components/schemas/RsvpDraft/properties/guestId/type": {
       "classification": "current-first-party-public-asset-research",
       "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
     },
@@ -3706,13 +4135,137 @@
       "classification": "current-first-party-public-asset-research",
       "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
     },
+    "#/components/schemas/RsvpDraft/properties/password/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
+    },
     "#/components/schemas/RsvpDraft/properties/questionnaireResponse": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
+    },
+    "#/components/schemas/RsvpDraft/properties/questionnaireResponse/$ref": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
+    },
+    "#/components/schemas/RsvpDraft/properties/shouldFollowOrgs": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
+    },
+    "#/components/schemas/RsvpDraft/properties/shouldFollowOrgs/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
+    },
+    "#/components/schemas/RsvpDraft/properties/shouldFollowOrgs/const": {
       "classification": "current-first-party-public-asset-research",
       "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
     },
     "#/components/schemas/RsvpDraft/additionalProperties": {
       "classification": "current-first-party-public-asset-research",
       "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
+    },
+    "#/components/schemas/RsvpQuestionnaireResponse/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
+    },
+    "#/components/schemas/RsvpQuestionnaireResponse/properties/questionnaireVersion": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
+    },
+    "#/components/schemas/RsvpQuestionnaireResponse/properties/questionnaireVersion/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
+    },
+    "#/components/schemas/RsvpQuestionnaireResponse/properties/questionnaireVersion/minimum": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
+    },
+    "#/components/schemas/RsvpQuestionnaireResponse/properties/answers": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
+    },
+    "#/components/schemas/RsvpQuestionnaireResponse/properties/answers/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
+    },
+    "#/components/schemas/RsvpQuestionnaireResponse/properties/answers/additionalProperties/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
+    },
+    "#/components/schemas/RsvpQuestionnaireResponse/required/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
+    },
+    "#/components/schemas/RsvpQuestionnaireResponse/required/1": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
+    },
+    "#/components/schemas/RsvpQuestionnaireResponse/additionalProperties": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
+    },
+    "#/components/schemas/AddGuestCompletionResponse/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-completion"
+    },
+    "#/components/schemas/AddGuestCompletionResponse/required/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-completion"
+    },
+    "#/components/schemas/AddGuestCompletionResponse/properties/result": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-completion"
+    },
+    "#/components/schemas/AddGuestCompletionResponse/properties/result/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-completion"
+    },
+    "#/components/schemas/AddGuestCompletionResponse/properties/result/required/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-completion"
+    },
+    "#/components/schemas/AddGuestCompletionResponse/properties/result/properties/data": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-completion"
+    },
+    "#/components/schemas/AddGuestCompletionResponse/properties/result/additionalProperties": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-completion"
+    },
+    "#/components/schemas/AddGuestCompletionResponse/additionalProperties": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-completion"
+    },
+    "#/components/schemas/MarkEventInterestCompletionResponse/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#markeventinterest-request-and-completion"
+    },
+    "#/components/schemas/MarkEventInterestCompletionResponse/required/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#markeventinterest-request-and-completion"
+    },
+    "#/components/schemas/MarkEventInterestCompletionResponse/properties/result": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#markeventinterest-request-and-completion"
+    },
+    "#/components/schemas/MarkEventInterestCompletionResponse/properties/result/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#markeventinterest-request-and-completion"
+    },
+    "#/components/schemas/MarkEventInterestCompletionResponse/properties/result/required/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#markeventinterest-request-and-completion"
+    },
+    "#/components/schemas/MarkEventInterestCompletionResponse/properties/result/properties/data": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#markeventinterest-request-and-completion"
+    },
+    "#/components/schemas/MarkEventInterestCompletionResponse/properties/result/additionalProperties": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#markeventinterest-request-and-completion"
+    },
+    "#/components/schemas/MarkEventInterestCompletionResponse/additionalProperties": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#markeventinterest-request-and-completion"
     },
     "#/components/schemas/CallableResponse/type": {
       "classification": "typescript-derived-inference",
@@ -3738,89 +4291,333 @@
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/CallableResponse/additionalProperties"
     },
-    "#/components/schemas/FirestoreValue/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreValue/type"
+    "#/components/schemas/FirestoreValue/oneOf/0/type": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
-    "#/components/schemas/FirestoreValue/additionalProperties": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreValue/additionalProperties"
+    "#/components/schemas/FirestoreValue/oneOf/0/required/0": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/0/properties/nullValue": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/0/properties/nullValue/type": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/0/properties/nullValue/const": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/0/additionalProperties": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/1/type": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/1/required/0": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/1/properties/booleanValue": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/1/properties/booleanValue/type": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/1/additionalProperties": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/2/type": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/2/required/0": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/2/properties/integerValue": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/2/properties/integerValue/type": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/2/properties/integerValue/pattern": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/2/additionalProperties": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/3/type": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/3/required/0": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/3/properties/doubleValue": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/3/properties/doubleValue/oneOf/0/type": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/3/properties/doubleValue/oneOf/1/type": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/3/properties/doubleValue/oneOf/1/enum/0": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/3/properties/doubleValue/oneOf/1/enum/1": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/3/properties/doubleValue/oneOf/1/enum/2": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/3/additionalProperties": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/4/type": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/4/required/0": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/4/properties/timestampValue": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/4/properties/timestampValue/type": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/4/properties/timestampValue/format": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/4/additionalProperties": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/5/type": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/5/required/0": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/5/properties/stringValue": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/5/properties/stringValue/type": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/5/additionalProperties": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/6/type": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/6/required/0": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/6/properties/bytesValue": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/6/properties/bytesValue/type": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/6/properties/bytesValue/format": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/6/additionalProperties": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/7/type": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/7/required/0": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/7/properties/referenceValue": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/7/properties/referenceValue/type": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/7/additionalProperties": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/8/type": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/8/required/0": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/8/properties/geoPointValue": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/8/properties/geoPointValue/$ref": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/8/additionalProperties": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/9/type": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/9/required/0": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/9/properties/arrayValue": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/9/properties/arrayValue/$ref": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/9/additionalProperties": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/10/type": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/10/required/0": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/10/properties/mapValue": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/10/properties/mapValue/$ref": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/FirestoreValue/oneOf/10/additionalProperties": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
     "#/components/schemas/FirestoreDocument/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreDocument/type"
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
     "#/components/schemas/FirestoreDocument/properties/name": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreDocument/properties/name"
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
     "#/components/schemas/FirestoreDocument/properties/name/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreDocument/properties/name/type"
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
     "#/components/schemas/FirestoreDocument/properties/fields": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreDocument/properties/fields"
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
     "#/components/schemas/FirestoreDocument/properties/fields/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreDocument/properties/fields/type"
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
     "#/components/schemas/FirestoreDocument/properties/fields/additionalProperties/$ref": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreDocument/properties/fields/additionalProperties/$ref"
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
     "#/components/schemas/FirestoreDocument/properties/createTime": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreDocument/properties/createTime"
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
     "#/components/schemas/FirestoreDocument/properties/createTime/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreDocument/properties/createTime/type"
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
     "#/components/schemas/FirestoreDocument/properties/createTime/format": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreDocument/properties/createTime/format"
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
     "#/components/schemas/FirestoreDocument/properties/updateTime": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreDocument/properties/updateTime"
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
     "#/components/schemas/FirestoreDocument/properties/updateTime/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreDocument/properties/updateTime/type"
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
     "#/components/schemas/FirestoreDocument/properties/updateTime/format": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreDocument/properties/updateTime/format"
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
     "#/components/schemas/FirestoreDocument/additionalProperties": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreDocument/additionalProperties"
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
     "#/components/schemas/FirestoreWriteDocument/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreWriteDocument/type"
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
     "#/components/schemas/FirestoreWriteDocument/required/0": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreWriteDocument/required/0"
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
     "#/components/schemas/FirestoreWriteDocument/properties/fields": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreWriteDocument/properties/fields"
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
     "#/components/schemas/FirestoreWriteDocument/properties/fields/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreWriteDocument/properties/fields/type"
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
     "#/components/schemas/FirestoreWriteDocument/properties/fields/additionalProperties/$ref": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreWriteDocument/properties/fields/additionalProperties/$ref"
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
     "#/components/schemas/FirestoreWriteDocument/additionalProperties": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/components/schemas/FirestoreWriteDocument/additionalProperties"
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
     "#/components/schemas/FirestoreListResponse/type": {
       "classification": "typescript-derived-inference",
@@ -5138,6 +5935,10 @@
       "classification": "current-first-party-public-asset-research",
       "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#guest-status-and-product-intent"
     },
+    "#/components/schemas/CurrentGuest/properties/status/$ref": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#guest-status-and-product-intent"
+    },
     "#/components/schemas/CurrentGuest/properties/userId": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
@@ -5486,201 +6287,645 @@
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#contact-observations"
     },
-    "#/paths/~1addGuest/post/responses/200": {
+    "#/components/schemas/NewEventGuestStatusCounts/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/required/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/required/1": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/required/2": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/required/3": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/required/4": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/required/5": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/required/6": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/required/7": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/required/8": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/required/9": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/required/10": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/required/11": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/required/12": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/required/13": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/required/14": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/required/15": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/READY_TO_SEND": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/READY_TO_SEND/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/READY_TO_SEND/const": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/SENDING": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/SENDING/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/SENDING/const": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/SENT": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/SENT/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/SENT/const": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/SEND_ERROR": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/SEND_ERROR/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/SEND_ERROR/const": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/DELIVERY_ERROR": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/DELIVERY_ERROR/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/DELIVERY_ERROR/const": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/INTERESTED": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/INTERESTED/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/INTERESTED/const": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/MAYBE": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/MAYBE/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/MAYBE/const": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/GOING": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/GOING/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/GOING/const": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/DECLINED": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/DECLINED/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/DECLINED/const": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/WAITLIST": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/WAITLIST/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/WAITLIST/const": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/PENDING_APPROVAL": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/PENDING_APPROVAL/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/PENDING_APPROVAL/const": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/APPROVED": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/APPROVED/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/APPROVED/const": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/WITHDRAWN": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/WITHDRAWN/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/WITHDRAWN/const": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/RESPONDED_TO_FIND_A_TIME": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/RESPONDED_TO_FIND_A_TIME/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/RESPONDED_TO_FIND_A_TIME/const": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/WAITLISTED_FOR_APPROVAL": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/WAITLISTED_FOR_APPROVAL/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/WAITLISTED_FOR_APPROVAL/const": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/REJECTED": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/REJECTED/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/properties/REJECTED/const": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/NewEventGuestStatusCounts/additionalProperties": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDisplaySettings/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDisplaySettings/required/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDisplaySettings/required/1": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDisplaySettings/required/2": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDisplaySettings/properties/theme": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDisplaySettings/properties/theme/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDisplaySettings/properties/effect": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDisplaySettings/properties/effect/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDisplaySettings/properties/titleFont": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDisplaySettings/properties/titleFont/type/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDisplaySettings/properties/titleFont/type/1": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventDisplaySettings/additionalProperties": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventLocationInfo/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventLocationInfo/required/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventLocationInfo/properties/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventLocationInfo/properties/type/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventLocationInfo/properties/type/enum/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventLocationInfo/properties/type/enum/1": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventLocationInfo/properties/value": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventLocationInfo/properties/value/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventLocationInfo/additionalProperties": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventCustomField/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventCustomField/required/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventCustomField/required/1": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventCustomField/properties/icon": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventCustomField/properties/icon/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventCustomField/properties/value": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventCustomField/properties/value/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventCustomField/properties/url": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventCustomField/properties/url/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventCustomField/properties/url/format": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventCustomField/additionalProperties": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/PartifulPosterImage/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#built-in-poster-representation"
+    },
+    "#/components/schemas/PartifulPosterImage/required/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#built-in-poster-representation"
+    },
+    "#/components/schemas/PartifulPosterImage/required/1": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#built-in-poster-representation"
+    },
+    "#/components/schemas/PartifulPosterImage/required/2": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#built-in-poster-representation"
+    },
+    "#/components/schemas/PartifulPosterImage/required/3": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#built-in-poster-representation"
+    },
+    "#/components/schemas/PartifulPosterImage/required/4": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#built-in-poster-representation"
+    },
+    "#/components/schemas/PartifulPosterImage/required/5": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#built-in-poster-representation"
+    },
+    "#/components/schemas/PartifulPosterImage/required/6": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#built-in-poster-representation"
+    },
+    "#/components/schemas/PartifulPosterImage/required/7": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#built-in-poster-representation"
+    },
+    "#/components/schemas/PartifulPosterImage/properties/source": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#built-in-poster-representation"
+    },
+    "#/components/schemas/PartifulPosterImage/properties/source/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#built-in-poster-representation"
+    },
+    "#/components/schemas/PartifulPosterImage/properties/source/const": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#built-in-poster-representation"
+    },
+    "#/components/schemas/PartifulPosterImage/properties/poster": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#built-in-poster-representation"
+    },
+    "#/components/schemas/PartifulPosterImage/properties/poster/$ref": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#built-in-poster-representation"
+    },
+    "#/components/schemas/PartifulPosterImage/properties/url": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#built-in-poster-representation"
+    },
+    "#/components/schemas/PartifulPosterImage/properties/url/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#built-in-poster-representation"
+    },
+    "#/components/schemas/PartifulPosterImage/properties/url/format": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#built-in-poster-representation"
+    },
+    "#/components/schemas/PartifulPosterImage/properties/blurHash": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#built-in-poster-representation"
+    },
+    "#/components/schemas/PartifulPosterImage/properties/blurHash/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#built-in-poster-representation"
+    },
+    "#/components/schemas/PartifulPosterImage/properties/contentType": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#built-in-poster-representation"
+    },
+    "#/components/schemas/PartifulPosterImage/properties/contentType/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#built-in-poster-representation"
+    },
+    "#/components/schemas/PartifulPosterImage/properties/name": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#built-in-poster-representation"
+    },
+    "#/components/schemas/PartifulPosterImage/properties/name/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#built-in-poster-representation"
+    },
+    "#/components/schemas/PartifulPosterImage/properties/height": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#built-in-poster-representation"
+    },
+    "#/components/schemas/PartifulPosterImage/properties/height/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#built-in-poster-representation"
+    },
+    "#/components/schemas/PartifulPosterImage/properties/width": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#built-in-poster-representation"
+    },
+    "#/components/schemas/PartifulPosterImage/properties/width/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#built-in-poster-representation"
+    },
+    "#/components/schemas/PartifulPosterImage/additionalProperties": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#built-in-poster-representation"
+    },
+    "#/components/schemas/CreateEventCompletionResponse/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-completion"
+    },
+    "#/components/schemas/CreateEventCompletionResponse/required/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-completion"
+    },
+    "#/components/schemas/CreateEventCompletionResponse/properties/result": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-completion"
+    },
+    "#/components/schemas/CreateEventCompletionResponse/properties/result/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-completion"
+    },
+    "#/components/schemas/CreateEventCompletionResponse/properties/result/required/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-completion"
+    },
+    "#/components/schemas/CreateEventCompletionResponse/properties/result/properties/data": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-completion"
+    },
+    "#/components/schemas/CreateEventCompletionResponse/properties/result/additionalProperties": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-completion"
+    },
+    "#/components/schemas/CreateEventCompletionResponse/additionalProperties": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-completion"
+    },
+    "#/components/schemas/CancelEventCompletionResponse/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
+    },
+    "#/components/schemas/CancelEventCompletionResponse/required/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
+    },
+    "#/components/schemas/CancelEventCompletionResponse/properties/result": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
+    },
+    "#/components/schemas/CancelEventCompletionResponse/properties/result/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
+    },
+    "#/components/schemas/CancelEventCompletionResponse/properties/result/required/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
+    },
+    "#/components/schemas/CancelEventCompletionResponse/properties/result/properties/data": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
+    },
+    "#/components/schemas/CancelEventCompletionResponse/properties/result/additionalProperties": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
+    },
+    "#/components/schemas/CancelEventCompletionResponse/additionalProperties": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
+    },
+    "#/components/schemas/FirestoreLatLng/type": {
       "classification": "official-protocol-specification",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firebase-callable-protocol"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
-    "#/paths/~1addGuest/post/responses/200/content/application~1json": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-completion"
-    },
-    "#/paths/~1addGuest/post/responses/200/content/application~1json/schema/$ref": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-completion"
-    },
-    "#/paths/~1markEventInterest/post/responses/200": {
+    "#/components/schemas/FirestoreLatLng/required/0": {
       "classification": "official-protocol-specification",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firebase-callable-protocol"
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
-    "#/paths/~1markEventInterest/post/responses/200/content/application~1json": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#markeventinterest-request-and-completion"
+    "#/components/schemas/FirestoreLatLng/required/1": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
-    "#/paths/~1markEventInterest/post/responses/200/content/application~1json/schema/$ref": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#markeventinterest-request-and-completion"
+    "#/components/schemas/FirestoreLatLng/properties/latitude": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
-    "#/components/schemas/RsvpDraft/required/5": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
+    "#/components/schemas/FirestoreLatLng/properties/latitude/type": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
-    "#/components/schemas/RsvpDraft/properties/name/minLength": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
+    "#/components/schemas/FirestoreLatLng/properties/longitude": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
-    "#/components/schemas/RsvpDraft/properties/name/maxLength": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
+    "#/components/schemas/FirestoreLatLng/properties/longitude/type": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
-    "#/components/schemas/RsvpDraft/properties/count/minimum": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
+    "#/components/schemas/FirestoreLatLng/additionalProperties": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
-    "#/components/schemas/RsvpDraft/properties/message/type": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
+    "#/components/schemas/FirestoreArrayValue/type": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
-    "#/components/schemas/RsvpDraft/properties/message/maxLength": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
+    "#/components/schemas/FirestoreArrayValue/properties/values": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
-    "#/components/schemas/RsvpDraft/properties/emailInvitationId/type": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
+    "#/components/schemas/FirestoreArrayValue/properties/values/type": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
-    "#/components/schemas/RsvpDraft/properties/status/enum/0": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
+    "#/components/schemas/FirestoreArrayValue/properties/values/items/$ref": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
-    "#/components/schemas/RsvpDraft/properties/status/enum/1": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
+    "#/components/schemas/FirestoreArrayValue/additionalProperties": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
-    "#/components/schemas/RsvpDraft/properties/status/enum/2": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#guest-status-and-product-intent"
+    "#/components/schemas/FirestoreMapValue/type": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
-    "#/components/schemas/RsvpDraft/properties/guestId/type": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
+    "#/components/schemas/FirestoreMapValue/properties/fields": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
-    "#/components/schemas/RsvpDraft/properties/password/type": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
+    "#/components/schemas/FirestoreMapValue/properties/fields/type": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
-    "#/components/schemas/RsvpDraft/properties/questionnaireResponse/$ref": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
+    "#/components/schemas/FirestoreMapValue/properties/fields/additionalProperties/$ref": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     },
-    "#/components/schemas/RsvpDraft/properties/shouldFollowOrgs": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
-    },
-    "#/components/schemas/RsvpDraft/properties/shouldFollowOrgs/type": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
-    },
-    "#/components/schemas/RsvpDraft/properties/shouldFollowOrgs/const": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
-    },
-    "#/components/schemas/RsvpQuestionnaireResponse/type": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
-    },
-    "#/components/schemas/RsvpQuestionnaireResponse/properties/questionnaireVersion": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
-    },
-    "#/components/schemas/RsvpQuestionnaireResponse/properties/questionnaireVersion/type": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
-    },
-    "#/components/schemas/RsvpQuestionnaireResponse/properties/questionnaireVersion/minimum": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
-    },
-    "#/components/schemas/RsvpQuestionnaireResponse/properties/answers": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
-    },
-    "#/components/schemas/RsvpQuestionnaireResponse/properties/answers/type": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
-    },
-    "#/components/schemas/RsvpQuestionnaireResponse/properties/answers/additionalProperties/type": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
-    },
-    "#/components/schemas/RsvpQuestionnaireResponse/required/0": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
-    },
-    "#/components/schemas/RsvpQuestionnaireResponse/required/1": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
-    },
-    "#/components/schemas/RsvpQuestionnaireResponse/additionalProperties": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-request"
-    },
-    "#/components/schemas/AddGuestCompletionResponse/type": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-completion"
-    },
-    "#/components/schemas/AddGuestCompletionResponse/required/0": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-completion"
-    },
-    "#/components/schemas/AddGuestCompletionResponse/properties/result": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-completion"
-    },
-    "#/components/schemas/AddGuestCompletionResponse/properties/result/type": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-completion"
-    },
-    "#/components/schemas/AddGuestCompletionResponse/properties/result/required/0": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-completion"
-    },
-    "#/components/schemas/AddGuestCompletionResponse/properties/result/properties/data": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-completion"
-    },
-    "#/components/schemas/AddGuestCompletionResponse/properties/result/additionalProperties": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-completion"
-    },
-    "#/components/schemas/AddGuestCompletionResponse/additionalProperties": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#addguest-completion"
-    },
-    "#/components/schemas/MarkEventInterestCompletionResponse/type": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#markeventinterest-request-and-completion"
-    },
-    "#/components/schemas/MarkEventInterestCompletionResponse/required/0": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#markeventinterest-request-and-completion"
-    },
-    "#/components/schemas/MarkEventInterestCompletionResponse/properties/result": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#markeventinterest-request-and-completion"
-    },
-    "#/components/schemas/MarkEventInterestCompletionResponse/properties/result/type": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#markeventinterest-request-and-completion"
-    },
-    "#/components/schemas/MarkEventInterestCompletionResponse/properties/result/required/0": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#markeventinterest-request-and-completion"
-    },
-    "#/components/schemas/MarkEventInterestCompletionResponse/properties/result/properties/data": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#markeventinterest-request-and-completion"
-    },
-    "#/components/schemas/MarkEventInterestCompletionResponse/properties/result/additionalProperties": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#markeventinterest-request-and-completion"
-    },
-    "#/components/schemas/MarkEventInterestCompletionResponse/additionalProperties": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#markeventinterest-request-and-completion"
-    },
-    "#/components/schemas/CurrentGuest/properties/status/$ref": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-rsvp-mapping-public-assets.md#guest-status-and-product-intent"
+    "#/components/schemas/FirestoreMapValue/additionalProperties": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
     }
   },
   "posterCatalogObservation": {
@@ -6265,5 +7510,22 @@
     "successSemantics": "submitted-request-only",
     "currentGuestNullability": "explicit-unknown",
     "errorsAndOtherStatuses": "explicit-unknown"
-  }
+  },
+  "eventWriteAssetResearch": {
+    "sourceCitation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#scope-and-provenance",
+    "researchedAt": "2026-08-12",
+    "buildId": "2KXQa2wzQWzlyvnJPIrVj",
+    "deploymentId": "dpl_D9bWXWUaTVfWyHiJz1RT7qdjuzUC",
+    "loginUrl": "https://partiful.com/login",
+    "manifestSha256": "71b824c18ccb5779d024fde62431a302f26f2c0d9ffaafd3640d02d9c86880f3",
+    "liveMutations": false,
+    "credentialsUsed": false,
+    "uploadRegistered": false,
+    "postWriteEventReadEstablished": false,
+    "callableUpdateEventFound": false,
+    "createCompletion": "decoded-data-used-as-event-id-no-complete-event",
+    "cancelCompletion": "decoded-data-awaited-no-business-field",
+    "firestorePatchCompletion": "official-document-protocol-only"
+  },
+  "materialClaimCount": 1625
 }

--- a/spec/partiful.api-evidence.json
+++ b/spec/partiful.api-evidence.json
@@ -5699,6 +5699,54 @@
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#event-detail-observations"
     },
+    "#/components/schemas/EventInfo/properties/ownerIds": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#update-preconditions"
+    },
+    "#/components/schemas/EventInfo/properties/ownerIds/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#update-preconditions"
+    },
+    "#/components/schemas/EventInfo/properties/ownerIds/items/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#update-preconditions"
+    },
+    "#/components/schemas/EventInfo/properties/guestCount": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
+    },
+    "#/components/schemas/EventInfo/properties/guestStatusCounts": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventInfo/properties/guestStatusCounts/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventInfo/properties/guestStatusCounts/additionalProperties/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-request"
+    },
+    "#/components/schemas/EventInfo/properties/hasGuests": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#update-preconditions"
+    },
+    "#/components/schemas/EventInfo/properties/hasGuests/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#update-preconditions"
+    },
+    "#/components/schemas/EventInfo/properties/customFields": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#firestore-event-update"
+    },
+    "#/components/schemas/EventInfo/properties/customFields/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#firestore-event-update"
+    },
+    "#/components/schemas/EventInfo/properties/customFields/items/$ref": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#firestore-event-update"
+    },
     "#/components/schemas/EventInfo/properties/rsvpsEnabled": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-12-rsvp-read-observation.md#event-safeguard-observations"
@@ -6751,7 +6799,11 @@
       "classification": "current-first-party-public-asset-research",
       "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#built-in-poster-representation"
     },
-    "#/components/schemas/PartifulPosterImage/properties/blurHash/type": {
+    "#/components/schemas/PartifulPosterImage/properties/blurHash/type/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#built-in-poster-representation"
+    },
+    "#/components/schemas/PartifulPosterImage/properties/blurHash/type/1": {
       "classification": "current-first-party-public-asset-research",
       "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#built-in-poster-representation"
     },
@@ -6775,7 +6827,11 @@
       "classification": "current-first-party-public-asset-research",
       "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#built-in-poster-representation"
     },
-    "#/components/schemas/PartifulPosterImage/properties/height/type": {
+    "#/components/schemas/PartifulPosterImage/properties/height/type/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#built-in-poster-representation"
+    },
+    "#/components/schemas/PartifulPosterImage/properties/height/type/1": {
       "classification": "current-first-party-public-asset-research",
       "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#built-in-poster-representation"
     },
@@ -6783,7 +6839,11 @@
       "classification": "current-first-party-public-asset-research",
       "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#built-in-poster-representation"
     },
-    "#/components/schemas/PartifulPosterImage/properties/width/type": {
+    "#/components/schemas/PartifulPosterImage/properties/width/type/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#built-in-poster-representation"
+    },
+    "#/components/schemas/PartifulPosterImage/properties/width/type/1": {
       "classification": "current-first-party-public-asset-research",
       "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#built-in-poster-representation"
     },
@@ -6791,67 +6851,67 @@
       "classification": "current-first-party-public-asset-research",
       "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#built-in-poster-representation"
     },
-    "#/components/schemas/CreateEventCompletionResponse/type": {
+    "#/components/schemas/CreateEventCompletionResponse/anyOf/0/type": {
       "classification": "current-first-party-public-asset-research",
       "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-completion"
     },
-    "#/components/schemas/CreateEventCompletionResponse/required/0": {
+    "#/components/schemas/CreateEventCompletionResponse/anyOf/0/required/0": {
       "classification": "current-first-party-public-asset-research",
       "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-completion"
     },
-    "#/components/schemas/CreateEventCompletionResponse/properties/result": {
+    "#/components/schemas/CreateEventCompletionResponse/anyOf/0/properties/result": {
       "classification": "current-first-party-public-asset-research",
       "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-completion"
     },
-    "#/components/schemas/CreateEventCompletionResponse/properties/result/type": {
+    "#/components/schemas/CreateEventCompletionResponse/anyOf/0/additionalProperties": {
       "classification": "current-first-party-public-asset-research",
       "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-completion"
     },
-    "#/components/schemas/CreateEventCompletionResponse/properties/result/required/0": {
+    "#/components/schemas/CreateEventCompletionResponse/anyOf/1/type": {
       "classification": "current-first-party-public-asset-research",
       "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-completion"
     },
-    "#/components/schemas/CreateEventCompletionResponse/properties/result/properties/data": {
+    "#/components/schemas/CreateEventCompletionResponse/anyOf/1/required/0": {
       "classification": "current-first-party-public-asset-research",
       "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-completion"
     },
-    "#/components/schemas/CreateEventCompletionResponse/properties/result/additionalProperties": {
+    "#/components/schemas/CreateEventCompletionResponse/anyOf/1/properties/data": {
       "classification": "current-first-party-public-asset-research",
       "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-completion"
     },
-    "#/components/schemas/CreateEventCompletionResponse/additionalProperties": {
+    "#/components/schemas/CreateEventCompletionResponse/anyOf/1/additionalProperties": {
       "classification": "current-first-party-public-asset-research",
       "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#createevent-completion"
     },
-    "#/components/schemas/CancelEventCompletionResponse/type": {
+    "#/components/schemas/CancelEventCompletionResponse/anyOf/0/type": {
       "classification": "current-first-party-public-asset-research",
       "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
     },
-    "#/components/schemas/CancelEventCompletionResponse/required/0": {
+    "#/components/schemas/CancelEventCompletionResponse/anyOf/0/required/0": {
       "classification": "current-first-party-public-asset-research",
       "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
     },
-    "#/components/schemas/CancelEventCompletionResponse/properties/result": {
+    "#/components/schemas/CancelEventCompletionResponse/anyOf/0/properties/result": {
       "classification": "current-first-party-public-asset-research",
       "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
     },
-    "#/components/schemas/CancelEventCompletionResponse/properties/result/type": {
+    "#/components/schemas/CancelEventCompletionResponse/anyOf/0/additionalProperties": {
       "classification": "current-first-party-public-asset-research",
       "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
     },
-    "#/components/schemas/CancelEventCompletionResponse/properties/result/required/0": {
+    "#/components/schemas/CancelEventCompletionResponse/anyOf/1/type": {
       "classification": "current-first-party-public-asset-research",
       "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
     },
-    "#/components/schemas/CancelEventCompletionResponse/properties/result/properties/data": {
+    "#/components/schemas/CancelEventCompletionResponse/anyOf/1/required/0": {
       "classification": "current-first-party-public-asset-research",
       "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
     },
-    "#/components/schemas/CancelEventCompletionResponse/properties/result/additionalProperties": {
+    "#/components/schemas/CancelEventCompletionResponse/anyOf/1/properties/data": {
       "classification": "current-first-party-public-asset-research",
       "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
     },
-    "#/components/schemas/CancelEventCompletionResponse/additionalProperties": {
+    "#/components/schemas/CancelEventCompletionResponse/anyOf/1/additionalProperties": {
       "classification": "current-first-party-public-asset-research",
       "citation": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion"
     },

--- a/spec/partiful.openapi.json
+++ b/spec/partiful.openapi.json
@@ -2980,6 +2980,28 @@
             ]
           },
           "visibility": {},
+          "ownerIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "guestCount": {},
+          "guestStatusCounts": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "number"
+            }
+          },
+          "hasGuests": {
+            "type": "boolean"
+          },
+          "customFields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EventCustomField"
+            }
+          },
           "rsvpsEnabled": {
             "type": "boolean"
           },
@@ -3459,7 +3481,10 @@
             "format": "uri"
           },
           "blurHash": {
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "contentType": {
             "type": "string"
@@ -3468,55 +3493,67 @@
             "type": "string"
           },
           "height": {
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "width": {
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           }
         },
         "additionalProperties": false
       },
       "CreateEventCompletionResponse": {
-        "type": "object",
-        "required": [
-          "result"
-        ],
-        "properties": {
-          "result": {
+        "anyOf": [
+          {
+            "type": "object",
+            "required": [
+              "result"
+            ],
+            "properties": {
+              "result": {}
+            },
+            "additionalProperties": true
+          },
+          {
             "type": "object",
             "required": [
               "data"
             ],
             "properties": {
-              "data": {
-                "description": "The current client uses this decoded value as an event ID but performs no runtime type check."
-              }
+              "data": {}
             },
             "additionalProperties": true
           }
-        },
-        "additionalProperties": true
+        ]
       },
       "CancelEventCompletionResponse": {
-        "type": "object",
-        "required": [
-          "result"
-        ],
-        "properties": {
-          "result": {
+        "anyOf": [
+          {
+            "type": "object",
+            "required": [
+              "result"
+            ],
+            "properties": {
+              "result": {}
+            },
+            "additionalProperties": true
+          },
+          {
             "type": "object",
             "required": [
               "data"
             ],
             "properties": {
-              "data": {
-                "description": "The current client requires generic callable completion but inspects no endpoint business field."
-              }
+              "data": {}
             },
             "additionalProperties": true
           }
-        },
-        "additionalProperties": true
+        ]
       },
       "FirestoreLatLng": {
         "type": "object",

--- a/spec/partiful.openapi.json
+++ b/spec/partiful.openapi.json
@@ -2,8 +2,8 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Partiful remote API contract",
-    "version": "2026-08-12.3",
-    "description": "Owner-reviewed remote-only transport snapshot. Evidence classifications and uncertainty are recorded in spec/partiful.api-evidence.json."
+    "version": "2026-08-12.4",
+    "description": "Proposed remote-only transport snapshot pending delegated review. Evidence classifications and uncertainty are recorded in spec/partiful.api-evidence.json."
   },
   "servers": [
     {
@@ -29,7 +29,7 @@
                     "type": "object",
                     "required": [
                       "params",
-                      "amplitudeDeviceId"
+                      "userId"
                     ],
                     "properties": {
                       "params": {
@@ -43,6 +43,11 @@
                             "items": {
                               "type": "string"
                             }
+                          },
+                          "ticketTypes": {},
+                          "promoCodes": {},
+                          "affiliateId": {
+                            "type": "string"
                           }
                         },
                         "additionalProperties": false,
@@ -51,6 +56,16 @@
                           "cohostIds"
                         ]
                       },
+                      "userId": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "deviceInfo": {
+                        "type": "object",
+                        "additionalProperties": true
+                      },
                       "amplitudeDeviceId": {
                         "type": "string"
                       },
@@ -58,11 +73,9 @@
                         "type": "integer",
                         "format": "int64"
                       },
-                      "userId": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
+                      "adminAccessRequested": {
+                        "type": "boolean",
+                        "const": true
                       }
                     },
                     "additionalProperties": false
@@ -74,8 +87,18 @@
           }
         },
         "responses": {
+          "200": {
+            "description": "Generic callable protocol completion. The current client uses decoded completion data as an event ID; persisted event state is not established.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateEventCompletionResponse"
+                }
+              }
+            }
+          },
           "default": {
-            "description": "Response status and body are unknown."
+            "description": "Unobserved response status or body."
           }
         },
         "security": [
@@ -102,7 +125,7 @@
                     "type": "object",
                     "required": [
                       "params",
-                      "amplitudeDeviceId"
+                      "userId"
                     ],
                     "properties": {
                       "params": {
@@ -110,12 +133,30 @@
                         "properties": {
                           "eventId": {
                             "type": "string"
+                          },
+                          "cancellationMessage": {
+                            "type": "string"
+                          },
+                          "shouldSkipNotifyGuests": {
+                            "type": "boolean"
                           }
                         },
                         "additionalProperties": false,
                         "required": [
-                          "eventId"
+                          "eventId",
+                          "cancellationMessage",
+                          "shouldSkipNotifyGuests"
                         ]
+                      },
+                      "userId": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "deviceInfo": {
+                        "type": "object",
+                        "additionalProperties": true
                       },
                       "amplitudeDeviceId": {
                         "type": "string"
@@ -124,11 +165,9 @@
                         "type": "integer",
                         "format": "int64"
                       },
-                      "userId": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
+                      "adminAccessRequested": {
+                        "type": "boolean",
+                        "const": true
                       }
                     },
                     "additionalProperties": false
@@ -140,8 +179,18 @@
           }
         },
         "responses": {
+          "200": {
+            "description": "Generic callable protocol completion. The current client inspects no endpoint business field; cancellation and notification delivery are not established.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CancelEventCompletionResponse"
+                }
+              }
+            }
+          },
           "default": {
-            "description": "Response status and body are unknown."
+            "description": "Unobserved response status or body."
           }
         },
         "security": [
@@ -1346,6 +1395,23 @@
             },
             "style": "form",
             "explode": true
+          },
+          {
+            "name": "currentDocument.exists",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "currentDocument.updateTime",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           }
         ],
         "requestBody": {
@@ -1359,8 +1425,18 @@
           }
         },
         "responses": {
+          "200": {
+            "description": "Official Firestore PATCH protocol completion with a Document. Partiful business state and a complete product Event are not established.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FirestoreDocument"
+                }
+              }
+            }
+          },
           "default": {
-            "description": "Response status and body are unknown."
+            "description": "Unobserved response status or body."
           }
         },
         "security": [
@@ -1509,9 +1585,6 @@
               }
             }
           },
-          "default": {
-            "description": "Response status and body are unknown."
-          },
           "400": {
             "description": "Invalid or expired refresh token.",
             "content": {
@@ -1521,6 +1594,9 @@
                 }
               }
             }
+          },
+          "default": {
+            "description": "Response status and body are unknown."
           }
         },
         "security": [
@@ -1706,9 +1782,6 @@
               }
             }
           },
-          "default": {
-            "description": "Response status and body are unknown."
-          },
           "403": {
             "description": "Invalid authentication code.",
             "content": {
@@ -1718,6 +1791,9 @@
                 }
               }
             }
+          },
+          "default": {
+            "description": "Response status and body are unknown."
           }
         }
       }
@@ -1759,9 +1835,6 @@
               }
             }
           },
-          "default": {
-            "description": "Response status and body are unknown."
-          },
           "400": {
             "description": "Invalid or expired custom token.",
             "content": {
@@ -1771,6 +1844,9 @@
                 }
               }
             }
+          },
+          "default": {
+            "description": "Response status and body are unknown."
           }
         },
         "security": [
@@ -1830,9 +1906,6 @@
               }
             }
           },
-          "default": {
-            "description": "Response status and body are unknown."
-          },
           "400": {
             "description": "Invalid or expired ID token.",
             "content": {
@@ -1842,6 +1915,9 @@
                 }
               }
             }
+          },
+          "default": {
+            "description": "Response status and body are unknown."
           }
         },
         "security": [
@@ -1971,54 +2047,114 @@
           "title",
           "startDate",
           "timezone",
-          "displaySettings"
+          "guestStatusCounts",
+          "displaySettings",
+          "status",
+          "rsvpButtonGlyphType",
+          "image",
+          "showHostList",
+          "showGuestCount",
+          "showGuestList",
+          "showActivityTimestamps",
+          "displayInviteButton",
+          "visibility",
+          "allowGuestPhotoUpload",
+          "enableGuestReminders",
+          "rsvpsEnabled",
+          "allowGuestsToInviteMutuals"
         ],
         "properties": {
           "title": {
             "type": "string"
           },
           "startDate": {
-            "type": "string",
-            "format": "date-time"
+            "type": "string"
           },
           "endDate": {
-            "type": "string",
-            "format": "date-time"
+            "type": "string"
           },
           "timezone": {
             "type": "string"
           },
+          "guestStatusCounts": {
+            "$ref": "#/components/schemas/NewEventGuestStatusCounts"
+          },
           "displaySettings": {
-            "type": "object",
-            "additionalProperties": true
+            "$ref": "#/components/schemas/EventDisplaySettings"
+          },
+          "status": {
+            "type": "string",
+            "const": "UNSAVED"
+          },
+          "rsvpButtonGlyphType": {
+            "type": "string",
+            "const": "emojis"
+          },
+          "image": {
+            "$ref": "#/components/schemas/PartifulPosterImage"
+          },
+          "showHostList": {
+            "type": "boolean",
+            "const": true
+          },
+          "showGuestCount": {
+            "type": "boolean",
+            "const": true
+          },
+          "showGuestList": {
+            "type": "boolean",
+            "const": true
+          },
+          "showActivityTimestamps": {
+            "type": "boolean",
+            "const": true
+          },
+          "displayInviteButton": {
+            "type": "boolean",
+            "const": true
           },
           "visibility": {
             "type": "string",
-            "enum": [
-              "public",
-              "private"
-            ]
+            "const": "public"
           },
-          "location": {
-            "type": "string"
+          "allowGuestPhotoUpload": {
+            "type": "boolean",
+            "const": true
           },
-          "address": {
-            "type": "string"
+          "enableGuestReminders": {
+            "type": "boolean",
+            "const": true
+          },
+          "rsvpsEnabled": {
+            "type": "boolean",
+            "const": true
+          },
+          "allowGuestsToInviteMutuals": {
+            "type": "boolean",
+            "const": true
           },
           "description": {
             "type": "string"
           },
-          "guestLimit": {
-            "type": "integer"
+          "locationInfo": {
+            "$ref": "#/components/schemas/EventLocationInfo"
           },
-          "links": {
+          "isPublic": {
+            "type": "boolean"
+          },
+          "maxCapacity": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "enableWaitlist": {
+            "type": "boolean"
+          },
+          "customFields": {
             "type": "array",
             "items": {
-              "type": "object",
-              "additionalProperties": true
+              "$ref": "#/components/schemas/EventCustomField"
             }
-          },
-          "image": {}
+          }
         },
         "additionalProperties": true
       },
@@ -2156,8 +2292,156 @@
         "additionalProperties": true
       },
       "FirestoreValue": {
-        "type": "object",
-        "additionalProperties": true
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "nullValue"
+            ],
+            "properties": {
+              "nullValue": {
+                "type": "string",
+                "const": "NULL_VALUE"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "booleanValue"
+            ],
+            "properties": {
+              "booleanValue": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "integerValue"
+            ],
+            "properties": {
+              "integerValue": {
+                "type": "string",
+                "pattern": "^-?[0-9]+$"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "doubleValue"
+            ],
+            "properties": {
+              "doubleValue": {
+                "oneOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "string",
+                    "enum": [
+                      "NaN",
+                      "Infinity",
+                      "-Infinity"
+                    ]
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "timestampValue"
+            ],
+            "properties": {
+              "timestampValue": {
+                "type": "string",
+                "format": "date-time"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "stringValue"
+            ],
+            "properties": {
+              "stringValue": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "bytesValue"
+            ],
+            "properties": {
+              "bytesValue": {
+                "type": "string",
+                "format": "byte"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "referenceValue"
+            ],
+            "properties": {
+              "referenceValue": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "geoPointValue"
+            ],
+            "properties": {
+              "geoPointValue": {
+                "$ref": "#/components/schemas/FirestoreLatLng"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "arrayValue"
+            ],
+            "properties": {
+              "arrayValue": {
+                "$ref": "#/components/schemas/FirestoreArrayValue"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "mapValue"
+            ],
+            "properties": {
+              "mapValue": {
+                "$ref": "#/components/schemas/FirestoreMapValue"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
       },
       "FirestoreDocument": {
         "type": "object",
@@ -2180,7 +2464,7 @@
             "format": "date-time"
           }
         },
-        "additionalProperties": true
+        "additionalProperties": false
       },
       "FirestoreWriteDocument": {
         "type": "object",
@@ -2999,6 +3283,280 @@
             }
           }
         }
+      },
+      "NewEventGuestStatusCounts": {
+        "type": "object",
+        "required": [
+          "READY_TO_SEND",
+          "SENDING",
+          "SENT",
+          "SEND_ERROR",
+          "DELIVERY_ERROR",
+          "INTERESTED",
+          "MAYBE",
+          "GOING",
+          "DECLINED",
+          "WAITLIST",
+          "PENDING_APPROVAL",
+          "APPROVED",
+          "WITHDRAWN",
+          "RESPONDED_TO_FIND_A_TIME",
+          "WAITLISTED_FOR_APPROVAL",
+          "REJECTED"
+        ],
+        "properties": {
+          "READY_TO_SEND": {
+            "type": "integer",
+            "const": 0
+          },
+          "SENDING": {
+            "type": "integer",
+            "const": 0
+          },
+          "SENT": {
+            "type": "integer",
+            "const": 0
+          },
+          "SEND_ERROR": {
+            "type": "integer",
+            "const": 0
+          },
+          "DELIVERY_ERROR": {
+            "type": "integer",
+            "const": 0
+          },
+          "INTERESTED": {
+            "type": "integer",
+            "const": 0
+          },
+          "MAYBE": {
+            "type": "integer",
+            "const": 0
+          },
+          "GOING": {
+            "type": "integer",
+            "const": 0
+          },
+          "DECLINED": {
+            "type": "integer",
+            "const": 0
+          },
+          "WAITLIST": {
+            "type": "integer",
+            "const": 0
+          },
+          "PENDING_APPROVAL": {
+            "type": "integer",
+            "const": 0
+          },
+          "APPROVED": {
+            "type": "integer",
+            "const": 0
+          },
+          "WITHDRAWN": {
+            "type": "integer",
+            "const": 0
+          },
+          "RESPONDED_TO_FIND_A_TIME": {
+            "type": "integer",
+            "const": 0
+          },
+          "WAITLISTED_FOR_APPROVAL": {
+            "type": "integer",
+            "const": 0
+          },
+          "REJECTED": {
+            "type": "integer",
+            "const": 0
+          }
+        },
+        "additionalProperties": false
+      },
+      "EventDisplaySettings": {
+        "type": "object",
+        "required": [
+          "theme",
+          "effect",
+          "titleFont"
+        ],
+        "properties": {
+          "theme": {
+            "type": "string"
+          },
+          "effect": {
+            "type": "string"
+          },
+          "titleFont": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "additionalProperties": true
+      },
+      "EventLocationInfo": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "freeform",
+              "structured"
+            ]
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": true
+      },
+      "EventCustomField": {
+        "type": "object",
+        "required": [
+          "icon",
+          "value"
+        ],
+        "properties": {
+          "icon": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string",
+            "format": "uri"
+          }
+        },
+        "additionalProperties": true
+      },
+      "PartifulPosterImage": {
+        "type": "object",
+        "required": [
+          "source",
+          "poster",
+          "url",
+          "blurHash",
+          "contentType",
+          "name",
+          "height",
+          "width"
+        ],
+        "properties": {
+          "source": {
+            "type": "string",
+            "const": "partiful_posters"
+          },
+          "poster": {
+            "$ref": "#/components/schemas/Poster"
+          },
+          "url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "blurHash": {
+            "type": "string"
+          },
+          "contentType": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "height": {
+            "type": "number"
+          },
+          "width": {
+            "type": "number"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateEventCompletionResponse": {
+        "type": "object",
+        "required": [
+          "result"
+        ],
+        "properties": {
+          "result": {
+            "type": "object",
+            "required": [
+              "data"
+            ],
+            "properties": {
+              "data": {
+                "description": "The current client uses this decoded value as an event ID but performs no runtime type check."
+              }
+            },
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": true
+      },
+      "CancelEventCompletionResponse": {
+        "type": "object",
+        "required": [
+          "result"
+        ],
+        "properties": {
+          "result": {
+            "type": "object",
+            "required": [
+              "data"
+            ],
+            "properties": {
+              "data": {
+                "description": "The current client requires generic callable completion but inspects no endpoint business field."
+              }
+            },
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": true
+      },
+      "FirestoreLatLng": {
+        "type": "object",
+        "required": [
+          "latitude",
+          "longitude"
+        ],
+        "properties": {
+          "latitude": {
+            "type": "number"
+          },
+          "longitude": {
+            "type": "number"
+          }
+        },
+        "additionalProperties": false
+      },
+      "FirestoreArrayValue": {
+        "type": "object",
+        "properties": {
+          "values": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FirestoreValue"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "FirestoreMapValue": {
+        "type": "object",
+        "properties": {
+          "fields": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/FirestoreValue"
+            }
+          }
+        },
+        "additionalProperties": false
       }
     }
   }

--- a/spec/partiful.openapi.json
+++ b/spec/partiful.openapi.json
@@ -2300,8 +2300,7 @@
             ],
             "properties": {
               "nullValue": {
-                "type": "string",
-                "const": "NULL_VALUE"
+                "type": "null"
               }
             },
             "additionalProperties": false

--- a/tests/remote-api-contract.test.js
+++ b/tests/remote-api-contract.test.js
@@ -19,6 +19,8 @@ const rsvpAssetResearchPath =
   'docs/research/2026-08-12-rsvp-mapping-public-assets.md';
 const rsvpReadObservationPath =
   'docs/research/2026-08-12-rsvp-read-observation.md';
+const eventWriteAssetResearchPath =
+  'docs/research/2026-08-12-event-write-mapping-public-assets.md';
 const productContractPath = 'docs/CLI-PRODUCT-CONTRACT.md';
 const sourceCache = new Map([
   [historicalDraftPath, historicalDraft],
@@ -479,10 +481,14 @@ function citationResolves(citation) {
 describe('remote API contract', () => {
   it('is a consistently versioned OpenAPI 3.1 document with unique operation IDs', () => {
     expect(spec.openapi).toBe('3.1.0');
-    expect(evidence.contractRevision).toBe('2026-08-12.3');
-    expect(evidence.ownerReviewedBaseline).toBe('2026-08-12.2');
+    expect(evidence.contractRevision).toBe('2026-08-12.4');
+    expect(evidence.ownerReviewedBaseline).toBe('2026-08-12.3');
     expect(spec.info.version).toBe(evidence.contractRevision);
-    expect(evidence.status).toBe('owner-reviewed');
+    expect(evidence.status).toBe('pending-delegated-review');
+    expect(evidence.sources.publicEventWriteMapping20260812)
+      .toBe(`${eventWriteAssetResearchPath}#scope-and-provenance`);
+    expect(citationResolves(evidence.sources.publicEventWriteMapping20260812))
+      .toBe(true);
     expect(evidence.sources.publicEventMapping20260812)
       .toBe(`${eventAssetResearchPath}#scope-and-provenance`);
     expect(citationResolves(evidence.sources.publicEventMapping20260812)).toBe(true);
@@ -528,7 +534,13 @@ describe('remote API contract', () => {
         'firestoreGetGuest',
         'getContacts',
       ]);
-      const protocolStatusOps = new Set(['addGuest', 'markEventInterest']);
+      const protocolStatusOps = new Set([
+        'addGuest',
+        'markEventInterest',
+        'createEvent',
+        'cancelEvent',
+        'firestorePatchEvent',
+      ]);
       const expectedStatus = liveStatusOps.has(operation.operationId)
         ? 'dated-live-observation'
         : protocolStatusOps.has(operation.operationId)
@@ -542,7 +554,7 @@ describe('remote API contract', () => {
       ...materialClaimPointers(spec.paths, '#/paths', 'paths'),
       ...materialClaimPointers(spec.components, '#/components', 'components'),
     ]);
-    expect(pointers).toHaveLength(1316);
+    expect(pointers).toHaveLength(1625);
     for (const pointer of pointers) {
       const claim = evidence.claims[pointer];
       expect(claim, pointer).toBeDefined();
@@ -576,7 +588,7 @@ describe('remote API contract', () => {
     });
   });
 
-  it('separates twelve observed and two protocol-specified 200 responses', () => {
+  it('separates observed and protocol-specified 200 responses', () => {
     const with200 = operations()
       .filter(({ operation }) => operation.responses['200'])
       .map(({ operation }) => operation.operationId)
@@ -585,8 +597,8 @@ describe('remote API contract', () => {
       .filter(({ operation }) => operation.responses['200']?.content)
       .map(({ operation }) => operation.operationId)
       .sort();
-    expect(with200).toHaveLength(14);
-    expect(withTyped200Body).toHaveLength(13);
+    expect(with200).toHaveLength(17);
+    expect(withTyped200Body).toHaveLength(16);
     expect(with200.filter((id) => !withTyped200Body.includes(id)))
       .toEqual(['sendAuthCodeTrusted']);
 
@@ -601,14 +613,17 @@ describe('remote API contract', () => {
       /Eleven of those\s+operations have a typed `200` response body\./,
     );
     expect(ledger).toContain(
-      'Two additional callable operations have protocol-specified HTTP `200` completion responses.',
-    );
-    expect(ledger.match(/The 1316 material claims/g)).toHaveLength(2);
-    expect(ledger).toContain(
-      '**Owner-reviewed contract revision:** `2026-08-12.3`',
+      'Four callable operations have protocol-specified HTTP `200` completion',
     );
     expect(ledger).toContain(
-      '**Status:** Owner-reviewed under the issue #114 delegation',
+      '`firestorePatchEvent` uses the official Firestore PATCH path',
+    );
+    expect(ledger.match(/The 1625 material claims/g)).toHaveLength(2);
+    expect(ledger).toContain(
+      '**Proposed contract revision:** `2026-08-12.4`',
+    );
+    expect(ledger).toContain(
+      '**Status:** Pending one delegated review under issue #167',
     );
     expect(ledger).toContain('Current first-party public-asset research');
   });
@@ -649,6 +664,9 @@ describe('remote API contract', () => {
       'getContacts',
       'addGuest',
       'markEventInterest',
+      'createEvent',
+      'cancelEvent',
+      'firestorePatchEvent',
     ]);
     const observedErrorOps = {
       getLoginToken: ['200', '403', 'default'],
@@ -664,6 +682,9 @@ describe('remote API contract', () => {
       getContacts: ['200', '401', 'default'],
       addGuest: ['200', 'default'],
       markEventInterest: ['200', 'default'],
+      createEvent: ['200', 'default'],
+      cancelEvent: ['200', 'default'],
+      firestorePatchEvent: ['200', 'default'],
     };
     for (const { operation } of operations()) {
       if (observedStatusOps.has(operation.operationId)) {
@@ -708,6 +729,9 @@ describe('remote API contract', () => {
       'getContacts',
       'addGuest',
       'markEventInterest',
+      'createEvent',
+      'cancelEvent',
+      'firestorePatchEvent',
     ]);
     const observedResponseSources = new Map([
       ['getPosterCatalog', evidence.sources.posterCatalogObservation],
@@ -725,6 +749,9 @@ describe('remote API contract', () => {
       ['getContacts', evidence.sources.readContacts20260811],
       ['addGuest', evidence.sources.publicAddGuestCompletion20260812],
       ['markEventInterest', evidence.sources.publicInterestCompletion20260812],
+      ['createEvent', evidence.sources.publicCreateEventCompletion20260812],
+      ['cancelEvent', evidence.sources.publicCancelEvent20260812],
+      ['firestorePatchEvent', evidence.sources.officialFirestoreProtocol],
     ]);
     for (const { path, method, operation } of operations()) {
       const base = `#/paths/${escapePointerSegment(path)}/${method}/responses/default`;
@@ -732,10 +759,12 @@ describe('remote API contract', () => {
       expect(operation.responses.default).not.toHaveProperty('content');
       const operationClaim = evidence.operationClaims[operation.operationId];
       if (observedResponseOps.has(operation.operationId)) {
-        const expectedClassification = ['addGuest', 'markEventInterest']
-          .includes(operation.operationId)
-          ? 'current-first-party-public-asset-research'
-          : 'dated-live-observation';
+        const expectedClassification = operation.operationId === 'firestorePatchEvent'
+          ? 'official-protocol-specification'
+          : ['addGuest', 'markEventInterest', 'createEvent', 'cancelEvent']
+              .includes(operation.operationId)
+            ? 'current-first-party-public-asset-research'
+            : 'dated-live-observation';
         expect(operationClaim.response).toBe(expectedClassification);
         expect(citationResolves(operationClaim.responseCitation), `${operation.operationId} responseCitation`).toBe(true);
         expect(operationClaim.responseCitation)
@@ -802,8 +831,171 @@ describe('remote API contract', () => {
       style: 'form',
       explode: true,
     });
+    expect(patch.parameters.find(({ name }) => name === 'currentDocument.exists'))
+      .toMatchObject({
+        in: 'query',
+        required: false,
+        schema: { type: 'boolean' },
+      });
+    expect(patch.parameters.find(({ name }) => name === 'currentDocument.updateTime'))
+      .toMatchObject({
+        in: 'query',
+        required: false,
+        schema: { type: 'string', format: 'date-time' },
+      });
     expect(spec.components.schemas.FirebaseSignInResponse.properties ?? {})
       .not.toHaveProperty('localId');
+  });
+
+  it('closes current event-write requests and keeps completion submitted-only', () => {
+    const create = spec.paths['/createEvent'].post;
+    const createData = create.requestBody.content['application/json'].schema
+      .properties.data;
+    expect(createData.required).toEqual(['params', 'userId']);
+    expect(createData.required).not.toContain('amplitudeDeviceId');
+    expect(createData.properties).toMatchObject({
+      amplitudeDeviceId: { type: 'string' },
+      amplitudeSessionId: { type: 'integer', format: 'int64' },
+      adminAccessRequested: { type: 'boolean', const: true },
+      userId: { type: ['string', 'null'] },
+    });
+    expect(createData.properties.params.required).toEqual(['event', 'cohostIds']);
+    expect(create.responses['200'].content['application/json'].schema)
+      .toEqual({ $ref: '#/components/schemas/CreateEventCompletionResponse' });
+
+    const draft = spec.components.schemas.EventDraft;
+    expect(draft.additionalProperties).toBe(true);
+    expect(draft.required).toEqual(expect.arrayContaining([
+      'title',
+      'startDate',
+      'timezone',
+      'guestStatusCounts',
+      'displaySettings',
+      'status',
+      'rsvpButtonGlyphType',
+      'image',
+      'visibility',
+      'rsvpsEnabled',
+    ]));
+    expect(draft.properties.status).toEqual({ type: 'string', const: 'UNSAVED' });
+    expect(draft.properties.visibility).toEqual({ type: 'string', const: 'public' });
+    expect(draft.properties.image)
+      .toEqual({ $ref: '#/components/schemas/PartifulPosterImage' });
+    expect(spec.components.schemas.EventDisplaySettings.required)
+      .toEqual(['theme', 'effect', 'titleFont']);
+    expect(spec.components.schemas.PartifulPosterImage.required)
+      .toEqual([
+        'source',
+        'poster',
+        'url',
+        'blurHash',
+        'contentType',
+        'name',
+        'height',
+        'width',
+      ]);
+
+    const cancel = spec.paths['/cancelEvent'].post;
+    const cancelData = cancel.requestBody.content['application/json'].schema
+      .properties.data;
+    expect(cancelData.required).toEqual(['params', 'userId']);
+    expect(cancelData.properties.params.required)
+      .toEqual(['eventId', 'cancellationMessage', 'shouldSkipNotifyGuests']);
+    expect(cancel.responses['200'].content['application/json'].schema)
+      .toEqual({ $ref: '#/components/schemas/CancelEventCompletionResponse' });
+
+    const patch = spec.paths[
+      '/v1/projects/getpartiful/databases/(default)/documents/events/{eventId}'
+    ].patch;
+    expect(patch.responses['200'].content['application/json'].schema)
+      .toEqual({ $ref: '#/components/schemas/FirestoreDocument' });
+    const firestoreVariants = spec.components.schemas.FirestoreValue.oneOf
+      .map(({ required }) => required[0]);
+    expect(firestoreVariants).toEqual([
+      'nullValue',
+      'booleanValue',
+      'integerValue',
+      'doubleValue',
+      'timestampValue',
+      'stringValue',
+      'bytesValue',
+      'referenceValue',
+      'geoPointValue',
+      'arrayValue',
+      'mapValue',
+    ]);
+
+    expect(evidence.eventWriteAssetResearch).toMatchObject({
+      sourceCitation: evidence.sources.publicEventWriteMapping20260812,
+      buildId: '2KXQa2wzQWzlyvnJPIrVj',
+      deploymentId: 'dpl_D9bWXWUaTVfWyHiJz1RT7qdjuzUC',
+      liveMutations: false,
+      credentialsUsed: false,
+      uploadRegistered: false,
+      postWriteEventReadEstablished: false,
+      callableUpdateEventFound: false,
+    });
+    expect(evidence.operationClaims.createEvent).toMatchObject({
+      request: 'current-first-party-public-asset-research',
+      response: 'current-first-party-public-asset-research',
+      status: 'official-protocol-specification',
+    });
+    expect(evidence.operationClaims.cancelEvent).toMatchObject({
+      request: 'current-first-party-public-asset-research',
+      response: 'current-first-party-public-asset-research',
+      status: 'official-protocol-specification',
+    });
+    expect(evidence.operationClaims.firestorePatchEvent).toMatchObject({
+      request: 'official-protocol-specification',
+      response: 'official-protocol-specification',
+      status: 'official-protocol-specification',
+    });
+
+    const product = fs.readFileSync(productContractPath, 'utf8');
+    const eventWrites = product.slice(
+      product.indexOf('#### `partiful events create`'),
+      product.indexOf('### Guests'),
+    );
+    for (const expected of [
+      '`cohostIds: []`',
+      "`Let's Party`",
+      '`displaySettings:',
+      '`locationInfo: {"type":"freeform","value":<location>}`',
+      '`customFields`',
+      'no existing-event read or precondition',
+      '`updatedBy.referenceValue`',
+      '`currentDocument.exists=true`',
+      'sorted, percent-encoded, repeated `updateMask.fieldPaths`',
+      '`ownerIds` must be present',
+      'update status guard was found',
+      '`setEventLocation`',
+      '`updateDisplaySettings`',
+      'no general callable `updateEvent` was found',
+      '`shouldSkipNotifyGuests: !notifyGuests`',
+      '`status` must be exactly `PUBLISHED`',
+      '`--yes` bypass',
+      'performs no post-write read',
+      '"submitted":true',
+    ]) {
+      expect(eventWrites, expected).toContain(expected);
+    }
+    expect(eventWrites).not.toContain('returns the complete updated `Event`');
+    expect(eventWrites).not.toContain('"state":"cancelled"');
+
+    const research = fs.readFileSync(eventWriteAssetResearchPath, 'utf8');
+    for (const expected of [
+      'https://partiful.com/login',
+      '2KXQa2wzQWzlyvnJPIrVj',
+      'dpl_D9bWXWUaTVfWyHiJz1RT7qdjuzUC',
+      'Module `25231`',
+      'Module `52630`',
+      'Module `22248`',
+      'Module `95074`',
+      'No account, credential, event ID, guest',
+      'Document is protocol completion only',
+    ]) {
+      expect(research, expected).toContain(expected);
+    }
   });
 
   it('does not claim client defaults or client-specific behavior as remote facts', () => {
@@ -1340,9 +1532,9 @@ describe('remote API contract', () => {
   it('defines conservative nullable event reads and bounded local snapshots', () => {
     const product = fs.readFileSync(productContractPath, 'utf8');
     for (const expected of [
-      '**Status:** Approved product contract',
-      '**Product contract revision:** `2026-08-12.3`',
-      '**Remote API contract revision:** `2026-08-12.3`',
+      '**Status:** Proposed; pending delegated review',
+      '**Product contract revision:** `2026-08-12.4`',
+      '**Remote API contract revision:** `2026-08-12.4`',
       '**Currently shipped Go revisions:** product and remote `2026-08-12.3`',
       '`PUBLISHED` → `active`',
       '`CANCELED` → `cancelled`',
@@ -1897,7 +2089,7 @@ describe('remote API contract', () => {
       .toBe(rsvpReadEvidencePath);
   });
 
-  it('ships the approved RSVP product and remote revisions together', () => {
+  it('keeps the proposed event-write revision separate from shipped Go', () => {
     const productContract = fs.readFileSync(
       'docs/CLI-PRODUCT-CONTRACT.md',
       'utf8',
@@ -1921,12 +2113,12 @@ describe('remote API contract', () => {
     )].map((match) => match[1]);
 
     expect(shippedRevision).toBe('2026-08-12.3');
-    expect(documentedRevision).toBe('2026-08-12.3');
-    expect(documentedProductRevision).toBe('2026-08-12.3');
+    expect(documentedRevision).toBe('2026-08-12.4');
+    expect(documentedProductRevision).toBe('2026-08-12.4');
     expect(new Set(envelopeRevisions)).toEqual(new Set([documentedRevision]));
     expect(spec.info.version).toBe(documentedRevision);
-    expect(evidence.status).toBe('owner-reviewed');
-    expect(spec.info.version).toBe(shippedRevision);
+    expect(evidence.status).toBe('pending-delegated-review');
+    expect(spec.info.version).not.toBe(shippedRevision);
     expect(appSource).toContain('ProductContractRevision = "2026-08-12.3"');
     expect(productContract)
       .not.toContain('currently leaves every operation response status and body unknown');

--- a/tests/remote-api-contract.test.js
+++ b/tests/remote-api-contract.test.js
@@ -554,7 +554,7 @@ describe('remote API contract', () => {
       ...materialClaimPointers(spec.paths, '#/paths', 'paths'),
       ...materialClaimPointers(spec.components, '#/components', 'components'),
     ]);
-    expect(pointers).toHaveLength(1640);
+    expect(pointers).toHaveLength(1639);
     for (const pointer of pointers) {
       const claim = evidence.claims[pointer];
       expect(claim, pointer).toBeDefined();
@@ -618,7 +618,7 @@ describe('remote API contract', () => {
     expect(ledger).toContain(
       '`firestorePatchEvent` uses the official Firestore PATCH path',
     );
-    expect(ledger.match(/The 1640 material claims/g)).toHaveLength(2);
+    expect(ledger.match(/The 1639 material claims/g)).toHaveLength(2);
     expect(ledger).toContain(
       '**Proposed contract revision:** `2026-08-12.4`',
     );
@@ -940,6 +940,8 @@ describe('remote API contract', () => {
       'arrayValue',
       'mapValue',
     ]);
+    expect(spec.components.schemas.FirestoreValue.oneOf[0].properties.nullValue)
+      .toEqual({ type: 'null' });
 
     expect(evidence.eventWriteAssetResearch).toMatchObject({
       sourceCitation: evidence.sources.publicEventWriteMapping20260812,

--- a/tests/remote-api-contract.test.js
+++ b/tests/remote-api-contract.test.js
@@ -554,7 +554,7 @@ describe('remote API contract', () => {
       ...materialClaimPointers(spec.paths, '#/paths', 'paths'),
       ...materialClaimPointers(spec.components, '#/components', 'components'),
     ]);
-    expect(pointers).toHaveLength(1625);
+    expect(pointers).toHaveLength(1640);
     for (const pointer of pointers) {
       const claim = evidence.claims[pointer];
       expect(claim, pointer).toBeDefined();
@@ -618,7 +618,7 @@ describe('remote API contract', () => {
     expect(ledger).toContain(
       '`firestorePatchEvent` uses the official Firestore PATCH path',
     );
-    expect(ledger.match(/The 1625 material claims/g)).toHaveLength(2);
+    expect(ledger.match(/The 1640 material claims/g)).toHaveLength(2);
     expect(ledger).toContain(
       '**Proposed contract revision:** `2026-08-12.4`',
     );
@@ -894,6 +894,22 @@ describe('remote API contract', () => {
         'height',
         'width',
       ]);
+    expect(spec.components.schemas.PartifulPosterImage.properties).toMatchObject({
+      blurHash: { type: ['string', 'null'] },
+      height: { type: ['number', 'null'] },
+      width: { type: ['number', 'null'] },
+    });
+    for (const completionName of [
+      'CreateEventCompletionResponse',
+      'CancelEventCompletionResponse',
+    ]) {
+      const completion = spec.components.schemas[completionName];
+      expect(completion.anyOf).toHaveLength(2);
+      expect(completion.anyOf.map(({ required }) => required)).toEqual([
+        ['result'],
+        ['data'],
+      ]);
+    }
 
     const cancel = spec.paths['/cancelEvent'].post;
     const cancelData = cancel.requestBody.content['application/json'].schema
@@ -950,12 +966,26 @@ describe('remote API contract', () => {
       response: 'official-protocol-specification',
       status: 'official-protocol-specification',
     });
+    expect(spec.components.schemas.EventInfo.properties).toMatchObject({
+      ownerIds: { type: 'array', items: { type: 'string' } },
+      guestCount: {},
+      guestStatusCounts: {
+        type: 'object',
+        additionalProperties: { type: 'number' },
+      },
+      hasGuests: { type: 'boolean' },
+      customFields: {
+        type: 'array',
+        items: { $ref: '#/components/schemas/EventCustomField' },
+      },
+    });
 
     const product = fs.readFileSync(productContractPath, 'utf8');
-    const eventWrites = product.slice(
-      product.indexOf('#### `partiful events create`'),
-      product.indexOf('### Guests'),
-    );
+    const eventWritesStart = product.indexOf('#### `partiful events create`');
+    const eventWritesEnd = product.indexOf('### Guests');
+    expect(eventWritesStart).toBeGreaterThanOrEqual(0);
+    expect(eventWritesEnd).toBeGreaterThan(eventWritesStart);
+    const eventWrites = product.slice(eventWritesStart, eventWritesEnd);
     for (const expected of [
       '`cohostIds: []`',
       "`Let's Party`",
@@ -968,6 +998,7 @@ describe('remote API contract', () => {
       'sorted, percent-encoded, repeated `updateMask.fieldPaths`',
       '`ownerIds` must be present',
       'update status guard was found',
+      'An inverted merged range returns `input.invalid`',
       '`setEventLocation`',
       '`updateDisplaySettings`',
       'no general callable `updateEvent` was found',
@@ -990,6 +1021,8 @@ describe('remote API contract', () => {
       'Module `25231`',
       'Module `52630`',
       'Module `22248`',
+      'Module `24441`',
+      '9580-feaa5337a786edee.js',
       'Module `95074`',
       'No account, credential, event ID, guest',
       'Document is protocol completion only',
@@ -1300,7 +1333,8 @@ describe('remote API contract', () => {
       .toEqual({ $ref: '#/components/schemas/GuestStatus' });
     expect(spec.components.schemas.EventInfo.properties.status)
       .toEqual({ $ref: '#/components/schemas/EventStatus' });
-    expect(spec.components.schemas.EventInfo.properties).not.toHaveProperty('ownerIds');
+    expect(spec.components.schemas.EventInfo.properties.ownerIds)
+      .toEqual({ type: 'array', items: { type: 'string' } });
     expect(spec.components.schemas.EventInfo.properties).not.toHaveProperty('guest');
 
     const publicAssetClass = 'current-first-party-public-asset-research';


### PR DESCRIPTION
## Summary

Phase 1 contract evidence for #167. This PR proposes product and remote revision `2026-08-12.4`, pending one delegated review. It does not implement Go, change shipped `.3` constants, use credentials, or make a live Partiful mutation.

- records the current public build, deployment, exact asset URLs, hashes, and module IDs
- closes `createEvent` and `cancelEvent` request/completion mappings
- maps a closed product update allowlist onto official Firestore PATCH/Value/Document protocol
- defines account/input/request/precondition-bound single-use plans and exact cancel confirmation
- changes create/update/cancel success to submitted-only because no post-write complete Event is established
- keeps upload unregistered and resolves built-in posters only by an exact catalog ID

## Key mappings

- Create: `event` + `cohostIds: []`; fixed first-party fallback display/poster defaults; callable completion only
- Update: `title`, `description`, `startDate`, `endDate`, `timezone`, `maxCapacity`/`enableWaitlist`, `customFields`, `image`, plus private `updatedBy`; location, visibility, and display settings are excluded because they use field-specific callables
- Cancel: `{eventId,cancellationMessage,shouldSkipNotifyGuests}`; owned `PUBLISHED`, positive-guest, future event; exact confirmation required

## Verification

- `npm test -- --run tests/remote-api-contract.test.js` — 36 passed
- `TZ=America/Los_Angeles npx vitest run --exclude 'tests/*integration.test.js' --exclude 'tests/smoke-real-api.test.js'` — 300 passed
- `npm run typecheck`
- `go test ./...`
- `go test -race ./...`
- `go vet ./... && go build ./... && go mod verify`
- staged privacy scan and `git diff --check`

## Review gate

One delegated reviewer is required before merge. Go implementation remains blocked until this contract proposal is reviewed and merged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the proposed API and CLI contract to revision `2026-08-12.4`.
  - Documented event creation, updates, and cancellation, including validation, confirmations, safeguards, request formats, and submitted-only results.
  - Added research covering callable APIs, Firestore updates, completion behavior, and known limitations.

- **API Specification**
  - Expanded event request and response schemas with stricter fields and typed Firestore values.
  - Added support for event completion responses and Firestore update parameters.

- **Tests**
  - Added coverage for event-write validation, response formats, protocol statuses, and contract revisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->