### PR TITLE
feat(go): implement safe event writes (#167)

### DIFF
--- a/docs/CLI-PRODUCT-CONTRACT.md
+++ b/docs/CLI-PRODUCT-CONTRACT.md
@@ -1,6 +1,6 @@
 # CLI product contract
 
-**Status:** Proposed; pending delegated review
+**Status:** Approved product contract
 
 **Product contract revision:** `2026-08-12.4`
 
@@ -8,7 +8,7 @@
 
 **Owner-reviewed baseline:** product and remote `2026-08-12.3`
 
-**Currently shipped Go revisions:** product and remote `2026-08-12.3`
+**Currently shipped Go revisions:** product and remote `2026-08-12.4`
 
 This document defines the public behavior of the greenfield Go `partiful` CLI.
 It is the authority for commands, inputs, JSON outputs, failures, and mutation
@@ -987,9 +987,8 @@ reviewed callable and client completion condition. It does not prove
 persisted RSVP state, delivery, notification, or another business side
 effect.
 
-This `2026-08-12.4` contract is proposed under issue #167 and is pending one
-delegated review. The Go implementation continues to ship the owner-reviewed
-`2026-08-12.3` revisions until this proposal is reviewed and merged.
+This `2026-08-12.4` contract is the approved event-write product contract and
+the current shipped Go contract revision.
 
 ### Contacts
 

--- a/docs/REMOTE-API-CONTRACT.md
+++ b/docs/REMOTE-API-CONTRACT.md
@@ -1,13 +1,12 @@
 # Remote API contract
 
-`spec/partiful.openapi.json` is proposed revision `2026-08-12.4` of the remote
-transport snapshot, pending one delegated review. Its owner-reviewed baseline
-is `2026-08-12.3`. It
-describes only network operations and wire shapes. It does not prescribe
-commands, output, credentials, mutation safeguards, or implementation
-architecture.
+`spec/partiful.openapi.json` is owner-reviewed revision `2026-08-12.4` of the
+remote transport snapshot. Its owner-reviewed baseline is `2026-08-12.3`,
+which is based on owner-reviewed revision `2026-08-12.2`. It describes only
+network operations and wire shapes. It does not prescribe commands, output,
+credentials, mutation safeguards, or implementation architecture.
 
-The Go CLI ships remote contract revision `2026-08-12.3`.
+The Go CLI ships remote contract revision `2026-08-12.4`.
 
 ## Authority and change process
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -278,9 +278,9 @@ var commandCatalog = []commandDefinition{
 		safety: readOnlySafety(),
 	},
 	{
-		path:       "events.create",
-		invocation: []string{"events", "create"},
-		kind:       eventsCreateCommand,
+		path:        "events.create",
+		invocation:  []string{"events", "create"},
+		kind:        eventsCreateCommand,
 		positionals: []positionalDefinition{},
 		flags: []flagDefinition{
 			{Name: "--input", Description: "Read one structured JSON input object.", TakesValue: true},
@@ -540,7 +540,7 @@ func schemaSuccessSchema() jsonSchema {
 		map[string]jsonSchema{
 			"kind": {
 				Type: "string",
-				Enum: []string{"read-only", "local-mutation", "standard-mutation"},
+				Enum: []string{"read-only", "local-mutation", "standard-mutation", "consequential-action"},
 			},
 			"planRequired":         {Type: "boolean"},
 			"confirmationRequired": {Type: "boolean"},

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -14,8 +14,8 @@ import (
 
 const (
 	Version                 = "1.0.0"
-	ProductContractRevision = "2026-08-12.3"
-	RemoteContractRevision  = "2026-08-12.3"
+	ProductContractRevision = "2026-08-12.4"
+	RemoteContractRevision  = "2026-08-12.4"
 )
 
 type Request struct {
@@ -57,6 +57,9 @@ const (
 	contactsListCommand
 	eventsListCommand
 	eventsGetCommand
+	eventsCreateCommand
+	eventsUpdateCommand
+	eventsCancelCommand
 	rsvpGetCommand
 	rsvpSetCommand
 )
@@ -273,6 +276,108 @@ var commandCatalog = []commandDefinition{
 			"internal.failure",
 		},
 		safety: readOnlySafety(),
+	},
+	{
+		path:       "events.create",
+		invocation: []string{"events", "create"},
+		kind:       eventsCreateCommand,
+		positionals: []positionalDefinition{},
+		flags: []flagDefinition{
+			{Name: "--input", Description: "Read one structured JSON input object.", TakesValue: true},
+			{Name: "--title", Description: "Event title.", TakesValue: true},
+			{Name: "--start", Description: "RFC 3339 start time.", TakesValue: true},
+			{Name: "--end", Description: "RFC 3339 end time.", TakesValue: true},
+			{Name: "--timezone", Description: "IANA timezone.", TakesValue: true},
+			{Name: "--description", Description: "Optional description.", TakesValue: true},
+			{Name: "--location", Description: "Optional free-form location.", TakesValue: true},
+			{Name: "--visibility", Description: "private or public.", TakesValue: true},
+			{Name: "--guest-limit", Description: "Positive guest limit.", TakesValue: true},
+			{Name: "--link", Description: "Link in label=url form; this flag can repeat.", TakesValue: true},
+			{Name: "--poster-id", Description: "Exact built-in poster ID.", TakesValue: true},
+			{Name: "--apply", Description: "Apply a reviewed mutation plan."},
+			{Name: "--plan", Description: "Opaque mutation plan token.", TakesValue: true},
+		},
+		inputSchema:   eventCreateInputSchema(),
+		successSchema: eventCreateSuccessSchema(),
+		failureTypes: []string{
+			"auth.required",
+			"auth.expired",
+			"resource.not_found",
+			"safety.plan_stale",
+			"remote.unavailable",
+			"contract.protocol_changed",
+			"internal.failure",
+		},
+		safety: standardMutationSafety(),
+	},
+	{
+		path:       "events.update",
+		invocation: []string{"events", "update"},
+		kind:       eventsUpdateCommand,
+		positionals: []positionalDefinition{{
+			Name:        "event-id",
+			Required:    true,
+			Description: "Event identifier.",
+		}},
+		flags: []flagDefinition{
+			{Name: "--input", Description: "Read one structured JSON input object.", TakesValue: true},
+			{Name: "--title", Description: "Event title.", TakesValue: true},
+			{Name: "--description", Description: "Optional description.", TakesValue: true},
+			{Name: "--start", Description: "RFC 3339 start time.", TakesValue: true},
+			{Name: "--end", Description: "RFC 3339 end time or null in structured input.", TakesValue: true},
+			{Name: "--timezone", Description: "IANA timezone.", TakesValue: true},
+			{Name: "--guest-limit", Description: "Positive guest limit.", TakesValue: true},
+			{Name: "--link", Description: "Link in label=url form; this flag can repeat.", TakesValue: true},
+			{Name: "--poster-id", Description: "Exact built-in poster ID.", TakesValue: true},
+			{Name: "--apply", Description: "Apply a reviewed mutation plan."},
+			{Name: "--plan", Description: "Opaque mutation plan token.", TakesValue: true},
+		},
+		inputSchema:   eventUpdateInputSchema(),
+		successSchema: eventUpdateSuccessSchema(),
+		failureTypes: []string{
+			"auth.required",
+			"auth.expired",
+			"permission.denied",
+			"resource.not_found",
+			"state.conflict",
+			"safety.plan_stale",
+			"remote.unavailable",
+			"contract.protocol_changed",
+			"internal.failure",
+		},
+		safety: standardMutationSafety(),
+	},
+	{
+		path:       "events.cancel",
+		invocation: []string{"events", "cancel"},
+		kind:       eventsCancelCommand,
+		positionals: []positionalDefinition{{
+			Name:        "event-id",
+			Required:    true,
+			Description: "Event identifier.",
+		}},
+		flags: []flagDefinition{
+			{Name: "--input", Description: "Read one structured JSON input object.", TakesValue: true},
+			{Name: "--message", Description: "Optional cancellation message.", TakesValue: true},
+			{Name: "--notify-guests", Description: "true or false.", TakesValue: true},
+			{Name: "--apply", Description: "Apply a reviewed consequential plan."},
+			{Name: "--confirm", Description: "Exact consequential confirmation token.", TakesValue: true},
+		},
+		inputSchema:   eventCancelInputSchema(),
+		successSchema: eventCancelSuccessSchema(),
+		failureTypes: []string{
+			"auth.required",
+			"auth.expired",
+			"permission.denied",
+			"resource.not_found",
+			"state.conflict",
+			"safety.confirmation_required",
+			"safety.plan_stale",
+			"remote.unavailable",
+			"contract.protocol_changed",
+			"internal.failure",
+		},
+		safety: consequentialActionSafety(),
 	},
 	{
 		path:       "rsvp.get",
@@ -1166,6 +1271,12 @@ func Execute(ctx context.Context, request Request, dependencies Dependencies) Re
 				return executeEventsList(ctx, definition, argv, dependencies, pretty)
 			case eventsGetCommand:
 				return executeEventGet(ctx, definition, argv, dependencies, pretty)
+			case eventsCreateCommand:
+				return executeEventCreate(ctx, request, definition, argv, dependencies, pretty)
+			case eventsUpdateCommand:
+				return executeEventUpdate(ctx, request, definition, argv, dependencies, pretty)
+			case eventsCancelCommand:
+				return executeEventCancel(ctx, request, definition, argv, dependencies, pretty)
 			case rsvpGetCommand:
 				return executeRSVPGet(ctx, definition, argv, dependencies, pretty)
 			case rsvpSetCommand:
@@ -1202,6 +1313,9 @@ func (definition commandDefinition) matches(argv []string) bool {
 		definition.kind == contactsListCommand ||
 		definition.kind == eventsListCommand ||
 		definition.kind == eventsGetCommand ||
+		definition.kind == eventsCreateCommand ||
+		definition.kind == eventsUpdateCommand ||
+		definition.kind == eventsCancelCommand ||
 		definition.kind == rsvpGetCommand ||
 		definition.kind == rsvpSetCommand) &&
 		len(argv) >= len(definition.invocation) {

--- a/internal/app/event_write.go
+++ b/internal/app/event_write.go
@@ -722,10 +722,12 @@ func validateMergedUpdateRange(command string, event remote.Event, input normali
 	var start *time.Time
 	if input.HasStart {
 		start = input.Start
-	} else if parsed, failure := requiredCurrentEventTime(event, "startDate"); failure == nil {
+	} else {
+		parsed, failure := requiredCurrentEventTime(event, "startDate")
+		if failure != nil {
+			return failure
+		}
 		start = &parsed
-	} else if rawEventField(event, "startDate").State == "value" {
-		return failure
 	}
 	var end *time.Time
 	if input.HasEnd {

--- a/internal/app/event_write.go
+++ b/internal/app/event_write.go
@@ -226,11 +226,26 @@ func executeEventUpdate(
 	if mergedRangeError != nil {
 		return *mergedRangeError
 	}
-	preconditions, conditionFailure := buildUpdatePreconditions(event, session.UserID, options.Input, clock())
+	preconditions, conditionFailure := buildUpdatePreconditions(
+		definition.path,
+		event,
+		session.UserID,
+		options.Input,
+		clock(),
+		pretty,
+	)
 	if conditionFailure != nil {
 		return *conditionFailure
 	}
-	privateRequest, publicRequest, fieldPaths, prepareErr := buildUpdateRequest(ctx, client, event, options.Input, session.UserID)
+	privateRequest, publicRequest, fieldPaths, prepareErr := buildUpdateRequest(
+		ctx,
+		definition.path,
+		client,
+		event,
+		options.Input,
+		session.UserID,
+		pretty,
+	)
 	if prepareErr != nil {
 		return *prepareErr
 	}
@@ -326,7 +341,13 @@ func executeEventCancel(
 			return eventWriteProtocolChangedFailure(definition.path, "EVENT_CANCEL_PROTOCOL_CHANGED", "The event cancel flow no longer matches the reviewed remote contract.", "partiful: event cancel protocol changed\n", pretty)
 		}
 	}
-	preconditions, conditionFailure := buildCancelPreconditions(event, session.UserID, clock())
+	preconditions, conditionFailure := buildCancelPreconditions(
+		definition.path,
+		event,
+		session.UserID,
+		clock(),
+		pretty,
+	)
 	if conditionFailure != nil {
 		return *conditionFailure
 	}
@@ -463,7 +484,14 @@ func mapPosterError(command string, err error, pretty bool) Result {
 	}
 }
 
-func buildUpdatePreconditions(event remote.Event, currentUserID string, input normalizedEventUpdateInput, now time.Time) (eventUpdatePrivatePreconditions, *Result) {
+func buildUpdatePreconditions(
+	command string,
+	event remote.Event,
+	currentUserID string,
+	input normalizedEventUpdateInput,
+	now time.Time,
+	pretty bool,
+) (eventUpdatePrivatePreconditions, *Result) {
 	preconditions := eventUpdatePrivatePreconditions{
 		OwnerIDs: rawEventField(event, "ownerIds"),
 		Status:   rawEventField(event, "status"),
@@ -496,10 +524,10 @@ func buildUpdatePreconditions(event remote.Event, currentUserID string, input no
 	}
 	if input.HasStart || input.HasEnd || input.HasTimezone {
 		if event.HasGuests.State == remote.FieldAbsent {
-			return eventUpdatePrivatePreconditions{}, resultPointer(eventWriteProtocolChangedFailure("events.update", "EVENT_UPDATE_PROTOCOL_CHANGED", "The event update no longer matches the reviewed remote contract.", "partiful: event update protocol changed\n", false))
+			return eventUpdatePrivatePreconditions{}, resultPointer(eventTimeProtocolChangedFailure(command, pretty))
 		}
 		if event.Safeguards.Ticketing.State == remote.FieldValue {
-			return eventUpdatePrivatePreconditions{}, resultPointer(eventPreconditionFailure("events.update", prettyFalse))
+			return eventUpdatePrivatePreconditions{}, resultPointer(eventPreconditionFailure(command, pretty))
 		}
 		preconditions.DateGuard = map[string]eventFieldSnapshot{
 			"startDate": rawEventField(event, "startDate"),
@@ -508,14 +536,14 @@ func buildUpdatePreconditions(event remote.Event, currentUserID string, input no
 			"ticketing": rawEventField(event, "ticketing"),
 		}
 		if event.HasGuests.State != remote.FieldValue {
-			return eventUpdatePrivatePreconditions{}, resultPointer(eventWriteProtocolChangedFailure("events.update", "EVENT_UPDATE_PROTOCOL_CHANGED", "The event update no longer matches the reviewed remote contract.", "partiful: event update protocol changed\n", false))
+			return eventUpdatePrivatePreconditions{}, resultPointer(eventTimeProtocolChangedFailure(command, pretty))
 		}
 		if event.HasGuests.Value {
-			start, failure := requiredCurrentEventTime(event, "startDate")
+			start, failure := requiredCurrentEventTime(command, event, "startDate", pretty)
 			if failure != nil {
 				return eventUpdatePrivatePreconditions{}, resultPointer(*failure)
 			}
-			end, hasEnd, failure := optionalCurrentEventTime(event, "endDate")
+			end, hasEnd, failure := optionalCurrentEventTime(command, event, "endDate", pretty)
 			if failure != nil {
 				return eventUpdatePrivatePreconditions{}, resultPointer(*failure)
 			}
@@ -524,7 +552,7 @@ func buildUpdatePreconditions(event remote.Event, currentUserID string, input no
 				boundary = end.Add(2 * time.Hour)
 			}
 			if now.After(boundary) {
-				return eventUpdatePrivatePreconditions{}, resultPointer(eventPreconditionFailure("events.update", prettyFalse))
+				return eventUpdatePrivatePreconditions{}, resultPointer(eventPreconditionFailure(command, pretty))
 			}
 		}
 	}
@@ -532,14 +560,14 @@ func buildUpdatePreconditions(event remote.Event, currentUserID string, input no
 	return preconditions, nil
 }
 
-var prettyFalse = false
-
 func buildUpdateRequest(
 	ctx context.Context,
+	command string,
 	client remote.Client,
 	event remote.Event,
 	input normalizedEventUpdateInput,
 	currentUserID string,
+	pretty bool,
 ) (remote.FirestoreWriteDocument, map[string]any, []string, *Result) {
 	fields := make(map[string]any)
 	publicFields := make(map[string]any)
@@ -596,7 +624,7 @@ func buildUpdateRequest(
 		if input.PosterID != nil {
 			image, _, err := resolvePosterBinding(ctx, client, *input.PosterID)
 			if err != nil {
-				result := mapPosterError("events.update", err, false)
+				result := mapPosterError(command, err, pretty)
 				return remote.FirestoreWriteDocument{}, nil, nil, &result
 			}
 			encoded := firestoreImageValue(image)
@@ -673,7 +701,13 @@ func firestoreStringArray(values []string) []any {
 	return encoded
 }
 
-func buildCancelPreconditions(event remote.Event, currentUserID string, now time.Time) (eventCancelPrivatePreconditions, *Result) {
+func buildCancelPreconditions(
+	command string,
+	event remote.Event,
+	currentUserID string,
+	now time.Time,
+	pretty bool,
+) (eventCancelPrivatePreconditions, *Result) {
 	preconditions := eventCancelPrivatePreconditions{
 		OwnerIDs:   rawEventField(event, "ownerIds"),
 		Status:     rawEventField(event, "status"),
@@ -681,35 +715,35 @@ func buildCancelPreconditions(event remote.Event, currentUserID string, now time
 		GuestCount: rawEventField(event, "guestCount"),
 	}
 	if preconditions.OwnerIDs.State != "value" {
-		result := eventWriteProtocolChangedFailure("events.cancel", "EVENT_CANCEL_PROTOCOL_CHANGED", "The event cancel flow no longer matches the reviewed remote contract.", "partiful: event cancel protocol changed\n", false)
+		result := eventTimeProtocolChangedFailure(command, pretty)
 		return eventCancelPrivatePreconditions{}, &result
 	}
 	if !event.OwnerIDsPresent || !slices.Contains(event.OwnerIDs, currentUserID) {
-		result := hostPermissionFailure("events.cancel", false)
+		result := hostPermissionFailure(command, pretty)
 		return eventCancelPrivatePreconditions{}, &result
 	}
 	if preconditions.Status.State != "value" || event.Status == nil {
-		result := eventWriteProtocolChangedFailure("events.cancel", "EVENT_CANCEL_PROTOCOL_CHANGED", "The event cancel flow no longer matches the reviewed remote contract.", "partiful: event cancel protocol changed\n", false)
+		result := eventTimeProtocolChangedFailure(command, pretty)
 		return eventCancelPrivatePreconditions{}, &result
 	}
 	if *event.Status != "PUBLISHED" {
-		result := eventPreconditionFailure("events.cancel", false)
+		result := eventPreconditionFailure(command, pretty)
 		return eventCancelPrivatePreconditions{}, &result
 	}
 	if preconditions.GuestCount.State != "value" || event.GuestCount.State != remote.FieldValue {
-		result := eventWriteProtocolChangedFailure("events.cancel", "EVENT_CANCEL_PROTOCOL_CHANGED", "The event cancel flow no longer matches the reviewed remote contract.", "partiful: event cancel protocol changed\n", false)
+		result := eventTimeProtocolChangedFailure(command, pretty)
 		return eventCancelPrivatePreconditions{}, &result
 	}
 	if event.GuestCount.Value <= 0 {
-		result := eventPreconditionFailure("events.cancel", false)
+		result := eventPreconditionFailure(command, pretty)
 		return eventCancelPrivatePreconditions{}, &result
 	}
-	start, failure := requiredCurrentEventTime(event, "startDate")
+	start, failure := requiredCurrentEventTime(command, event, "startDate", pretty)
 	if failure != nil {
 		return eventCancelPrivatePreconditions{}, resultPointer(*failure)
 	}
 	if !start.After(now) {
-		result := eventPreconditionFailure("events.cancel", false)
+		result := eventPreconditionFailure(command, pretty)
 		return eventCancelPrivatePreconditions{}, &result
 	}
 	return preconditions, nil
@@ -723,7 +757,7 @@ func validateMergedUpdateRange(command string, event remote.Event, input normali
 	if input.HasStart {
 		start = input.Start
 	} else {
-		parsed, failure := requiredCurrentEventTime(event, "startDate")
+		parsed, failure := requiredCurrentEventTime(command, event, "startDate", pretty)
 		if failure != nil {
 			return failure
 		}
@@ -732,7 +766,7 @@ func validateMergedUpdateRange(command string, event remote.Event, input normali
 	var end *time.Time
 	if input.HasEnd {
 		end = input.End
-	} else if parsed, hasValue, failure := optionalCurrentEventTime(event, "endDate"); failure == nil && hasValue {
+	} else if parsed, hasValue, failure := optionalCurrentEventTime(command, event, "endDate", pretty); failure == nil && hasValue {
 		end = &parsed
 	} else if failure != nil {
 		return failure
@@ -744,26 +778,36 @@ func validateMergedUpdateRange(command string, event remote.Event, input normali
 	return nil
 }
 
-func requiredCurrentEventTime(event remote.Event, field string) (time.Time, *Result) {
+func requiredCurrentEventTime(
+	command string,
+	event remote.Event,
+	field string,
+	pretty bool,
+) (time.Time, *Result) {
 	snapshot := rawEventField(event, field)
 	if snapshot.State != "value" {
-		result := eventWriteProtocolChangedFailure("events.update", "EVENT_UPDATE_PROTOCOL_CHANGED", "The event update no longer matches the reviewed remote contract.", "partiful: event update protocol changed\n", false)
+		result := eventTimeProtocolChangedFailure(command, pretty)
 		return time.Time{}, &result
 	}
 	var value string
 	if json.Unmarshal(snapshot.Value, &value) != nil {
-		result := eventWriteProtocolChangedFailure("events.update", "EVENT_UPDATE_PROTOCOL_CHANGED", "The event update no longer matches the reviewed remote contract.", "partiful: event update protocol changed\n", false)
+		result := eventTimeProtocolChangedFailure(command, pretty)
 		return time.Time{}, &result
 	}
 	decoded, err := time.Parse(time.RFC3339, value)
 	if err != nil {
-		result := eventWriteProtocolChangedFailure("events.update", "EVENT_UPDATE_PROTOCOL_CHANGED", "The event update no longer matches the reviewed remote contract.", "partiful: event update protocol changed\n", false)
+		result := eventTimeProtocolChangedFailure(command, pretty)
 		return time.Time{}, &result
 	}
 	return decoded, nil
 }
 
-func optionalCurrentEventTime(event remote.Event, field string) (time.Time, bool, *Result) {
+func optionalCurrentEventTime(
+	command string,
+	event remote.Event,
+	field string,
+	pretty bool,
+) (time.Time, bool, *Result) {
 	snapshot := rawEventField(event, field)
 	switch snapshot.State {
 	case "absent", "null":
@@ -771,19 +815,38 @@ func optionalCurrentEventTime(event remote.Event, field string) (time.Time, bool
 	case "value":
 		var value string
 		if json.Unmarshal(snapshot.Value, &value) != nil {
-			result := eventWriteProtocolChangedFailure("events.update", "EVENT_UPDATE_PROTOCOL_CHANGED", "The event update no longer matches the reviewed remote contract.", "partiful: event update protocol changed\n", false)
+			result := eventTimeProtocolChangedFailure(command, pretty)
 			return time.Time{}, false, &result
 		}
 		decoded, err := time.Parse(time.RFC3339, value)
 		if err != nil {
-			result := eventWriteProtocolChangedFailure("events.update", "EVENT_UPDATE_PROTOCOL_CHANGED", "The event update no longer matches the reviewed remote contract.", "partiful: event update protocol changed\n", false)
+			result := eventTimeProtocolChangedFailure(command, pretty)
 			return time.Time{}, false, &result
 		}
 		return decoded, true, nil
 	default:
-		result := eventWriteProtocolChangedFailure("events.update", "EVENT_UPDATE_PROTOCOL_CHANGED", "The event update no longer matches the reviewed remote contract.", "partiful: event update protocol changed\n", false)
+		result := eventTimeProtocolChangedFailure(command, pretty)
 		return time.Time{}, false, &result
 	}
+}
+
+func eventTimeProtocolChangedFailure(command string, pretty bool) Result {
+	if command == "events.cancel" {
+		return eventWriteProtocolChangedFailure(
+			command,
+			"EVENT_CANCEL_PROTOCOL_CHANGED",
+			"The event cancel flow no longer matches the reviewed remote contract.",
+			"partiful: event cancel protocol changed\n",
+			pretty,
+		)
+	}
+	return eventWriteProtocolChangedFailure(
+		command,
+		"EVENT_UPDATE_PROTOCOL_CHANGED",
+		"The event update no longer matches the reviewed remote contract.",
+		"partiful: event update protocol changed\n",
+		pretty,
+	)
 }
 
 func rawEventField(event remote.Event, name string) eventFieldSnapshot {

--- a/internal/app/event_write.go
+++ b/internal/app/event_write.go
@@ -1,0 +1,853 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+	"sort"
+	"time"
+
+	"github.com/KalebCole/partiful-cli/internal/mutation"
+	"github.com/KalebCole/partiful-cli/internal/remote"
+)
+
+type eventCreatePlan struct {
+	Operation        string                 `json:"operation"`
+	Input            eventCreatePublicInput `json:"input"`
+	Request          any                    `json:"request"`
+	Preconditions    map[string]string      `json:"preconditions"`
+	ExpiresInSeconds int                    `json:"expiresInSeconds"`
+	PlanToken        string                 `json:"planToken"`
+}
+
+type eventUpdatePlan struct {
+	Operation        string            `json:"operation"`
+	EventID          string            `json:"eventId"`
+	Fields           []string          `json:"fields"`
+	Input            map[string]any    `json:"input"`
+	Request          any               `json:"request"`
+	Preconditions    map[string]string `json:"preconditions"`
+	ExpiresInSeconds int               `json:"expiresInSeconds"`
+	PlanToken        string            `json:"planToken"`
+}
+
+type eventCancelPlan struct {
+	Operation        string                     `json:"operation"`
+	EventID          string                     `json:"eventId"`
+	Input            normalizedEventCancelInput `json:"input"`
+	Request          remote.CancelEventParams   `json:"request"`
+	Effects          []string                   `json:"effects"`
+	Preconditions    map[string]string          `json:"preconditions"`
+	ExpiresInSeconds int                        `json:"expiresInSeconds"`
+	PlanToken        string                     `json:"planToken"`
+}
+
+type eventCreateSubmitted struct {
+	Submitted bool `json:"submitted"`
+}
+
+type eventUpdateSubmitted struct {
+	EventID   string   `json:"eventId"`
+	Fields    []string `json:"fields"`
+	Submitted bool     `json:"submitted"`
+}
+
+type eventCancelSubmitted struct {
+	EventID      string `json:"eventId"`
+	NotifyGuests bool   `json:"notifyGuests"`
+	Submitted    bool   `json:"submitted"`
+}
+
+type eventPosterBinding struct {
+	CatalogDigest string                `json:"catalogDigest"`
+	Poster        remote.PartifulPoster `json:"poster"`
+}
+
+type eventFieldSnapshot struct {
+	State string          `json:"state"`
+	Value json.RawMessage `json:"value,omitempty"`
+}
+
+type eventUpdatePrivatePreconditions struct {
+	OwnerIDs  eventFieldSnapshot            `json:"ownerIds"`
+	Status    eventFieldSnapshot            `json:"status"`
+	Target    map[string]eventFieldSnapshot `json:"target"`
+	DateGuard map[string]eventFieldSnapshot `json:"dateGuard,omitempty"`
+}
+
+type eventCancelPrivatePreconditions struct {
+	OwnerIDs   eventFieldSnapshot `json:"ownerIds"`
+	Status     eventFieldSnapshot `json:"status"`
+	StartDate  eventFieldSnapshot `json:"startDate"`
+	GuestCount eventFieldSnapshot `json:"guestCount"`
+}
+
+func executeEventCreate(
+	ctx context.Context,
+	request Request,
+	definition commandDefinition,
+	argv []string,
+	dependencies Dependencies,
+	pretty bool,
+) Result {
+	options, inputError := parseEventCreateOptions(request, definition, argv, dependencies)
+	if inputError != nil {
+		return failure(definition.path, exitCodeForType(inputError.Type), *inputError, pretty)
+	}
+	session, sessionFailure := acquireProtectedSession(ctx, definition.path, dependencies, pretty)
+	if sessionFailure != nil {
+		return *sessionFailure
+	}
+	if session.AccountFingerprint == "" {
+		return internalFailure(definition.path, pretty)
+	}
+	clock := time.Now
+	if dependencies.Now != nil {
+		clock = dependencies.Now
+	}
+	authority := mutation.Authority{Files: dependencies.Files, Path: eventMutationPath(dependencies), Now: clock, Random: dependencies.MutationRandom}
+	inputDocument := options.Input.document()
+	var inspected mutation.Record
+	if options.Apply {
+		var err error
+		inspected, err = authority.Inspect(options.PlanToken, definition.path, "createEvent", session.AccountFingerprint, inputDocument)
+		if err != nil {
+			if errors.Is(err, mutation.ErrStale) {
+				return eventPlanStaleFailure(definition.path, pretty)
+			}
+			return internalFailure(definition.path, pretty)
+		}
+	}
+	client := remote.Client{HTTP: dependencies.HTTP}
+	posterImage, posterBinding, err := resolvePosterBinding(ctx, client, options.Input.PosterID)
+	if err != nil {
+		return mapPosterError(definition.path, err, pretty)
+	}
+	privateRequest := remote.CreateEventParams{Event: buildCreateEventDraft(options.Input, posterImage), CohostIDs: []string{}}
+	requestDocument, _ := json.Marshal(privateRequest)
+	preconditionDocument, _ := json.Marshal(posterBinding)
+	binding := mutation.Binding{Command: definition.path, Operation: "createEvent", AccountFingerprint: session.AccountFingerprint, Input: inputDocument, Request: requestDocument, Preconditions: preconditionDocument}
+	if options.Apply {
+		if !bytes.Equal(inspected.Binding.Request, requestDocument) || !bytes.Equal(inspected.Binding.Preconditions, preconditionDocument) {
+			return eventPlanStaleFailure(definition.path, pretty)
+		}
+		if err := authority.Consume(options.PlanToken, binding); err != nil {
+			if errors.Is(err, mutation.ErrStale) {
+				return eventPlanStaleFailure(definition.path, pretty)
+			}
+			return internalFailure(definition.path, pretty)
+		}
+		_, err := client.CreateEvent(ctx, session.AccessToken, session.UserID, privateRequest)
+		if err != nil {
+			if errors.Is(err, remote.ErrUnavailable) {
+				return eventSubmissionUnavailableFailure(definition.path, "Create submission could not be confirmed. Create a new plan before another attempt.", pretty)
+			}
+			return eventWriteProtocolChangedFailure(definition.path, "CREATE_EVENT_PROTOCOL_CHANGED", "The event create response no longer matches the reviewed remote contract.", "partiful: event create protocol changed\n", pretty)
+		}
+		return success(definition.path, eventCreateSubmitted{Submitted: true}, pretty)
+	}
+	token, err := authority.Create(binding)
+	if err != nil {
+		return internalFailure(definition.path, pretty)
+	}
+	return success(definition.path, eventCreatePlan{
+		Operation:        "createEvent",
+		Input:            options.Input.public(),
+		Request:          privateRequest,
+		Preconditions:    map[string]string{"poster": "bound"},
+		ExpiresInSeconds: 300,
+		PlanToken:        token,
+	}, pretty)
+}
+
+func executeEventUpdate(
+	ctx context.Context,
+	request Request,
+	definition commandDefinition,
+	argv []string,
+	dependencies Dependencies,
+	pretty bool,
+) Result {
+	options, inputError := parseEventUpdateOptions(request, definition, argv, dependencies)
+	if inputError != nil {
+		return failure(definition.path, exitCodeForType(inputError.Type), *inputError, pretty)
+	}
+	session, sessionFailure := acquireProtectedSession(ctx, definition.path, dependencies, pretty)
+	if sessionFailure != nil {
+		return *sessionFailure
+	}
+	if session.AccountFingerprint == "" || session.UserID == "" {
+		return internalFailure(definition.path, pretty)
+	}
+	clock := time.Now
+	if dependencies.Now != nil {
+		clock = dependencies.Now
+	}
+	authority := mutation.Authority{Files: dependencies.Files, Path: eventMutationPath(dependencies), Now: clock, Random: dependencies.MutationRandom}
+	inputDocument := options.Input.document()
+	var inspected mutation.Record
+	if options.Apply {
+		var err error
+		inspected, err = authority.Inspect(options.PlanToken, definition.path, "firestorePatchEvent", session.AccountFingerprint, inputDocument)
+		if err != nil {
+			if errors.Is(err, mutation.ErrStale) {
+				return eventPlanStaleFailure(definition.path, pretty)
+			}
+			return internalFailure(definition.path, pretty)
+		}
+	}
+	deviceID, err := randomDeviceID(dependencies.AuthRandom)
+	if err != nil {
+		return internalFailure(definition.path, pretty)
+	}
+	client := remote.Client{HTTP: dependencies.HTTP}
+	event, err := client.GetEventInfo(ctx, session.AccessToken, deviceID, options.EventID)
+	if err != nil {
+		switch {
+		case errors.Is(err, remote.ErrEventNotFound):
+			if options.Apply {
+				return eventPlanStaleFailure(definition.path, pretty)
+			}
+			return eventNotFoundFailure(definition.path, pretty)
+		case errors.Is(err, remote.ErrUnavailable):
+			return eventRemoteUnavailableFailure(definition.path, "The event update could not read current event data.", "partiful: event update unavailable\n", pretty)
+		default:
+			return eventWriteProtocolChangedFailure(definition.path, "EVENT_UPDATE_PROTOCOL_CHANGED", "The event update no longer matches the reviewed remote contract.", "partiful: event update protocol changed\n", pretty)
+		}
+	}
+	if !event.OwnerIDsPresent || !slices.Contains(event.OwnerIDs, session.UserID) {
+		return hostPermissionFailure(definition.path, pretty)
+	}
+	mergedRangeError := validateMergedUpdateRange(definition.path, event, options.Input, pretty)
+	if mergedRangeError != nil {
+		return *mergedRangeError
+	}
+	preconditions, conditionFailure := buildUpdatePreconditions(event, session.UserID, options.Input, clock())
+	if conditionFailure != nil {
+		return *conditionFailure
+	}
+	privateRequest, publicRequest, fieldPaths, prepareErr := buildUpdateRequest(ctx, client, event, options.Input, session.UserID)
+	if prepareErr != nil {
+		return *prepareErr
+	}
+	requestDocument, _ := json.Marshal(privateRequest)
+	preconditionDocument, _ := json.Marshal(preconditions)
+	binding := mutation.Binding{Command: definition.path, Operation: "firestorePatchEvent", AccountFingerprint: session.AccountFingerprint, Input: inputDocument, Request: requestDocument, Preconditions: preconditionDocument}
+	if options.Apply {
+		if !bytes.Equal(inspected.Binding.Request, requestDocument) || !bytes.Equal(inspected.Binding.Preconditions, preconditionDocument) {
+			return eventPlanStaleFailure(definition.path, pretty)
+		}
+		if err := authority.Consume(options.PlanToken, binding); err != nil {
+			if errors.Is(err, mutation.ErrStale) {
+				return eventPlanStaleFailure(definition.path, pretty)
+			}
+			return internalFailure(definition.path, pretty)
+		}
+		if err := client.FirestorePatchEvent(ctx, session.AccessToken, options.EventID, fieldPaths, privateRequest); err != nil {
+			if errors.Is(err, remote.ErrUnavailable) {
+				return eventSubmissionUnavailableFailure(definition.path, "Update submission could not be confirmed. Create a new plan before another attempt.", pretty)
+			}
+			return eventWriteProtocolChangedFailure(definition.path, "EVENT_UPDATE_PROTOCOL_CHANGED", "The event update response no longer matches the reviewed remote contract.", "partiful: event update protocol changed\n", pretty)
+		}
+		return success(definition.path, eventUpdateSubmitted{EventID: options.EventID, Fields: options.Input.fields(), Submitted: true}, pretty)
+	}
+	token, err := authority.Create(binding)
+	if err != nil {
+		return internalFailure(definition.path, pretty)
+	}
+	return success(definition.path, eventUpdatePlan{
+		Operation:        "firestorePatchEvent",
+		EventID:          options.EventID,
+		Fields:           options.Input.fields(),
+		Input:            options.Input.public(),
+		Request:          publicRequest,
+		Preconditions:    map[string]string{"ownership": "bound", "status": "bound", "targetFields": "bound"},
+		ExpiresInSeconds: 300,
+		PlanToken:        token,
+	}, pretty)
+}
+
+func executeEventCancel(
+	ctx context.Context,
+	request Request,
+	definition commandDefinition,
+	argv []string,
+	dependencies Dependencies,
+	pretty bool,
+) Result {
+	options, inputError := parseEventCancelOptions(request, definition, argv, dependencies)
+	if inputError != nil {
+		return failure(definition.path, exitCodeForType(inputError.Type), *inputError, pretty)
+	}
+	session, sessionFailure := acquireProtectedSession(ctx, definition.path, dependencies, pretty)
+	if sessionFailure != nil {
+		return *sessionFailure
+	}
+	if session.AccountFingerprint == "" || session.UserID == "" {
+		return internalFailure(definition.path, pretty)
+	}
+	clock := time.Now
+	if dependencies.Now != nil {
+		clock = dependencies.Now
+	}
+	authority := mutation.Authority{Files: dependencies.Files, Path: eventMutationPath(dependencies), Now: clock, Random: dependencies.MutationRandom}
+	inputDocument := options.Input.document()
+	var inspected mutation.Record
+	if options.Apply {
+		var err error
+		inspected, err = authority.Inspect(options.ConfirmToken, definition.path, "cancelEvent", session.AccountFingerprint, inputDocument)
+		if err != nil {
+			if errors.Is(err, mutation.ErrStale) {
+				return eventPlanStaleFailure(definition.path, pretty)
+			}
+			return internalFailure(definition.path, pretty)
+		}
+	}
+	deviceID, err := randomDeviceID(dependencies.AuthRandom)
+	if err != nil {
+		return internalFailure(definition.path, pretty)
+	}
+	client := remote.Client{HTTP: dependencies.HTTP}
+	event, err := client.GetEventInfo(ctx, session.AccessToken, deviceID, options.EventID)
+	if err != nil {
+		switch {
+		case errors.Is(err, remote.ErrEventNotFound):
+			if options.Apply {
+				return eventPlanStaleFailure(definition.path, pretty)
+			}
+			return eventNotFoundFailure(definition.path, pretty)
+		case errors.Is(err, remote.ErrUnavailable):
+			return eventRemoteUnavailableFailure(definition.path, "The event cancellation could not read current event data.", "partiful: event cancel unavailable\n", pretty)
+		default:
+			return eventWriteProtocolChangedFailure(definition.path, "EVENT_CANCEL_PROTOCOL_CHANGED", "The event cancel flow no longer matches the reviewed remote contract.", "partiful: event cancel protocol changed\n", pretty)
+		}
+	}
+	preconditions, conditionFailure := buildCancelPreconditions(event, session.UserID, clock())
+	if conditionFailure != nil {
+		return *conditionFailure
+	}
+	privateRequest := remote.CancelEventParams{EventID: options.EventID, CancellationMessage: options.Input.Message, ShouldSkipNotifyGuests: !options.Input.NotifyGuests}
+	requestDocument, _ := json.Marshal(privateRequest)
+	preconditionDocument, _ := json.Marshal(preconditions)
+	binding := mutation.Binding{Command: definition.path, Operation: "cancelEvent", AccountFingerprint: session.AccountFingerprint, Input: inputDocument, Request: requestDocument, Preconditions: preconditionDocument}
+	if options.Apply {
+		if !bytes.Equal(inspected.Binding.Request, requestDocument) || !bytes.Equal(inspected.Binding.Preconditions, preconditionDocument) {
+			return eventPlanStaleFailure(definition.path, pretty)
+		}
+		if err := authority.Consume(options.ConfirmToken, binding); err != nil {
+			if errors.Is(err, mutation.ErrStale) {
+				return eventPlanStaleFailure(definition.path, pretty)
+			}
+			return internalFailure(definition.path, pretty)
+		}
+		if err := client.CancelEvent(ctx, session.AccessToken, session.UserID, privateRequest); err != nil {
+			if errors.Is(err, remote.ErrUnavailable) {
+				return eventSubmissionUnavailableFailure(definition.path, "Cancel submission could not be confirmed. Create a new plan before another attempt.", pretty)
+			}
+			return eventWriteProtocolChangedFailure(definition.path, "EVENT_CANCEL_PROTOCOL_CHANGED", "The event cancel response no longer matches the reviewed remote contract.", "partiful: event cancel protocol changed\n", pretty)
+		}
+		return success(definition.path, eventCancelSubmitted{EventID: options.EventID, NotifyGuests: options.Input.NotifyGuests, Submitted: true}, pretty)
+	}
+	token, err := authority.Create(binding)
+	if err != nil {
+		return internalFailure(definition.path, pretty)
+	}
+	effects := []string{"Cancels the event"}
+	if options.Input.NotifyGuests {
+		effects = append(effects, "Sends a cancellation notification to guests")
+	}
+	return success(definition.path, eventCancelPlan{
+		Operation:        "cancelEvent",
+		EventID:          options.EventID,
+		Input:            options.Input,
+		Request:          privateRequest,
+		Effects:          effects,
+		Preconditions:    map[string]string{"ownership": "bound", "status": "bound", "start": "bound", "guestCount": "bound"},
+		ExpiresInSeconds: 300,
+		PlanToken:        token,
+	}, pretty)
+}
+
+func buildCreateEventDraft(input normalizedEventCreateInput, poster remote.PartifulPosterImage) remote.CreateEventDraft {
+	draft := remote.CreateEventDraft{
+		Title:                      input.Title,
+		StartDate:                  input.Start.UTC().Format(time.RFC3339),
+		Timezone:                   input.Timezone,
+		GuestStatusCounts:          createEventGuestStatusCounts(),
+		DisplaySettings:            defaultCreateDisplaySettings(),
+		Status:                     "UNSAVED",
+		RSVPButtonGlyphType:        "emojis",
+		Image:                      poster,
+		ShowHostList:               true,
+		ShowGuestCount:             true,
+		ShowGuestList:              true,
+		ShowActivityTimestamps:     true,
+		DisplayInviteButton:        true,
+		Visibility:                 "public",
+		AllowGuestPhotoUpload:      true,
+		EnableGuestReminders:       true,
+		RSVPsEnabled:               true,
+		AllowGuestsToInviteMutuals: true,
+	}
+	if input.End != nil {
+		value := input.End.UTC().Format(time.RFC3339)
+		draft.EndDate = &value
+	}
+	if input.Description != nil {
+		draft.Description = input.Description
+	}
+	if input.Location != nil {
+		draft.LocationInfo = &remote.EventLocationInfo{Type: "freeform", Value: *input.Location}
+	}
+	if input.Visibility == "public" {
+		value := true
+		draft.IsPublic = &value
+	}
+	if input.GuestLimit != nil {
+		value := false
+		draft.MaxCapacity = input.GuestLimit
+		draft.EnableWaitlist = &value
+	}
+	if len(input.Links) != 0 {
+		customFields := make([]remote.EventCustomField, 0, len(input.Links))
+		for _, link := range input.Links {
+			customFields = append(customFields, remote.EventCustomField{Icon: "link", Value: link.Label, URL: link.URL})
+		}
+		draft.CustomFields = customFields
+	}
+	return draft
+}
+
+func resolvePosterBinding(ctx context.Context, client remote.Client, posterID string) (remote.PartifulPosterImage, eventPosterBinding, error) {
+	catalog, err := client.GetPosterCatalog(ctx)
+	if err != nil {
+		return remote.PartifulPosterImage{}, eventPosterBinding{}, err
+	}
+	matches := make([]remote.Poster, 0, 1)
+	for _, poster := range catalog.Posters {
+		if poster.ID == posterID {
+			matches = append(matches, poster)
+		}
+	}
+	if len(matches) == 0 {
+		return remote.PartifulPosterImage{}, eventPosterBinding{}, errPosterNotFound
+	}
+	if len(matches) != 1 {
+		return remote.PartifulPosterImage{}, eventPosterBinding{}, errPosterDuplicate
+	}
+	posterImage := remote.NewPartifulPosterImage(matches[0])
+	return posterImage, eventPosterBinding{CatalogDigest: hex.EncodeToString(catalog.PayloadSHA256[:]), Poster: posterImage.Poster}, nil
+}
+
+var (
+	errPosterNotFound  = errors.New("poster not found")
+	errPosterDuplicate = errors.New("poster duplicate")
+)
+
+func mapPosterError(command string, err error, pretty bool) Result {
+	switch {
+	case errors.Is(err, errPosterNotFound):
+		result := failure(command, 5, errorBody{Type: "resource.not_found", Code: "POSTER_NOT_FOUND", Message: "The poster was not found.", Retryable: false, Details: map[string]any{}}, pretty)
+		result.Stderr = "partiful: poster not found\n"
+		return result
+	case errors.Is(err, errPosterDuplicate):
+		return eventWriteProtocolChangedFailure(command, "POSTER_CATALOG_PROTOCOL_CHANGED", "The poster catalog no longer matches the reviewed remote contract.", "partiful: poster catalog protocol changed\n", pretty)
+	case errors.Is(err, remote.ErrUnavailable):
+		return eventRemoteUnavailableFailure(command, "The poster catalog is unavailable.", "partiful: poster catalog unavailable\n", pretty)
+	default:
+		return eventWriteProtocolChangedFailure(command, "POSTER_CATALOG_PROTOCOL_CHANGED", "The poster catalog no longer matches the reviewed remote contract.", "partiful: poster catalog protocol changed\n", pretty)
+	}
+}
+
+func buildUpdatePreconditions(event remote.Event, currentUserID string, input normalizedEventUpdateInput, now time.Time) (eventUpdatePrivatePreconditions, *Result) {
+	preconditions := eventUpdatePrivatePreconditions{
+		OwnerIDs: rawEventField(event, "ownerIds"),
+		Status:   rawEventField(event, "status"),
+		Target:   make(map[string]eventFieldSnapshot),
+	}
+	if input.HasTitle {
+		preconditions.Target["title"] = rawEventField(event, "title")
+	}
+	if input.HasDescription {
+		preconditions.Target["description"] = rawEventField(event, "description")
+	}
+	if input.HasStart {
+		preconditions.Target["startDate"] = rawEventField(event, "startDate")
+	}
+	if input.HasEnd {
+		preconditions.Target["endDate"] = rawEventField(event, "endDate")
+	}
+	if input.HasTimezone {
+		preconditions.Target["timezone"] = rawEventField(event, "timezone")
+	}
+	if input.HasGuestLimit {
+		preconditions.Target["enableWaitlist"] = rawEventField(event, "enableWaitlist")
+		preconditions.Target["maxCapacity"] = rawEventField(event, "maxCapacity")
+	}
+	if input.HasLinks {
+		preconditions.Target["customFields"] = rawEventField(event, "customFields")
+	}
+	if input.HasPosterID {
+		preconditions.Target["image"] = rawEventField(event, "image")
+	}
+	if input.HasStart || input.HasEnd || input.HasTimezone {
+		if event.HasGuests.State == remote.FieldAbsent {
+			return eventUpdatePrivatePreconditions{}, resultPointer(eventWriteProtocolChangedFailure("events.update", "EVENT_UPDATE_PROTOCOL_CHANGED", "The event update no longer matches the reviewed remote contract.", "partiful: event update protocol changed\n", false))
+		}
+		if event.Safeguards.Ticketing.State == remote.FieldValue {
+			return eventUpdatePrivatePreconditions{}, resultPointer(eventPreconditionFailure("events.update", prettyFalse))
+		}
+		preconditions.DateGuard = map[string]eventFieldSnapshot{
+			"startDate": rawEventField(event, "startDate"),
+			"endDate":   rawEventField(event, "endDate"),
+			"hasGuests": rawEventField(event, "hasGuests"),
+			"ticketing": rawEventField(event, "ticketing"),
+		}
+		if event.HasGuests.State != remote.FieldValue {
+			return eventUpdatePrivatePreconditions{}, resultPointer(eventWriteProtocolChangedFailure("events.update", "EVENT_UPDATE_PROTOCOL_CHANGED", "The event update no longer matches the reviewed remote contract.", "partiful: event update protocol changed\n", false))
+		}
+		if event.HasGuests.Value {
+			start, failure := requiredCurrentEventTime(event, "startDate")
+			if failure != nil {
+				return eventUpdatePrivatePreconditions{}, resultPointer(*failure)
+			}
+			end, hasEnd, failure := optionalCurrentEventTime(event, "endDate")
+			if failure != nil {
+				return eventUpdatePrivatePreconditions{}, resultPointer(*failure)
+			}
+			boundary := start.Add(8 * time.Hour)
+			if hasEnd {
+				boundary = end.Add(2 * time.Hour)
+			}
+			if now.After(boundary) {
+				return eventUpdatePrivatePreconditions{}, resultPointer(eventPreconditionFailure("events.update", prettyFalse))
+			}
+		}
+	}
+	_ = currentUserID
+	return preconditions, nil
+}
+
+var prettyFalse = false
+
+func buildUpdateRequest(
+	ctx context.Context,
+	client remote.Client,
+	event remote.Event,
+	input normalizedEventUpdateInput,
+	currentUserID string,
+) (remote.FirestoreWriteDocument, map[string]any, []string, *Result) {
+	fields := make(map[string]any)
+	publicFields := make(map[string]any)
+	mask := make([]string, 0, 9)
+	if input.HasTitle {
+		fields["title"] = remote.FirestoreStringValue{StringValue: *input.Title}
+		publicFields["title"] = remote.FirestoreStringValue{StringValue: *input.Title}
+		mask = append(mask, "title")
+	}
+	if input.HasDescription {
+		mask = append(mask, "description")
+		if input.Description != nil {
+			fields["description"] = remote.FirestoreStringValue{StringValue: *input.Description}
+			publicFields["description"] = remote.FirestoreStringValue{StringValue: *input.Description}
+		}
+	}
+	if input.HasStart {
+		value := input.Start.UTC().Format(time.RFC3339)
+		fields["startDate"] = remote.FirestoreStringValue{StringValue: value}
+		publicFields["startDate"] = remote.FirestoreStringValue{StringValue: value}
+		mask = append(mask, "startDate")
+	}
+	if input.HasEnd {
+		mask = append(mask, "endDate")
+		if input.End != nil {
+			value := input.End.UTC().Format(time.RFC3339)
+			fields["endDate"] = remote.FirestoreStringValue{StringValue: value}
+			publicFields["endDate"] = remote.FirestoreStringValue{StringValue: value}
+		}
+	}
+	if input.HasTimezone {
+		fields["timezone"] = remote.FirestoreStringValue{StringValue: *input.Timezone}
+		publicFields["timezone"] = remote.FirestoreStringValue{StringValue: *input.Timezone}
+		mask = append(mask, "timezone")
+	}
+	if input.HasGuestLimit {
+		mask = append(mask, "enableWaitlist", "maxCapacity")
+		if input.GuestLimit != nil {
+			fields["enableWaitlist"] = remote.FirestoreBooleanValue{BooleanValue: false}
+			fields["maxCapacity"] = remote.FirestoreIntegerValue{IntegerValue: fmt.Sprintf("%d", *input.GuestLimit)}
+			publicFields["enableWaitlist"] = remote.FirestoreBooleanValue{BooleanValue: false}
+			publicFields["maxCapacity"] = remote.FirestoreIntegerValue{IntegerValue: fmt.Sprintf("%d", *input.GuestLimit)}
+		}
+	}
+	if input.HasLinks {
+		mask = append(mask, "customFields")
+		if input.Links != nil {
+			fields["customFields"] = remote.FirestoreArrayValue{ArrayValue: remote.FirestoreArray{Values: firestoreLinks(input.Links)}}
+			publicFields["customFields"] = fields["customFields"]
+		}
+	}
+	if input.HasPosterID {
+		mask = append(mask, "image")
+		if input.PosterID != nil {
+			image, _, err := resolvePosterBinding(ctx, client, *input.PosterID)
+			if err != nil {
+				result := mapPosterError("events.update", err, false)
+				return remote.FirestoreWriteDocument{}, nil, nil, &result
+			}
+			encoded := firestoreImageValue(image)
+			fields["image"] = encoded
+			publicFields["image"] = encoded
+		}
+	}
+	fields["updatedBy"] = remote.FirestoreReferenceValue{ReferenceValue: "projects/getpartiful/databases/(default)/documents/users/" + currentUserID}
+	publicFields["updatedBy"] = remote.FirestoreReferenceValue{ReferenceValue: "<redacted>"}
+	mask = append(mask, "updatedBy")
+	sort.Strings(mask)
+	_ = event
+	return remote.FirestoreWriteDocument{Fields: fields}, map[string]any{"fields": publicFields}, mask, nil
+}
+
+func firestoreLinks(links []eventLink) []any {
+	values := make([]any, 0, len(links))
+	for _, link := range links {
+		values = append(values, remote.FirestoreMapValue{MapValue: remote.FirestoreMap{Fields: map[string]any{
+			"icon":  remote.FirestoreStringValue{StringValue: "link"},
+			"url":   remote.FirestoreStringValue{StringValue: link.URL},
+			"value": remote.FirestoreStringValue{StringValue: link.Label},
+		}}})
+	}
+	return values
+}
+
+func firestoreImageValue(image remote.PartifulPosterImage) remote.FirestoreMapValue {
+	posterFields := map[string]any{
+		"categories":  remote.FirestoreArrayValue{ArrayValue: remote.FirestoreArray{Values: firestoreStringArray(image.Poster.Categories)}},
+		"contentType": remote.FirestoreStringValue{StringValue: image.Poster.ContentType},
+		"height":      firestoreNullableInteger(image.Poster.Height),
+		"id":          remote.FirestoreStringValue{StringValue: image.Poster.ID},
+		"name":        remote.FirestoreStringValue{StringValue: image.Poster.Name},
+		"tags":        remote.FirestoreArrayValue{ArrayValue: remote.FirestoreArray{Values: firestoreStringArray(image.Poster.Tags)}},
+		"url":         remote.FirestoreStringValue{StringValue: image.Poster.URL},
+		"width":       firestoreNullableInteger(image.Poster.Width),
+	}
+	if image.Poster.BlurHash != nil {
+		posterFields["blurHash"] = remote.FirestoreStringValue{StringValue: *image.Poster.BlurHash}
+	}
+	imageFields := map[string]any{
+		"blurHash":    firestoreNullableString(image.BlurHash),
+		"contentType": remote.FirestoreStringValue{StringValue: image.ContentType},
+		"height":      firestoreNullableInteger(image.Height),
+		"name":        remote.FirestoreStringValue{StringValue: image.Name},
+		"poster":      remote.FirestoreMapValue{MapValue: remote.FirestoreMap{Fields: posterFields}},
+		"source":      remote.FirestoreStringValue{StringValue: image.Source},
+		"url":         remote.FirestoreStringValue{StringValue: image.URL},
+		"width":       firestoreNullableInteger(image.Width),
+	}
+	return remote.FirestoreMapValue{MapValue: remote.FirestoreMap{Fields: imageFields}}
+}
+
+func firestoreNullableString(value *string) any {
+	if value == nil {
+		return map[string]any{"nullValue": nil}
+	}
+	return remote.FirestoreStringValue{StringValue: *value}
+}
+
+func firestoreNullableInteger(value *int) any {
+	if value == nil {
+		return map[string]any{"nullValue": nil}
+	}
+	return remote.FirestoreIntegerValue{IntegerValue: fmt.Sprintf("%d", *value)}
+}
+
+func firestoreStringArray(values []string) []any {
+	encoded := make([]any, 0, len(values))
+	for _, value := range values {
+		encoded = append(encoded, remote.FirestoreStringValue{StringValue: value})
+	}
+	return encoded
+}
+
+func buildCancelPreconditions(event remote.Event, currentUserID string, now time.Time) (eventCancelPrivatePreconditions, *Result) {
+	preconditions := eventCancelPrivatePreconditions{
+		OwnerIDs:   rawEventField(event, "ownerIds"),
+		Status:     rawEventField(event, "status"),
+		StartDate:  rawEventField(event, "startDate"),
+		GuestCount: rawEventField(event, "guestCount"),
+	}
+	if preconditions.OwnerIDs.State != "value" {
+		result := eventWriteProtocolChangedFailure("events.cancel", "EVENT_CANCEL_PROTOCOL_CHANGED", "The event cancel flow no longer matches the reviewed remote contract.", "partiful: event cancel protocol changed\n", false)
+		return eventCancelPrivatePreconditions{}, &result
+	}
+	if !event.OwnerIDsPresent || !slices.Contains(event.OwnerIDs, currentUserID) {
+		result := hostPermissionFailure("events.cancel", false)
+		return eventCancelPrivatePreconditions{}, &result
+	}
+	if preconditions.Status.State != "value" || event.Status == nil {
+		result := eventWriteProtocolChangedFailure("events.cancel", "EVENT_CANCEL_PROTOCOL_CHANGED", "The event cancel flow no longer matches the reviewed remote contract.", "partiful: event cancel protocol changed\n", false)
+		return eventCancelPrivatePreconditions{}, &result
+	}
+	if *event.Status != "PUBLISHED" {
+		result := eventPreconditionFailure("events.cancel", false)
+		return eventCancelPrivatePreconditions{}, &result
+	}
+	if preconditions.GuestCount.State != "value" || event.GuestCount.State != remote.FieldValue {
+		result := eventWriteProtocolChangedFailure("events.cancel", "EVENT_CANCEL_PROTOCOL_CHANGED", "The event cancel flow no longer matches the reviewed remote contract.", "partiful: event cancel protocol changed\n", false)
+		return eventCancelPrivatePreconditions{}, &result
+	}
+	if event.GuestCount.Value <= 0 {
+		result := eventPreconditionFailure("events.cancel", false)
+		return eventCancelPrivatePreconditions{}, &result
+	}
+	start, failure := requiredCurrentEventTime(event, "startDate")
+	if failure != nil {
+		return eventCancelPrivatePreconditions{}, resultPointer(*failure)
+	}
+	if !start.After(now) {
+		result := eventPreconditionFailure("events.cancel", false)
+		return eventCancelPrivatePreconditions{}, &result
+	}
+	return preconditions, nil
+}
+
+func validateMergedUpdateRange(command string, event remote.Event, input normalizedEventUpdateInput, pretty bool) *Result {
+	if !input.HasStart && !input.HasEnd {
+		return nil
+	}
+	var start *time.Time
+	if input.HasStart {
+		start = input.Start
+	} else if parsed, failure := requiredCurrentEventTime(event, "startDate"); failure == nil {
+		start = &parsed
+	} else if rawEventField(event, "startDate").State == "value" {
+		return failure
+	}
+	var end *time.Time
+	if input.HasEnd {
+		end = input.End
+	} else if parsed, hasValue, failure := optionalCurrentEventTime(event, "endDate"); failure == nil && hasValue {
+		end = &parsed
+	} else if failure != nil {
+		return failure
+	}
+	if start != nil && end != nil && end.Before(*start) {
+		result := failure(command, 2, *eventWriteInputFailure("EVENT_RANGE_INVALID", "End must not be before start."), pretty)
+		return &result
+	}
+	return nil
+}
+
+func requiredCurrentEventTime(event remote.Event, field string) (time.Time, *Result) {
+	snapshot := rawEventField(event, field)
+	if snapshot.State != "value" {
+		result := eventWriteProtocolChangedFailure("events.update", "EVENT_UPDATE_PROTOCOL_CHANGED", "The event update no longer matches the reviewed remote contract.", "partiful: event update protocol changed\n", false)
+		return time.Time{}, &result
+	}
+	var value string
+	if json.Unmarshal(snapshot.Value, &value) != nil {
+		result := eventWriteProtocolChangedFailure("events.update", "EVENT_UPDATE_PROTOCOL_CHANGED", "The event update no longer matches the reviewed remote contract.", "partiful: event update protocol changed\n", false)
+		return time.Time{}, &result
+	}
+	decoded, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		result := eventWriteProtocolChangedFailure("events.update", "EVENT_UPDATE_PROTOCOL_CHANGED", "The event update no longer matches the reviewed remote contract.", "partiful: event update protocol changed\n", false)
+		return time.Time{}, &result
+	}
+	return decoded, nil
+}
+
+func optionalCurrentEventTime(event remote.Event, field string) (time.Time, bool, *Result) {
+	snapshot := rawEventField(event, field)
+	switch snapshot.State {
+	case "absent", "null":
+		return time.Time{}, false, nil
+	case "value":
+		var value string
+		if json.Unmarshal(snapshot.Value, &value) != nil {
+			result := eventWriteProtocolChangedFailure("events.update", "EVENT_UPDATE_PROTOCOL_CHANGED", "The event update no longer matches the reviewed remote contract.", "partiful: event update protocol changed\n", false)
+			return time.Time{}, false, &result
+		}
+		decoded, err := time.Parse(time.RFC3339, value)
+		if err != nil {
+			result := eventWriteProtocolChangedFailure("events.update", "EVENT_UPDATE_PROTOCOL_CHANGED", "The event update no longer matches the reviewed remote contract.", "partiful: event update protocol changed\n", false)
+			return time.Time{}, false, &result
+		}
+		return decoded, true, nil
+	default:
+		result := eventWriteProtocolChangedFailure("events.update", "EVENT_UPDATE_PROTOCOL_CHANGED", "The event update no longer matches the reviewed remote contract.", "partiful: event update protocol changed\n", false)
+		return time.Time{}, false, &result
+	}
+}
+
+func rawEventField(event remote.Event, name string) eventFieldSnapshot {
+	raw, ok := event.RawFields[name]
+	if !ok {
+		return eventFieldSnapshot{State: "absent"}
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if bytes.Equal(trimmed, []byte("null")) {
+		return eventFieldSnapshot{State: "null"}
+	}
+	return eventFieldSnapshot{State: "value", Value: bytes.Clone(raw)}
+}
+
+func eventPlanStaleFailure(command string, pretty bool) Result {
+	result := failure(command, 7, errorBody{Type: "safety.plan_stale", Code: "PLAN_STALE", Message: "The mutation plan is expired, used, or no longer matches.", Retryable: false, Details: map[string]any{}}, pretty)
+	result.Stderr = "partiful: mutation plan stale\n"
+	return result
+}
+
+func hostPermissionFailure(command string, pretty bool) Result {
+	result := failure(command, 4, errorBody{Type: "permission.denied", Code: "HOST_PERMISSION_REQUIRED", Message: "This command requires host access to the event.", Retryable: false, Details: map[string]any{"requiredRole": "host"}}, pretty)
+	result.Stderr = "partiful: host access required\n"
+	return result
+}
+
+func eventPreconditionFailure(command string, pretty bool) Result {
+	result := failure(command, 6, errorBody{Type: "state.conflict", Code: "EVENT_PRECONDITION_FAILED", Message: "The event no longer satisfies this command's reviewed preconditions.", Retryable: false, Details: map[string]any{}}, pretty)
+	result.Stderr = "partiful: event precondition failed\n"
+	return result
+}
+
+func eventRemoteUnavailableFailure(command, message, stderr string, pretty bool) Result {
+	result := failure(command, 8, errorBody{Type: "remote.unavailable", Code: "EVENT_REMOTE_UNAVAILABLE", Message: message, Retryable: true, Details: map[string]any{}}, pretty)
+	result.Stderr = stderr
+	return result
+}
+
+func eventWriteProtocolChangedFailure(command, code, message, stderr string, pretty bool) Result {
+	result := failure(command, 9, errorBody{Type: "contract.protocol_changed", Code: code, Message: message, Retryable: false, Details: map[string]any{}}, pretty)
+	result.Stderr = stderr
+	return result
+}
+
+func eventSubmissionUnavailableFailure(command, message string, pretty bool) Result {
+	result := failure(command, 8, errorBody{Type: "remote.unavailable", Code: "EVENT_SUBMISSION_UNCERTAIN", Message: message, Retryable: false, Details: map[string]any{}}, pretty)
+	result.Stderr = "partiful: event submission uncertain\n"
+	return result
+}
+
+func exitCodeForType(failureType string) int {
+	switch failureType {
+	case "safety.confirmation_required", "safety.plan_stale":
+		return 7
+	default:
+		return 2
+	}
+}
+
+func eventMutationPath(dependencies Dependencies) string {
+	if dependencies.MutationPath != "" {
+		return dependencies.MutationPath
+	}
+	return "/config/partiful/mutation-plans.json"
+}
+
+func resultPointer(result Result) *Result {
+	return &result
+}

--- a/internal/app/event_write_input.go
+++ b/internal/app/event_write_input.go
@@ -353,10 +353,10 @@ func eventInputDocument(
 		}
 		return document, nil
 	}
-	return eventFlagsDocument(scalars, links), nil
+	return eventFlagsDocument(scalars, links)
 }
 
-func eventFlagsDocument(values map[string]string, links []string) map[string]json.RawMessage {
+func eventFlagsDocument(values map[string]string, links []string) (map[string]json.RawMessage, *errorBody) {
 	document := make(map[string]json.RawMessage)
 	copyString := func(flag, field string) {
 		if value, ok := values[flag]; ok {
@@ -383,14 +383,15 @@ func eventFlagsDocument(values map[string]string, links []string) map[string]jso
 		mapped := make([]eventLink, 0, len(links))
 		for _, entry := range links {
 			parts := strings.SplitN(entry, "=", 2)
-			if len(parts) == 2 {
-				mapped = append(mapped, eventLink{Label: parts[0], URL: parts[1]})
+			if len(parts) != 2 {
+				return nil, eventWriteInputFailure("LINKS_INVALID", "--link must use label=url.")
 			}
+			mapped = append(mapped, eventLink{Label: parts[0], URL: parts[1]})
 		}
 		raw, _ := json.Marshal(mapped)
 		document["links"] = raw
 	}
-	return document
+	return document, nil
 }
 
 func normalizeEventCreateInput(document map[string]json.RawMessage) (normalizedEventCreateInput, *errorBody) {

--- a/internal/app/event_write_input.go
+++ b/internal/app/event_write_input.go
@@ -1,0 +1,969 @@
+package app
+
+import (
+	"encoding/json"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/KalebCole/partiful-cli/internal/remote"
+)
+
+type eventLink struct {
+	Label string `json:"label"`
+	URL   string `json:"url"`
+}
+
+type normalizedEventCreateInput struct {
+	Title       string
+	Start       time.Time
+	StartText   string
+	End         *time.Time
+	EndText     *string
+	Timezone    string
+	Description *string
+	Location    *string
+	Visibility  string
+	GuestLimit  *int
+	Links       []eventLink
+	PosterID    string
+}
+
+type normalizedEventUpdateInput struct {
+	Title          *string
+	HasTitle       bool
+	Description    *string
+	HasDescription bool
+	Start          *time.Time
+	StartText      *string
+	HasStart       bool
+	End            *time.Time
+	EndText        *string
+	HasEnd         bool
+	Timezone       *string
+	HasTimezone    bool
+	GuestLimit     *int
+	HasGuestLimit  bool
+	Links          []eventLink
+	HasLinks       bool
+	PosterID       *string
+	HasPosterID    bool
+}
+
+type normalizedEventCancelInput struct {
+	Message      string `json:"message"`
+	NotifyGuests bool   `json:"notifyGuests"`
+}
+
+type eventCreateOptions struct {
+	Input     normalizedEventCreateInput
+	Apply     bool
+	PlanToken string
+}
+
+type eventUpdateOptions struct {
+	EventID   string
+	Input     normalizedEventUpdateInput
+	Apply     bool
+	PlanToken string
+}
+
+type eventCancelOptions struct {
+	EventID      string
+	Input        normalizedEventCancelInput
+	Apply        bool
+	ConfirmToken string
+}
+
+type eventCreatePublicInput struct {
+	Title       string      `json:"title"`
+	Start       string      `json:"start"`
+	End         *string     `json:"end,omitempty"`
+	Timezone    string      `json:"timezone"`
+	Description *string     `json:"description,omitempty"`
+	Location    *string     `json:"location,omitempty"`
+	Visibility  string      `json:"visibility"`
+	GuestLimit  *int        `json:"guestLimit,omitempty"`
+	Links       []eventLink `json:"links,omitempty"`
+	PosterID    string      `json:"posterId"`
+}
+
+func (input normalizedEventCreateInput) public() eventCreatePublicInput {
+	return eventCreatePublicInput{
+		Title:       input.Title,
+		Start:       input.StartText,
+		End:         input.EndText,
+		Timezone:    input.Timezone,
+		Description: input.Description,
+		Location:    input.Location,
+		Visibility:  input.Visibility,
+		GuestLimit:  input.GuestLimit,
+		Links:       append([]eventLink(nil), input.Links...),
+		PosterID:    input.PosterID,
+	}
+}
+
+func (input normalizedEventCreateInput) document() json.RawMessage {
+	document, _ := json.Marshal(input.public())
+	return document
+}
+
+func (input normalizedEventUpdateInput) fields() []string {
+	fields := make([]string, 0, 8)
+	if input.HasDescription {
+		fields = append(fields, "description")
+	}
+	if input.HasEnd {
+		fields = append(fields, "end")
+	}
+	if input.HasGuestLimit {
+		fields = append(fields, "guestLimit")
+	}
+	if input.HasLinks {
+		fields = append(fields, "links")
+	}
+	if input.HasPosterID {
+		fields = append(fields, "posterId")
+	}
+	if input.HasStart {
+		fields = append(fields, "start")
+	}
+	if input.HasTimezone {
+		fields = append(fields, "timezone")
+	}
+	if input.HasTitle {
+		fields = append(fields, "title")
+	}
+	return fields
+}
+
+func (input normalizedEventUpdateInput) public() map[string]any {
+	document := make(map[string]any)
+	if input.HasTitle {
+		document["title"] = *input.Title
+	}
+	if input.HasDescription {
+		document["description"] = input.Description
+	}
+	if input.HasStart {
+		document["start"] = *input.StartText
+	}
+	if input.HasEnd {
+		document["end"] = input.EndText
+	}
+	if input.HasTimezone {
+		document["timezone"] = *input.Timezone
+	}
+	if input.HasGuestLimit {
+		document["guestLimit"] = input.GuestLimit
+	}
+	if input.HasLinks {
+		if input.Links == nil {
+			document["links"] = nil
+		} else {
+			document["links"] = append([]eventLink(nil), input.Links...)
+		}
+	}
+	if input.HasPosterID {
+		document["posterId"] = input.PosterID
+	}
+	return document
+}
+
+func (input normalizedEventUpdateInput) document() json.RawMessage {
+	document, _ := json.Marshal(input.public())
+	return document
+}
+
+func (input normalizedEventCancelInput) document() json.RawMessage {
+	document, _ := json.Marshal(input)
+	return document
+}
+
+func parseEventCreateOptions(
+	request Request,
+	definition commandDefinition,
+	argv []string,
+	dependencies Dependencies,
+) (eventCreateOptions, *errorBody) {
+	scalars, links, inputError := parseEventMutationFlags(definition, argv, len(definition.invocation), true)
+	if inputError != nil {
+		return eventCreateOptions{}, inputError
+	}
+	options := eventCreateOptions{}
+	_, options.Apply = scalars["--apply"]
+	options.PlanToken = scalars["--plan"]
+	if options.Apply && options.PlanToken == "" {
+		return eventCreateOptions{}, eventWriteInputFailure("PLAN_REQUIRED", "--apply requires --plan.")
+	}
+	if !options.Apply && options.PlanToken != "" {
+		return eventCreateOptions{}, eventWriteInputFailure("APPLY_REQUIRED", "--plan requires --apply.")
+	}
+	document, readError := eventInputDocument(request, dependencies, scalars, links)
+	if readError != nil {
+		return eventCreateOptions{}, readError
+	}
+	input, inputError := normalizeEventCreateInput(document)
+	if inputError != nil {
+		return eventCreateOptions{}, inputError
+	}
+	options.Input = input
+	return options, nil
+}
+
+func parseEventUpdateOptions(
+	request Request,
+	definition commandDefinition,
+	argv []string,
+	dependencies Dependencies,
+) (eventUpdateOptions, *errorBody) {
+	eventID, inputError := parseEventID(definition, argv[:len(definition.invocation)+1])
+	if inputError != nil {
+		return eventUpdateOptions{}, inputError
+	}
+	scalars, links, parseError := parseEventMutationFlags(definition, argv, len(definition.invocation)+1, true)
+	if parseError != nil {
+		return eventUpdateOptions{}, parseError
+	}
+	options := eventUpdateOptions{EventID: eventID}
+	_, options.Apply = scalars["--apply"]
+	options.PlanToken = scalars["--plan"]
+	if options.Apply && options.PlanToken == "" {
+		return eventUpdateOptions{}, eventWriteInputFailure("PLAN_REQUIRED", "--apply requires --plan.")
+	}
+	if !options.Apply && options.PlanToken != "" {
+		return eventUpdateOptions{}, eventWriteInputFailure("APPLY_REQUIRED", "--plan requires --apply.")
+	}
+	document, readError := eventInputDocument(request, dependencies, scalars, links)
+	if readError != nil {
+		return eventUpdateOptions{}, readError
+	}
+	input, inputError := normalizeEventUpdateInput(document)
+	if inputError != nil {
+		return eventUpdateOptions{}, inputError
+	}
+	if len(input.fields()) == 0 {
+		return eventUpdateOptions{}, eventWriteInputFailure("UPDATE_FIELD_REQUIRED", "At least one writable field is required.")
+	}
+	options.Input = input
+	return options, nil
+}
+
+func parseEventCancelOptions(
+	request Request,
+	definition commandDefinition,
+	argv []string,
+	dependencies Dependencies,
+) (eventCancelOptions, *errorBody) {
+	eventID, inputError := parseEventID(definition, argv[:len(definition.invocation)+1])
+	if inputError != nil {
+		return eventCancelOptions{}, inputError
+	}
+	scalars, _, parseError := parseEventMutationFlags(definition, argv, len(definition.invocation)+1, false)
+	if parseError != nil {
+		return eventCancelOptions{}, parseError
+	}
+	options := eventCancelOptions{EventID: eventID}
+	_, options.Apply = scalars["--apply"]
+	options.ConfirmToken = scalars["--confirm"]
+	if options.Apply && options.ConfirmToken == "" {
+		return eventCancelOptions{}, confirmationRequiredErrorBody()
+	}
+	if !options.Apply && options.ConfirmToken != "" {
+		return eventCancelOptions{}, eventWriteInputFailure("APPLY_REQUIRED", "--confirm requires --apply.")
+	}
+	document, readError := eventInputDocument(request, dependencies, scalars, nil)
+	if readError != nil {
+		return eventCancelOptions{}, readError
+	}
+	input, normalizeError := normalizeEventCancelInput(document)
+	if normalizeError != nil {
+		return eventCancelOptions{}, normalizeError
+	}
+	options.Input = input
+	return options, nil
+}
+
+func parseEventMutationFlags(
+	definition commandDefinition,
+	argv []string,
+	start int,
+	allowLinks bool,
+) (map[string]string, []string, *errorBody) {
+	allowed := make(map[string]flagDefinition, len(definition.flags))
+	for _, flag := range definition.flags {
+		allowed[flag.Name] = flag
+	}
+	scalars := make(map[string]string)
+	var links []string
+	for index := start; index < len(argv); index++ {
+		name := argv[index]
+		flag, ok := allowed[name]
+		if !ok {
+			return nil, nil, eventWriteInputFailure("FLAG_UNKNOWN", "The command contains an unknown flag.")
+		}
+		if name == "--link" && allowLinks {
+			if index+1 >= len(argv) {
+				return nil, nil, eventWriteInputFailureWithDetail("FLAG_VALUE_REQUIRED", "A flag value is required.", "flag", name)
+			}
+			index++
+			links = append(links, argv[index])
+			continue
+		}
+		if _, repeated := scalars[name]; repeated {
+			return nil, nil, eventWriteInputFailureWithDetail("FLAG_REPEATED", "A scalar flag cannot be repeated.", "flag", name)
+		}
+		if !flag.TakesValue {
+			scalars[name] = "true"
+			continue
+		}
+		if index+1 >= len(argv) {
+			return nil, nil, eventWriteInputFailureWithDetail("FLAG_VALUE_REQUIRED", "A flag value is required.", "flag", name)
+		}
+		index++
+		scalars[name] = argv[index]
+	}
+	return scalars, links, nil
+}
+
+func eventInputDocument(
+	request Request,
+	dependencies Dependencies,
+	scalars map[string]string,
+	links []string,
+) (map[string]json.RawMessage, *errorBody) {
+	inputPath, hasInput := scalars["--input"]
+	hasFieldFlags := len(links) != 0
+	for name := range scalars {
+		switch name {
+		case "--apply", "--plan", "--confirm", "--input":
+		default:
+			hasFieldFlags = true
+		}
+	}
+	if hasInput && hasFieldFlags {
+		return nil, eventWriteInputFailure("INPUT_SOURCE_CONFLICT", "--input cannot be combined with field flags.")
+	}
+	if hasInput {
+		raw, ok := readRSVPInput(request.Stdin, dependencies.Files, inputPath)
+		var document map[string]json.RawMessage
+		if !ok || decodeRSVPObject(raw, &document) != nil {
+			return nil, eventWriteInputFailure("INPUT_DOCUMENT_INVALID", "Input must be one valid JSON object.")
+		}
+		return document, nil
+	}
+	return eventFlagsDocument(scalars, links), nil
+}
+
+func eventFlagsDocument(values map[string]string, links []string) map[string]json.RawMessage {
+	document := make(map[string]json.RawMessage)
+	copyString := func(flag, field string) {
+		if value, ok := values[flag]; ok {
+			raw, _ := json.Marshal(value)
+			document[field] = raw
+		}
+	}
+	copyString("--title", "title")
+	copyString("--start", "start")
+	copyString("--end", "end")
+	copyString("--timezone", "timezone")
+	copyString("--description", "description")
+	copyString("--location", "location")
+	copyString("--visibility", "visibility")
+	copyString("--poster-id", "posterId")
+	copyString("--message", "message")
+	if value, ok := values["--notify-guests"]; ok {
+		document["notifyGuests"] = json.RawMessage(strings.ToLower(value))
+	}
+	if value, ok := values["--guest-limit"]; ok {
+		document["guestLimit"] = json.RawMessage(value)
+	}
+	if links != nil {
+		mapped := make([]eventLink, 0, len(links))
+		for _, entry := range links {
+			parts := strings.SplitN(entry, "=", 2)
+			if len(parts) == 2 {
+				mapped = append(mapped, eventLink{Label: parts[0], URL: parts[1]})
+			}
+		}
+		raw, _ := json.Marshal(mapped)
+		document["links"] = raw
+	}
+	return document
+}
+
+func normalizeEventCreateInput(document map[string]json.RawMessage) (normalizedEventCreateInput, *errorBody) {
+	allowed := map[string]bool{
+		"title":       true,
+		"start":       true,
+		"end":         true,
+		"timezone":    true,
+		"description": true,
+		"location":    true,
+		"visibility":  true,
+		"guestLimit":  true,
+		"links":       true,
+		"posterId":    true,
+	}
+	for name := range document {
+		if !allowed[name] {
+			return normalizedEventCreateInput{}, eventWriteInputFailure("INPUT_FIELD_UNKNOWN", "Event input contains an unknown field.")
+		}
+	}
+	title, ok := requiredEventString(document, "title", true)
+	if !ok {
+		return normalizedEventCreateInput{}, eventWriteInputFailure("TITLE_REQUIRED", "Title is required.")
+	}
+	start, startText, ok := requiredEventTime(document, "start")
+	if !ok {
+		return normalizedEventCreateInput{}, eventWriteInputFailure("START_INVALID", "Start must be an RFC 3339 timestamp.")
+	}
+	timezone, ok := requiredTimezone(document, "timezone")
+	if !ok {
+		return normalizedEventCreateInput{}, eventWriteInputFailure("TIMEZONE_INVALID", "Timezone must be a valid IANA timezone.")
+	}
+	end, endText, endStatus := optionalEventTime(document, "end")
+	if endStatus == -1 {
+		return normalizedEventCreateInput{}, eventWriteInputFailure("END_INVALID", "End must be an RFC 3339 timestamp or null.")
+	}
+	description, ok := optionalTrimmedString(document, "description", true)
+	if !ok {
+		return normalizedEventCreateInput{}, eventWriteInputFailure("DESCRIPTION_INVALID", "Description must be a string or null.")
+	}
+	location, ok := optionalTrimmedString(document, "location", true)
+	if !ok {
+		return normalizedEventCreateInput{}, eventWriteInputFailure("LOCATION_INVALID", "Location must be a string or null.")
+	}
+	visibility, ok := optionalVisibility(document)
+	if !ok {
+		return normalizedEventCreateInput{}, eventWriteInputFailure("VISIBILITY_INVALID", "Visibility must be private or public.")
+	}
+	guestLimit, guestLimitStatus := optionalPositiveInteger(document, "guestLimit", true)
+	if guestLimitStatus == -1 {
+		return normalizedEventCreateInput{}, eventWriteInputFailure("GUEST_LIMIT_INVALID", "Guest limit must be a positive integer or null.")
+	}
+	links, linksStatus := optionalLinks(document, true)
+	if linksStatus == -1 {
+		return normalizedEventCreateInput{}, eventWriteInputFailure("LINKS_INVALID", "Links must be an array of {label,url} objects or null.")
+	}
+	posterID, ok := optionalPosterID(document, true)
+	if !ok {
+		return normalizedEventCreateInput{}, eventWriteInputFailure("POSTER_ID_INVALID", "Poster ID must be a string or null.")
+	}
+	if end != nil && end.Before(start) {
+		return normalizedEventCreateInput{}, eventWriteInputFailure("EVENT_RANGE_INVALID", "End must not be before start.")
+	}
+	return normalizedEventCreateInput{
+		Title:       title,
+		Start:       start,
+		StartText:   startText,
+		End:         end,
+		EndText:     endText,
+		Timezone:    timezone,
+		Description: description,
+		Location:    location,
+		Visibility:  visibility,
+		GuestLimit:  guestLimit,
+		Links:       links,
+		PosterID:    posterID,
+	}, nil
+}
+
+func normalizeEventUpdateInput(document map[string]json.RawMessage) (normalizedEventUpdateInput, *errorBody) {
+	allowed := map[string]bool{
+		"title":       true,
+		"description": true,
+		"start":       true,
+		"end":         true,
+		"timezone":    true,
+		"guestLimit":  true,
+		"links":       true,
+		"posterId":    true,
+	}
+	for name := range document {
+		if !allowed[name] {
+			return normalizedEventUpdateInput{}, eventWriteInputFailure("INPUT_FIELD_UNKNOWN", "Event input contains an unknown field.")
+		}
+	}
+	var input normalizedEventUpdateInput
+	if value, ok := document["title"]; ok {
+		decoded, valid := decodeRequiredString(value, true)
+		if !valid {
+			return normalizedEventUpdateInput{}, eventWriteInputFailure("TITLE_INVALID", "Title must be a non-empty string.")
+		}
+		input.Title = &decoded
+		input.HasTitle = true
+	}
+	if value, ok := document["description"]; ok {
+		decoded, valid, present := decodeNullableString(value, true)
+		if !valid {
+			return normalizedEventUpdateInput{}, eventWriteInputFailure("DESCRIPTION_INVALID", "Description must be a string or null.")
+		}
+		input.Description = decoded
+		input.HasDescription = present
+	}
+	if value, ok := document["start"]; ok {
+		decoded, text, valid := decodeRequiredTime(value)
+		if !valid {
+			return normalizedEventUpdateInput{}, eventWriteInputFailure("START_INVALID", "Start must be an RFC 3339 timestamp.")
+		}
+		input.Start = &decoded
+		input.StartText = &text
+		input.HasStart = true
+	}
+	if value, ok := document["end"]; ok {
+		decoded, text, status := decodeNullableTime(value)
+		if status == -1 {
+			return normalizedEventUpdateInput{}, eventWriteInputFailure("END_INVALID", "End must be an RFC 3339 timestamp or null.")
+		}
+		input.End = decoded
+		input.EndText = text
+		input.HasEnd = true
+	}
+	if value, ok := document["timezone"]; ok {
+		decoded, valid := decodeTimezone(value)
+		if !valid {
+			return normalizedEventUpdateInput{}, eventWriteInputFailure("TIMEZONE_INVALID", "Timezone must be a valid IANA timezone.")
+		}
+		input.Timezone = &decoded
+		input.HasTimezone = true
+	}
+	if value, ok := document["guestLimit"]; ok {
+		decoded, status := decodeNullablePositiveInteger(value)
+		if status == -1 {
+			return normalizedEventUpdateInput{}, eventWriteInputFailure("GUEST_LIMIT_INVALID", "Guest limit must be a positive integer or null.")
+		}
+		input.GuestLimit = decoded
+		input.HasGuestLimit = true
+	}
+	if value, ok := document["links"]; ok {
+		decoded, status := decodeNullableLinks(value)
+		if status == -1 {
+			return normalizedEventUpdateInput{}, eventWriteInputFailure("LINKS_INVALID", "Links must be an array of {label,url} objects or null.")
+		}
+		input.Links = decoded
+		input.HasLinks = true
+	}
+	if value, ok := document["posterId"]; ok {
+		decoded, valid, present := decodeNullableString(value, true)
+		if !valid {
+			return normalizedEventUpdateInput{}, eventWriteInputFailure("POSTER_ID_INVALID", "Poster ID must be a string or null.")
+		}
+		input.PosterID = decoded
+		input.HasPosterID = present
+	}
+	return input, nil
+}
+
+func normalizeEventCancelInput(document map[string]json.RawMessage) (normalizedEventCancelInput, *errorBody) {
+	allowed := map[string]bool{"message": true, "notifyGuests": true}
+	for name := range document {
+		if !allowed[name] {
+			return normalizedEventCancelInput{}, eventWriteInputFailure("INPUT_FIELD_UNKNOWN", "Event input contains an unknown field.")
+		}
+	}
+	message := ""
+	if value, ok := document["message"]; ok {
+		var decoded string
+		if json.Unmarshal(value, &decoded) != nil {
+			return normalizedEventCancelInput{}, eventWriteInputFailure("MESSAGE_INVALID", "Message must be a string.")
+		}
+		message = decoded
+	}
+	notifyGuests := true
+	if value, ok := document["notifyGuests"]; ok {
+		var decoded bool
+		if json.Unmarshal(value, &decoded) != nil {
+			return normalizedEventCancelInput{}, eventWriteInputFailure("NOTIFY_GUESTS_INVALID", "notifyGuests must be true or false.")
+		}
+		notifyGuests = decoded
+	}
+	return normalizedEventCancelInput{Message: message, NotifyGuests: notifyGuests}, nil
+}
+
+func requiredEventString(document map[string]json.RawMessage, field string, trim bool) (string, bool) {
+	raw, ok := document[field]
+	if !ok {
+		return "", false
+	}
+	value, valid := decodeRequiredString(raw, trim)
+	return value, valid
+}
+
+func optionalTrimmedString(document map[string]json.RawMessage, field string, nullAllowed bool) (*string, bool) {
+	raw, ok := document[field]
+	if !ok {
+		return nil, true
+	}
+	decoded, valid, _ := decodeNullableString(raw, true)
+	if !nullAllowed && decoded == nil {
+		return nil, false
+	}
+	return decoded, valid
+}
+
+func requiredEventTime(document map[string]json.RawMessage, field string) (time.Time, string, bool) {
+	raw, ok := document[field]
+	if !ok {
+		return time.Time{}, "", false
+	}
+	return decodeRequiredTime(raw)
+}
+
+func optionalEventTime(document map[string]json.RawMessage, field string) (*time.Time, *string, int) {
+	raw, ok := document[field]
+	if !ok {
+		return nil, nil, 0
+	}
+	return decodeNullableTime(raw)
+}
+
+func requiredTimezone(document map[string]json.RawMessage, field string) (string, bool) {
+	raw, ok := document[field]
+	if !ok {
+		return "", false
+	}
+	return decodeTimezone(raw)
+}
+
+func optionalVisibility(document map[string]json.RawMessage) (string, bool) {
+	raw, ok := document["visibility"]
+	if !ok {
+		return "private", true
+	}
+	var value string
+	if json.Unmarshal(raw, &value) != nil {
+		return "", false
+	}
+	value = strings.TrimSpace(value)
+	return value, value == "private" || value == "public"
+}
+
+func optionalPositiveInteger(document map[string]json.RawMessage, field string, nullAsMissing bool) (*int, int) {
+	raw, ok := document[field]
+	if !ok {
+		return nil, 0
+	}
+	decoded, status := decodeNullablePositiveInteger(raw)
+	if decoded == nil && status == 1 && nullAsMissing {
+		return nil, 0
+	}
+	return decoded, status
+}
+
+func optionalLinks(document map[string]json.RawMessage, nullAsMissing bool) ([]eventLink, int) {
+	raw, ok := document["links"]
+	if !ok {
+		return nil, 0
+	}
+	decoded, status := decodeNullableLinks(raw)
+	if decoded == nil && status == 1 && nullAsMissing {
+		return nil, 0
+	}
+	return decoded, status
+}
+
+func optionalPosterID(document map[string]json.RawMessage, nullAsDefault bool) (string, bool) {
+	raw, ok := document["posterId"]
+	if !ok {
+		return "Let's Party", true
+	}
+	decoded, valid, _ := decodeNullableString(raw, true)
+	if !valid {
+		return "", false
+	}
+	if decoded == nil && nullAsDefault {
+		return "Let's Party", true
+	}
+	if decoded == nil {
+		return "", true
+	}
+	return *decoded, true
+}
+
+func decodeRequiredString(raw json.RawMessage, trim bool) (string, bool) {
+	var value string
+	if json.Unmarshal(raw, &value) != nil {
+		return "", false
+	}
+	if trim {
+		value = strings.TrimSpace(value)
+	}
+	return value, value != ""
+}
+
+func decodeNullableString(raw json.RawMessage, trim bool) (*string, bool, bool) {
+	if string(raw) == "null" {
+		return nil, true, true
+	}
+	value, valid := decodeRequiredString(raw, trim)
+	if !valid {
+		return nil, false, false
+	}
+	return &value, true, true
+}
+
+func decodeRequiredTime(raw json.RawMessage) (time.Time, string, bool) {
+	var value string
+	if json.Unmarshal(raw, &value) != nil {
+		return time.Time{}, "", false
+	}
+	value = strings.TrimSpace(value)
+	decoded, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		return time.Time{}, "", false
+	}
+	return decoded, value, true
+}
+
+func decodeNullableTime(raw json.RawMessage) (*time.Time, *string, int) {
+	if string(raw) == "null" {
+		return nil, nil, 1
+	}
+	decoded, text, ok := decodeRequiredTime(raw)
+	if !ok {
+		return nil, nil, -1
+	}
+	return &decoded, &text, 1
+}
+
+func decodeTimezone(raw json.RawMessage) (string, bool) {
+	var value string
+	if json.Unmarshal(raw, &value) != nil {
+		return "", false
+	}
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", false
+	}
+	if _, err := time.LoadLocation(value); err != nil {
+		return "", false
+	}
+	return value, true
+}
+
+func decodeNullablePositiveInteger(raw json.RawMessage) (*int, int) {
+	if string(raw) == "null" {
+		return nil, 1
+	}
+	decoder := json.NewDecoder(strings.NewReader(string(raw)))
+	decoder.UseNumber()
+	var value any
+	if decoder.Decode(&value) != nil {
+		return nil, -1
+	}
+	number, ok := value.(json.Number)
+	if !ok {
+		return nil, -1
+	}
+	parsed, err := strconv.Atoi(number.String())
+	if err != nil || parsed < 1 {
+		return nil, -1
+	}
+	return &parsed, 1
+}
+
+func decodeNullableLinks(raw json.RawMessage) ([]eventLink, int) {
+	if string(raw) == "null" {
+		return nil, 1
+	}
+	var entries []map[string]json.RawMessage
+	if json.Unmarshal(raw, &entries) != nil || entries == nil {
+		return nil, -1
+	}
+	links := make([]eventLink, 0, len(entries))
+	for _, entry := range entries {
+		if len(entry) != 2 {
+			return nil, -1
+		}
+		label, ok := requiredEventString(entry, "label", true)
+		if !ok {
+			return nil, -1
+		}
+		urlValue, ok := requiredEventString(entry, "url", true)
+		if !ok || !validHTTPURL(urlValue) {
+			return nil, -1
+		}
+		links = append(links, eventLink{Label: label, URL: urlValue})
+	}
+	return links, 1
+}
+
+func validHTTPURL(value string) bool {
+	parsed, err := url.Parse(value)
+	return err == nil && parsed.IsAbs() && (parsed.Scheme == "http" || parsed.Scheme == "https") && parsed.Host != ""
+}
+
+func eventWriteInputFailure(code, message string) *errorBody {
+	return &errorBody{Type: "input.invalid", Code: code, Message: message, Retryable: false, Details: map[string]any{}}
+}
+
+func eventWriteInputFailureWithDetail(code, message, key string, value any) *errorBody {
+	return &errorBody{Type: "input.invalid", Code: code, Message: message, Retryable: false, Details: map[string]any{key: value}}
+}
+
+func confirmationRequiredErrorBody() *errorBody {
+	return &errorBody{Type: "safety.confirmation_required", Code: "CONFIRMATION_REQUIRED", Message: "--apply requires --confirm.", Retryable: false, Details: map[string]any{}}
+}
+
+func eventLinkSchema() jsonSchema {
+	one := 1
+	return objectSchema(
+		[]string{"label", "url"},
+		map[string]jsonSchema{
+			"label": {Type: "string", MinLength: &one},
+			"url":   {Type: "string", Format: "uri"},
+		},
+	)
+}
+
+func eventCreateInputSchema() jsonSchema {
+	one := 1
+	return objectSchema(
+		[]string{"title", "start", "timezone"},
+		map[string]jsonSchema{
+			"title":       {Type: "string", MinLength: &one},
+			"start":       {Type: "string", Format: "date-time"},
+			"end":         {Type: []string{"string", "null"}, Format: "date-time"},
+			"timezone":    {Type: "string", MinLength: &one},
+			"description": {Type: []string{"string", "null"}},
+			"location":    {Type: []string{"string", "null"}},
+			"visibility":  {Type: "string", Enum: []string{"private", "public"}},
+			"guestLimit":  {Type: []string{"integer", "null"}},
+			"links":       {Type: []string{"array", "null"}, Items: pointerSchema(eventLinkSchema())},
+			"posterId":    {Type: []string{"string", "null"}},
+		},
+	)
+}
+
+func eventUpdateInputSchema() jsonSchema {
+	return objectSchema(
+		nil,
+		map[string]jsonSchema{
+			"title":       {Type: "string"},
+			"description": {Type: []string{"string", "null"}},
+			"start":       {Type: "string", Format: "date-time"},
+			"end":         {Type: []string{"string", "null"}, Format: "date-time"},
+			"timezone":    {Type: "string"},
+			"guestLimit":  {Type: []string{"integer", "null"}},
+			"links":       {Type: []string{"array", "null"}, Items: pointerSchema(eventLinkSchema())},
+			"posterId":    {Type: []string{"string", "null"}},
+		},
+	)
+}
+
+func eventCancelInputSchema() jsonSchema {
+	return objectSchema(
+		nil,
+		map[string]jsonSchema{
+			"message":      {Type: "string"},
+			"notifyGuests": {Type: "boolean"},
+		},
+	)
+}
+
+func eventCreateSuccessSchema() jsonSchema {
+	one := 1
+	threeHundred := 300
+	plan := objectSchema(
+		[]string{"operation", "input", "request", "preconditions", "expiresInSeconds", "planToken"},
+		map[string]jsonSchema{
+			"operation":        {Type: "string", Enum: []string{"createEvent"}},
+			"input":            eventCreateInputSchema(),
+			"request":          objectSchema([]string{"event", "cohostIds"}, map[string]jsonSchema{"event": {Type: "object"}, "cohostIds": {Type: "array", Items: pointerSchema(jsonSchema{Type: "string"})}}),
+			"preconditions":    objectSchema([]string{"poster"}, map[string]jsonSchema{"poster": {Type: "string", Enum: []string{"bound"}}}),
+			"expiresInSeconds": {Type: "integer", Minimum: &threeHundred, Maximum: &threeHundred},
+			"planToken":        {Type: "string", MinLength: &one},
+		},
+	)
+	submitted := objectSchema([]string{"submitted"}, map[string]jsonSchema{"submitted": {Type: "boolean", Const: true}})
+	return jsonSchema{Type: "object", OneOf: []jsonSchema{plan, submitted}}
+}
+
+func eventUpdateSuccessSchema() jsonSchema {
+	one := 1
+	threeHundred := 300
+	plan := objectSchema(
+		[]string{"operation", "eventId", "fields", "input", "request", "preconditions", "expiresInSeconds", "planToken"},
+		map[string]jsonSchema{
+			"operation":        {Type: "string", Enum: []string{"firestorePatchEvent"}},
+			"eventId":          {Type: "string", MinLength: &one},
+			"fields":           {Type: "array", Items: pointerSchema(jsonSchema{Type: "string"})},
+			"input":            eventUpdateInputSchema(),
+			"request":          {Type: "object"},
+			"preconditions":    {Type: "object"},
+			"expiresInSeconds": {Type: "integer", Minimum: &threeHundred, Maximum: &threeHundred},
+			"planToken":        {Type: "string", MinLength: &one},
+		},
+	)
+	submitted := objectSchema(
+		[]string{"eventId", "fields", "submitted"},
+		map[string]jsonSchema{
+			"eventId":   {Type: "string", MinLength: &one},
+			"fields":    {Type: "array", Items: pointerSchema(jsonSchema{Type: "string"})},
+			"submitted": {Type: "boolean", Const: true},
+		},
+	)
+	return jsonSchema{Type: "object", OneOf: []jsonSchema{plan, submitted}}
+}
+
+func eventCancelSuccessSchema() jsonSchema {
+	one := 1
+	threeHundred := 300
+	plan := objectSchema(
+		[]string{"operation", "eventId", "input", "request", "effects", "preconditions", "expiresInSeconds", "planToken"},
+		map[string]jsonSchema{
+			"operation":        {Type: "string", Enum: []string{"cancelEvent"}},
+			"eventId":          {Type: "string", MinLength: &one},
+			"input":            eventCancelInputSchema(),
+			"request":          {Type: "object"},
+			"effects":          {Type: "array", Items: pointerSchema(jsonSchema{Type: "string"})},
+			"preconditions":    {Type: "object"},
+			"expiresInSeconds": {Type: "integer", Minimum: &threeHundred, Maximum: &threeHundred},
+			"planToken":        {Type: "string", MinLength: &one},
+		},
+	)
+	submitted := objectSchema(
+		[]string{"eventId", "notifyGuests", "submitted"},
+		map[string]jsonSchema{
+			"eventId":      {Type: "string", MinLength: &one},
+			"notifyGuests": {Type: "boolean"},
+			"submitted":    {Type: "boolean", Const: true},
+		},
+	)
+	return jsonSchema{Type: "object", OneOf: []jsonSchema{plan, submitted}}
+}
+
+func consequentialActionSafety() safetyDefinition {
+	return safetyDefinition{Kind: "consequential-action", PlanRequired: true, ConfirmationRequired: true}
+}
+
+func pointerSchema(schema jsonSchema) *jsonSchema {
+	return &schema
+}
+
+func createEventGuestStatusCounts() map[string]int {
+	return map[string]int{
+		"APPROVED":                 0,
+		"DECLINED":                 0,
+		"DELIVERY_ERROR":           0,
+		"GOING":                    0,
+		"INTERESTED":               0,
+		"MAYBE":                    0,
+		"PENDING_APPROVAL":         0,
+		"READY_TO_SEND":            0,
+		"REJECTED":                 0,
+		"RESPONDED_TO_FIND_A_TIME": 0,
+		"SENDING":                  0,
+		"SEND_ERROR":               0,
+		"SENT":                     0,
+		"WAITLIST":                 0,
+		"WAITLISTED_FOR_APPROVAL":  0,
+		"WITHDRAWN":                0,
+	}
+}
+
+func defaultCreateDisplaySettings() remote.EventDisplaySettings {
+	return remote.EventDisplaySettings{Theme: "cloudflow", Effect: "fireflies", TitleFont: "display"}
+}

--- a/internal/app/events_write_test.go
+++ b/internal/app/events_write_test.go
@@ -499,6 +499,27 @@ func TestExecuteEventUpdateBindsAbsentCustomFields(t *testing.T) {
 	}
 }
 
+func TestExecuteEventUpdateAllowsIrrelevantNullGuestCount(t *testing.T) {
+	files := &memoryFilesystem{files: map[string][]byte{
+		eventWriteCredentialsPath: []byte(eventWriteCredentials),
+	}}
+	dependencies := eventWriteDependencies(files)
+	dependencies.MutationRandom = strings.NewReader(strings.Repeat("n", 32))
+	event := compatibleUpdateEvent()
+	event["guestCount"] = nil
+	dependencies.HTTP = scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+		assertEventCallableRequest(t, request, "getEventInfo", `{"data":{"params":{"eventId":"event-example"},"amplitudeDeviceId":"MDEyMzQ1Njc4OWFiY2RlZg"}}`)
+		return jsonResponse(http.StatusOK, eventResponse(t, event)), nil
+	}}
+
+	result := app.Execute(context.Background(), app.Request{
+		Argv: []string{"events", "update", "event-example", "--title", "Updated title"},
+	}, dependencies)
+	if result.ExitCode != 0 {
+		t.Fatalf("result = %#v, want irrelevant null guest count accepted", result)
+	}
+}
+
 func TestExecuteEventCancelRequiresConfirmAndAppliesConsequentialPlan(t *testing.T) {
 	files := &memoryFilesystem{files: map[string][]byte{
 		eventWriteCredentialsPath: []byte(eventWriteCredentials),
@@ -605,6 +626,29 @@ func TestExecuteEventCancelFailsClosedOnMalformedFactsAndSubmissionUncertainty(t
 				t.Fatalf("reused = %#v, want stale consumed plan", reused)
 			}
 		})
+	}
+}
+
+func TestExecuteEventCancelPreservesPrettyFailureMetadata(t *testing.T) {
+	files := &memoryFilesystem{files: map[string][]byte{
+		eventWriteCredentialsPath: []byte(eventWriteCredentials),
+	}}
+	dependencies := eventWriteDependencies(files)
+	event := compatibleCancelEvent()
+	event["startDate"] = "not-a-timestamp"
+	dependencies.HTTP = scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+		assertEventCallableRequest(t, request, "getEventInfo", `{"data":{"params":{"eventId":"event-example"},"amplitudeDeviceId":"MDEyMzQ1Njc4OWFiY2RlZg"}}`)
+		return jsonResponse(http.StatusOK, eventResponse(t, event)), nil
+	}}
+
+	result := app.Execute(context.Background(), app.Request{
+		Argv: []string{"--pretty", "events", "cancel", "event-example"},
+	}, dependencies)
+	if result.ExitCode != 9 ||
+		!strings.Contains(result.Stdout, `"code": "EVENT_CANCEL_PROTOCOL_CHANGED"`) ||
+		!strings.Contains(result.Stdout, `"command": "events.cancel"`) ||
+		!strings.Contains(result.Stdout, "\n  \"error\"") {
+		t.Fatalf("result = %#v, want pretty cancel protocol failure", result)
 	}
 }
 

--- a/internal/app/events_write_test.go
+++ b/internal/app/events_write_test.go
@@ -1,0 +1,561 @@
+package app_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KalebCole/partiful-cli/internal/app"
+)
+
+const (
+	eventWriteCredentialsPath = "/config/partiful/credentials.json"
+	eventWriteMutationPath    = "/config/partiful/mutation-plans.json"
+	eventWriteCredentials     = `{"accessToken":"private-access-token","userId":"private-account","expiresAt":"2026-08-12T02:00:00Z"}`
+)
+
+func eventWriteDependencies(files *memoryFilesystem) app.Dependencies {
+	return app.Dependencies{
+		Files:           files,
+		CredentialsPath: eventWriteCredentialsPath,
+		MutationPath:    eventWriteMutationPath,
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 12, 0, 0, 0, 0, time.UTC)
+		},
+		AuthRandom: strings.NewReader(strings.Repeat("0123456789abcdef", 8)),
+	}
+}
+
+func eventResponse(t *testing.T, event map[string]any) string {
+	t.Helper()
+	body, err := json.Marshal(map[string]any{
+		"result": map[string]any{
+			"data": map[string]any{
+				"event": event,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("encode event response: %v", err)
+	}
+	return string(body)
+}
+
+func compatibleUpdateEvent() map[string]any {
+	return map[string]any{
+		"id":                    "event-example",
+		"title":                 "Current title",
+		"description":           "Current description",
+		"startDate":             "2026-09-12T19:00:00Z",
+		"endDate":               "2026-09-12T22:00:00Z",
+		"timezone":              "America/Los_Angeles",
+		"status":                "PUBLISHED",
+		"ownerIds":              []string{"private-account"},
+		"rsvpsEnabled":          true,
+		"atCapacity":            false,
+		"plusOneNamesRequired":  false,
+		"questionnaireVersions": nil,
+		"hasGuests":             false,
+		"ticketing":             nil,
+	}
+}
+
+func compatibleCancelEvent() map[string]any {
+	event := compatibleUpdateEvent()
+	event["guestCount"] = 12
+	event["startDate"] = "2026-09-12T19:00:00Z"
+	return event
+}
+
+func assertEventCallableRequest(t *testing.T, request *http.Request, operation, body string) {
+	t.Helper()
+	if request.Method != http.MethodPost || request.URL.String() != "https://api.partiful.com/"+operation {
+		t.Fatalf("request = %s %s, want %s", request.Method, request.URL, operation)
+	}
+	document, err := io.ReadAll(request.Body)
+	if err != nil {
+		t.Fatalf("read request body: %v", err)
+	}
+	if string(document) != body {
+		t.Fatalf("request body = %s, want %s", document, body)
+	}
+}
+
+func TestExecuteEventCreatePlansExactNormalizedRequestAndDefaultPoster(t *testing.T) {
+	files := &memoryFilesystem{files: map[string][]byte{
+		eventWriteCredentialsPath: []byte(eventWriteCredentials),
+	}}
+	dependencies := eventWriteDependencies(files)
+	dependencies.MutationRandom = strings.NewReader(strings.Repeat("c", 32))
+	requestCount := 0
+	dependencies.HTTP = scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+		requestCount++
+		if request.Method != http.MethodGet || request.URL.String() != "https://assets.getpartiful.com/posters.json" {
+			t.Fatalf("request = %s %s, want poster catalog", request.Method, request.URL)
+		}
+		return jsonResponse(http.StatusOK, `[{"id":"Let's Party","url":"https://assets.getpartiful.com/posters/Let's%20Party","name":"Let's Party","tags":["party"],"categories":["party"],"contentType":"image/jpeg","height":2000,"width":2000}]`), nil
+	}}
+
+	result := app.Execute(context.Background(), app.Request{
+		Argv: []string{
+			"events", "create",
+			"--title", "  Example event  ",
+			"--start", "2026-09-12T19:00:00-07:00",
+			"--end", "2026-09-12T22:00:00-07:00",
+			"--timezone", "America/Los_Angeles",
+			"--description", "  Bring snacks  ",
+			"--location", "  Sunset roof  ",
+			"--guest-limit", "75",
+			"--link", "Tickets=https://example.test/tickets",
+		},
+	}, dependencies)
+
+	if result.ExitCode != 0 || result.Stderr != "" {
+		t.Fatalf("result = %#v, want create plan", result)
+	}
+	var envelope struct {
+		Data struct {
+			Operation string `json:"operation"`
+			Input     struct {
+				Title       string `json:"title"`
+				Start       string `json:"start"`
+				End         string `json:"end"`
+				Timezone    string `json:"timezone"`
+				Description string `json:"description"`
+				Location    string `json:"location"`
+				Visibility  string `json:"visibility"`
+				GuestLimit  int    `json:"guestLimit"`
+				PosterID    string `json:"posterId"`
+				Links       []struct {
+					Label string `json:"label"`
+					URL   string `json:"url"`
+				} `json:"links"`
+			} `json:"input"`
+			Request struct {
+				Event     map[string]any `json:"event"`
+				CohostIDs []string       `json:"cohostIds"`
+			} `json:"request"`
+			Preconditions struct {
+				Poster string `json:"poster"`
+			} `json:"preconditions"`
+			ExpiresInSeconds int    `json:"expiresInSeconds"`
+			PlanToken        string `json:"planToken"`
+		} `json:"data"`
+	}
+	if json.Unmarshal([]byte(result.Stdout), &envelope) != nil {
+		t.Fatalf("decode result: %s", result.Stdout)
+	}
+	if envelope.Data.Operation != "createEvent" ||
+		envelope.Data.Input.Title != "Example event" ||
+		envelope.Data.Input.Start != "2026-09-12T19:00:00-07:00" ||
+		envelope.Data.Input.End != "2026-09-12T22:00:00-07:00" ||
+		envelope.Data.Input.Timezone != "America/Los_Angeles" ||
+		envelope.Data.Input.Description != "Bring snacks" ||
+		envelope.Data.Input.Location != "Sunset roof" ||
+		envelope.Data.Input.Visibility != "private" ||
+		envelope.Data.Input.GuestLimit != 75 ||
+		envelope.Data.Input.PosterID != "Let's Party" ||
+		!reflect.DeepEqual(envelope.Data.Input.Links, []struct {
+			Label string `json:"label"`
+			URL   string `json:"url"`
+		}{{Label: "Tickets", URL: "https://example.test/tickets"}}) ||
+		envelope.Data.Preconditions.Poster != "bound" ||
+		envelope.Data.ExpiresInSeconds != 300 ||
+		envelope.Data.PlanToken == "" {
+		t.Fatalf("plan = %#v, want normalized create plan", envelope.Data)
+	}
+	if !reflect.DeepEqual(envelope.Data.Request.CohostIDs, []string{}) {
+		t.Fatalf("cohost ids = %#v, want empty list", envelope.Data.Request.CohostIDs)
+	}
+	if event := envelope.Data.Request.Event; event["status"] != "UNSAVED" || event["visibility"] != "public" || event["rsvpButtonGlyphType"] != "emojis" {
+		t.Fatalf("request event = %#v, want reviewed defaults", event)
+	}
+	for _, privateValue := range []string{"private-access-token", "private-account"} {
+		if strings.Contains(result.Stdout+result.Stderr, privateValue) {
+			t.Fatalf("output exposed private value %q", privateValue)
+		}
+	}
+	if requestCount != 1 || files.atomicWrites != 1 {
+		t.Fatalf("request count = %d atomic writes = %d, want one catalog read and one plan write", requestCount, files.atomicWrites)
+	}
+}
+
+func TestExecuteEventCreateConsumesPlanBeforeOneAttemptAndReturnsSubmittedOnly(t *testing.T) {
+	files := &memoryFilesystem{files: map[string][]byte{
+		eventWriteCredentialsPath: []byte(eventWriteCredentials),
+	}}
+	dependencies := eventWriteDependencies(files)
+	dependencies.MutationRandom = strings.NewReader(strings.Repeat("a", 32))
+	call := 0
+	catalogBody := `[{
+		"id":"birthdaycake.png",
+		"url":"https://assets.getpartiful.com/posters/birthdaycake.png",
+		"name":"Birthday Cake",
+		"tags":["birthday"],
+		"categories":["birthday"],
+		"blurHash":"LKO2?U%2Tw=w]~RBVZRi};RPxuwH",
+		"contentType":"image/png",
+		"height":1200,
+		"width":800
+	}]`
+	dependencies.HTTP = scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+		call++
+		switch call {
+		case 1, 2:
+			if request.Method != http.MethodGet || request.URL.String() != "https://assets.getpartiful.com/posters.json" {
+				t.Fatalf("request = %s %s, want poster catalog", request.Method, request.URL)
+			}
+			return jsonResponse(http.StatusOK, catalogBody), nil
+		case 3:
+			assertEventCallableRequest(t, request, "createEvent", `{"data":{"params":{"event":{"title":"Example event","startDate":"2026-09-13T02:00:00Z","timezone":"America/Los_Angeles","guestStatusCounts":{"APPROVED":0,"DECLINED":0,"DELIVERY_ERROR":0,"GOING":0,"INTERESTED":0,"MAYBE":0,"PENDING_APPROVAL":0,"READY_TO_SEND":0,"REJECTED":0,"RESPONDED_TO_FIND_A_TIME":0,"SENDING":0,"SEND_ERROR":0,"SENT":0,"WAITLIST":0,"WAITLISTED_FOR_APPROVAL":0,"WITHDRAWN":0},"displaySettings":{"theme":"cloudflow","effect":"fireflies","titleFont":"display"},"status":"UNSAVED","rsvpButtonGlyphType":"emojis","image":{"source":"partiful_posters","poster":{"id":"birthdaycake.png","name":"Birthday Cake","url":"https://assets.getpartiful.com/posters/birthdaycake.png","blurHash":"LKO2?U%2Tw=w]~RBVZRi};RPxuwH","contentType":"image/png","height":1200,"width":800,"tags":["birthday"],"categories":["birthday"]},"url":"https://assets.getpartiful.com/posters/birthdaycake.png","blurHash":"LKO2?U%2Tw=w]~RBVZRi};RPxuwH","contentType":"image/png","name":"Birthday Cake","height":1200,"width":800},"showHostList":true,"showGuestCount":true,"showGuestList":true,"showActivityTimestamps":true,"displayInviteButton":true,"visibility":"public","allowGuestPhotoUpload":true,"enableGuestReminders":true,"rsvpsEnabled":true,"allowGuestsToInviteMutuals":true},"cohostIds":[]},"userId":"private-account"}}`)
+			return jsonResponse(http.StatusOK, `{"data":"private-event-id"}`), nil
+		default:
+			t.Fatalf("unexpected request %d: %s", call, request.URL)
+			return nil, nil
+		}
+	}}
+	argv := []string{
+		"events", "create",
+		"--title", "Example event",
+		"--start", "2026-09-12T19:00:00-07:00",
+		"--timezone", "America/Los_Angeles",
+		"--poster-id", "birthdaycake.png",
+	}
+	plan := app.Execute(context.Background(), app.Request{Argv: argv}, dependencies)
+	if plan.ExitCode != 0 {
+		t.Fatalf("plan = %#v", plan)
+	}
+	token := rsvpPlanToken(t, plan)
+	applied := app.Execute(context.Background(), app.Request{Argv: append(append([]string{}, argv...), "--apply", "--plan", token)}, dependencies)
+	if applied.ExitCode != 0 ||
+		!strings.Contains(applied.Stdout, `"data":{"submitted":true}`) ||
+		strings.Contains(applied.Stdout, "private-event-id") ||
+		applied.Stderr != "" {
+		t.Fatalf("applied = %#v, want submitted-only create result", applied)
+	}
+	reused := app.Execute(context.Background(), app.Request{Argv: append(append([]string{}, argv...), "--apply", "--plan", token)}, dependencies)
+	if reused.ExitCode != 7 || !strings.Contains(reused.Stdout, `"type":"safety.plan_stale"`) {
+		t.Fatalf("reused = %#v, want stale plan after one attempt", reused)
+	}
+}
+
+func TestExecuteEventCreateFailsClosedOnMalformedCompletionAndExpiredPlan(t *testing.T) {
+	files := &memoryFilesystem{files: map[string][]byte{
+		eventWriteCredentialsPath: []byte(eventWriteCredentials),
+	}}
+	dependencies := eventWriteDependencies(files)
+	dependencies.MutationRandom = strings.NewReader(strings.Repeat("e", 32))
+	call := 0
+	dependencies.HTTP = scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+		call++
+		switch call {
+		case 1, 2:
+			if request.Method != http.MethodGet || request.URL.String() != "https://assets.getpartiful.com/posters.json" {
+				t.Fatalf("request = %s %s, want poster catalog", request.Method, request.URL)
+			}
+			return jsonResponse(http.StatusOK, `[{"id":"birthdaycake.png","url":"https://assets.getpartiful.com/posters/birthdaycake.png","name":"Birthday Cake","tags":["birthday"],"categories":["birthday"],"contentType":"image/png","height":1200,"width":800}]`), nil
+		case 3:
+			assertEventCallableRequest(t, request, "createEvent", `{"data":{"params":{"event":{"title":"Example event","startDate":"2026-09-13T02:00:00Z","timezone":"America/Los_Angeles","guestStatusCounts":{"APPROVED":0,"DECLINED":0,"DELIVERY_ERROR":0,"GOING":0,"INTERESTED":0,"MAYBE":0,"PENDING_APPROVAL":0,"READY_TO_SEND":0,"REJECTED":0,"RESPONDED_TO_FIND_A_TIME":0,"SENDING":0,"SEND_ERROR":0,"SENT":0,"WAITLIST":0,"WAITLISTED_FOR_APPROVAL":0,"WITHDRAWN":0},"displaySettings":{"theme":"cloudflow","effect":"fireflies","titleFont":"display"},"status":"UNSAVED","rsvpButtonGlyphType":"emojis","image":{"source":"partiful_posters","poster":{"id":"birthdaycake.png","name":"Birthday Cake","url":"https://assets.getpartiful.com/posters/birthdaycake.png","contentType":"image/png","height":1200,"width":800,"tags":["birthday"],"categories":["birthday"]},"url":"https://assets.getpartiful.com/posters/birthdaycake.png","blurHash":null,"contentType":"image/png","name":"Birthday Cake","height":1200,"width":800},"showHostList":true,"showGuestCount":true,"showGuestList":true,"showActivityTimestamps":true,"displayInviteButton":true,"visibility":"public","allowGuestPhotoUpload":true,"enableGuestReminders":true,"rsvpsEnabled":true,"allowGuestsToInviteMutuals":true},"cohostIds":[]},"userId":"private-account"}}`)
+			return jsonResponse(http.StatusOK, `{"unexpected":true}`), nil
+		default:
+			t.Fatalf("unexpected request %d", call)
+			return nil, nil
+		}
+	}}
+	argv := []string{"events", "create", "--title", "Example event", "--start", "2026-09-12T19:00:00-07:00", "--timezone", "America/Los_Angeles", "--poster-id", "birthdaycake.png"}
+	plan := app.Execute(context.Background(), app.Request{Argv: argv}, dependencies)
+	if plan.ExitCode != 0 {
+		t.Fatalf("plan = %#v", plan)
+	}
+	token := rsvpPlanToken(t, plan)
+	applied := app.Execute(context.Background(), app.Request{Argv: append(append([]string{}, argv...), "--apply", "--plan", token)}, dependencies)
+	if applied.ExitCode != 9 || !strings.Contains(applied.Stdout, `"type":"contract.protocol_changed"`) {
+		t.Fatalf("applied = %#v, want protocol-changed failure", applied)
+	}
+
+	dependencies.Now = func() time.Time {
+		return time.Date(2026, time.August, 12, 0, 6, 0, 0, time.UTC)
+	}
+	expired := app.Execute(context.Background(), app.Request{Argv: append(append([]string{}, argv...), "--apply", "--plan", token)}, dependencies)
+	if expired.ExitCode != 7 || !strings.Contains(expired.Stdout, `"type":"safety.plan_stale"`) {
+		t.Fatalf("expired = %#v, want stale expired plan", expired)
+	}
+}
+
+func TestExecuteEventUpdatePlansSortedFirestorePatchAndStalesOnChangedPreconditions(t *testing.T) {
+	files := &memoryFilesystem{files: map[string][]byte{
+		eventWriteCredentialsPath: []byte(eventWriteCredentials),
+	}}
+	dependencies := eventWriteDependencies(files)
+	dependencies.MutationRandom = strings.NewReader(strings.Repeat("u", 32))
+	call := 0
+	first := compatibleUpdateEvent()
+	second := compatibleUpdateEvent()
+	second["title"] = "Changed elsewhere"
+	dependencies.HTTP = scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+		call++
+		switch call {
+		case 1:
+			assertEventCallableRequest(t, request, "getEventInfo", `{"data":{"params":{"eventId":"event-example"},"amplitudeDeviceId":"MDEyMzQ1Njc4OWFiY2RlZg"}}`)
+			return jsonResponse(http.StatusOK, eventResponse(t, first)), nil
+		case 2:
+			assertEventCallableRequest(t, request, "getEventInfo", `{"data":{"params":{"eventId":"event-example"},"amplitudeDeviceId":"MDEyMzQ1Njc4OWFiY2RlZg"}}`)
+			return jsonResponse(http.StatusOK, eventResponse(t, second)), nil
+		default:
+			t.Fatalf("unexpected request %d: %s", call, request.URL)
+			return nil, nil
+		}
+	}}
+	argv := []string{
+		"events", "update", "event-example",
+		"--title", "Updated title",
+		"--start", "2026-09-12T20:00:00Z",
+		"--timezone", "America/Los_Angeles",
+	}
+	plan := app.Execute(context.Background(), app.Request{Argv: argv}, dependencies)
+	if plan.ExitCode != 0 || !strings.Contains(plan.Stdout, `"fields":["start","timezone","title"]`) {
+		t.Fatalf("plan = %#v, want sorted update fields", plan)
+	}
+	token := rsvpPlanToken(t, plan)
+	applied := app.Execute(context.Background(), app.Request{Argv: append(append([]string{}, argv...), "--apply", "--plan", token)}, dependencies)
+	if applied.ExitCode != 7 || !strings.Contains(applied.Stdout, `"type":"safety.plan_stale"`) {
+		t.Fatalf("applied = %#v, want stale update plan", applied)
+	}
+	if call != 2 {
+		t.Fatalf("request count = %d, want one plan read and one apply read", call)
+	}
+}
+
+func TestExecuteEventUpdateAppliesExactFirestorePatchAndReturnsSubmittedFields(t *testing.T) {
+	files := &memoryFilesystem{files: map[string][]byte{
+		eventWriteCredentialsPath: []byte(eventWriteCredentials),
+	}}
+	dependencies := eventWriteDependencies(files)
+	dependencies.MutationRandom = strings.NewReader(strings.Repeat("p", 32))
+	call := 0
+	dependencies.HTTP = scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+		call++
+		switch call {
+		case 1, 2:
+			assertEventCallableRequest(t, request, "getEventInfo", `{"data":{"params":{"eventId":"event-example"},"amplitudeDeviceId":"MDEyMzQ1Njc4OWFiY2RlZg"}}`)
+			return jsonResponse(http.StatusOK, eventResponse(t, compatibleUpdateEvent())), nil
+		case 3:
+			if request.Method != http.MethodPatch || request.URL.String() != "https://firestore.googleapis.com/v1/projects/getpartiful/databases/(default)/documents/events/event-example?currentDocument.exists=true&updateMask.fieldPaths=description&updateMask.fieldPaths=title&updateMask.fieldPaths=updatedBy" {
+				t.Fatalf("request = %s %s, want reviewed patch request", request.Method, request.URL)
+			}
+			body, err := io.ReadAll(request.Body)
+			if err != nil {
+				t.Fatalf("read request body: %v", err)
+			}
+			const wantBody = `{"fields":{"description":{"stringValue":"Updated description"},"title":{"stringValue":"Updated title"},"updatedBy":{"referenceValue":"projects/getpartiful/databases/(default)/documents/users/private-account"}}}`
+			if string(body) != wantBody {
+				t.Fatalf("request body = %s, want %s", body, wantBody)
+			}
+			return jsonResponse(http.StatusOK, `{"name":"projects/getpartiful/databases/(default)/documents/events/event-example","fields":{"title":{"stringValue":"Updated title"}}}`), nil
+		default:
+			t.Fatalf("unexpected request %d: %s", call, request.URL)
+			return nil, nil
+		}
+	}}
+	argv := []string{"events", "update", "event-example", "--title", "Updated title", "--description", "Updated description"}
+	plan := app.Execute(context.Background(), app.Request{Argv: argv}, dependencies)
+	if plan.ExitCode != 0 || strings.Contains(plan.Stdout, "private-account") {
+		t.Fatalf("plan = %#v, want redacted update plan", plan)
+	}
+	token := rsvpPlanToken(t, plan)
+	applied := app.Execute(context.Background(), app.Request{Argv: append(append([]string{}, argv...), "--apply", "--plan", token)}, dependencies)
+	if applied.ExitCode != 0 ||
+		!strings.Contains(applied.Stdout, `"data":{"eventId":"event-example","fields":["description","title"],"submitted":true}`) ||
+		applied.Stderr != "" {
+		t.Fatalf("applied = %#v, want submitted-only update result", applied)
+	}
+}
+
+func TestExecuteEventUpdateFailsClosedOnMalformedPatchCompletion(t *testing.T) {
+	files := &memoryFilesystem{files: map[string][]byte{
+		eventWriteCredentialsPath: []byte(eventWriteCredentials),
+	}}
+	dependencies := eventWriteDependencies(files)
+	dependencies.MutationRandom = strings.NewReader(strings.Repeat("q", 32))
+	call := 0
+	dependencies.HTTP = scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+		call++
+		switch call {
+		case 1, 2:
+			assertEventCallableRequest(t, request, "getEventInfo", `{"data":{"params":{"eventId":"event-example"},"amplitudeDeviceId":"MDEyMzQ1Njc4OWFiY2RlZg"}}`)
+			return jsonResponse(http.StatusOK, eventResponse(t, compatibleUpdateEvent())), nil
+		case 3:
+			return jsonResponse(http.StatusOK, `{"unexpected":true}`), nil
+		default:
+			t.Fatalf("unexpected request %d", call)
+			return nil, nil
+		}
+	}}
+	argv := []string{"events", "update", "event-example", "--title", "Updated title"}
+	plan := app.Execute(context.Background(), app.Request{Argv: argv}, dependencies)
+	if plan.ExitCode != 0 {
+		t.Fatalf("plan = %#v", plan)
+	}
+	token := rsvpPlanToken(t, plan)
+	applied := app.Execute(context.Background(), app.Request{Argv: append(append([]string{}, argv...), "--apply", "--plan", token)}, dependencies)
+	if applied.ExitCode != 9 || !strings.Contains(applied.Stdout, `"type":"contract.protocol_changed"`) {
+		t.Fatalf("applied = %#v, want protocol-changed failure", applied)
+	}
+}
+
+func TestExecuteEventUpdateRejectsDisallowedFieldsAndInvertedMergedRange(t *testing.T) {
+	files := &memoryFilesystem{files: map[string][]byte{
+		eventWriteCredentialsPath: []byte(eventWriteCredentials),
+	}}
+	dependencies := eventWriteDependencies(files)
+	dependencies.HTTP = scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("must not call HTTP")
+	}}
+	badFlag := app.Execute(context.Background(), app.Request{Argv: []string{"events", "update", "event-example", "--location", "Elsewhere"}}, dependencies)
+	if badFlag.ExitCode != 2 || !strings.Contains(badFlag.Stdout, `"type":"input.invalid"`) {
+		t.Fatalf("bad flag = %#v, want input error", badFlag)
+	}
+
+	dependencies.AuthRandom = strings.NewReader("0123456789abcdef")
+	dependencies.HTTP = scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+		assertEventCallableRequest(t, request, "getEventInfo", `{"data":{"params":{"eventId":"event-example"},"amplitudeDeviceId":"MDEyMzQ1Njc4OWFiY2RlZg"}}`)
+		return jsonResponse(http.StatusOK, eventResponse(t, compatibleUpdateEvent())), nil
+	}}
+	inverted := app.Execute(context.Background(), app.Request{Argv: []string{"events", "update", "event-example", "--end", "2026-09-12T18:00:00Z"}}, dependencies)
+	if inverted.ExitCode != 2 || !strings.Contains(inverted.Stdout, `"code":"EVENT_RANGE_INVALID"`) {
+		t.Fatalf("inverted = %#v, want merged range failure", inverted)
+	}
+}
+
+func TestExecuteEventCancelRequiresConfirmAndAppliesConsequentialPlan(t *testing.T) {
+	files := &memoryFilesystem{files: map[string][]byte{
+		eventWriteCredentialsPath: []byte(eventWriteCredentials),
+	}}
+	dependencies := eventWriteDependencies(files)
+	dependencies.MutationRandom = strings.NewReader(strings.Repeat("k", 32))
+	call := 0
+	dependencies.HTTP = scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+		call++
+		switch call {
+		case 1, 2:
+			assertEventCallableRequest(t, request, "getEventInfo", `{"data":{"params":{"eventId":"event-example"},"amplitudeDeviceId":"MDEyMzQ1Njc4OWFiY2RlZg"}}`)
+			return jsonResponse(http.StatusOK, eventResponse(t, compatibleCancelEvent())), nil
+		case 3:
+			assertEventCallableRequest(t, request, "cancelEvent", `{"data":{"params":{"eventId":"event-example","cancellationMessage":"See you next time","shouldSkipNotifyGuests":true},"userId":"private-account"}}`)
+			return jsonResponse(http.StatusOK, `{"result":true}`), nil
+		default:
+			t.Fatalf("unexpected request %d: %s", call, request.URL)
+			return nil, nil
+		}
+	}}
+	argv := []string{"events", "cancel", "event-example", "--message", "See you next time", "--notify-guests", "false"}
+	plan := app.Execute(context.Background(), app.Request{Argv: argv}, dependencies)
+	if plan.ExitCode != 0 ||
+		!strings.Contains(plan.Stdout, `"eventId":"event-example"`) ||
+		!strings.Contains(plan.Stdout, `"notifyGuests":false`) ||
+		!strings.Contains(plan.Stdout, `"effects"`) {
+		t.Fatalf("plan = %#v, want consequential cancel plan", plan)
+	}
+	missingConfirm := app.Execute(context.Background(), app.Request{Argv: append(append([]string{}, argv...), "--apply")}, dependencies)
+	if missingConfirm.ExitCode != 7 || !strings.Contains(missingConfirm.Stdout, `"type":"safety.confirmation_required"`) {
+		t.Fatalf("missing confirm = %#v, want confirmation-required failure", missingConfirm)
+	}
+	token := rsvpPlanToken(t, plan)
+	applied := app.Execute(context.Background(), app.Request{Argv: append(append([]string{}, argv...), "--apply", "--confirm", token)}, dependencies)
+	if applied.ExitCode != 0 ||
+		!strings.Contains(applied.Stdout, `"data":{"eventId":"event-example","notifyGuests":false,"submitted":true}`) ||
+		applied.Stderr != "" {
+		t.Fatalf("applied = %#v, want submitted-only cancel result", applied)
+	}
+}
+
+func TestExecuteEventCancelFailsClosedOnMalformedFactsAndSubmissionUncertainty(t *testing.T) {
+	files := &memoryFilesystem{files: map[string][]byte{
+		eventWriteCredentialsPath: []byte(eventWriteCredentials),
+	}}
+	dependencies := eventWriteDependencies(files)
+	dependencies.MutationRandom = strings.NewReader(strings.Repeat("m", 32))
+
+	cases := []struct {
+		name     string
+		event    map[string]any
+		httpErr  error
+		exitCode int
+		contains string
+	}{
+		{name: "missing guest count", event: compatibleUpdateEvent(), exitCode: 9, contains: `"type":"contract.protocol_changed"`},
+		{name: "past start", event: func() map[string]any { e := compatibleCancelEvent(); e["startDate"] = "2026-08-11T19:00:00Z"; return e }(), exitCode: 6, contains: `"code":"EVENT_PRECONDITION_FAILED"`},
+		{name: "uncertain submission", httpErr: errors.New("private network"), exitCode: 8, contains: `"type":"remote.unavailable"`},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			call := 0
+			dependencies.HTTP = scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+				call++
+				switch call {
+				case 1:
+					assertEventCallableRequest(t, request, "getEventInfo", `{"data":{"params":{"eventId":"event-example"},"amplitudeDeviceId":"MDEyMzQ1Njc4OWFiY2RlZg"}}`)
+					if testCase.event == nil {
+						return jsonResponse(http.StatusOK, eventResponse(t, compatibleCancelEvent())), nil
+					}
+					return jsonResponse(http.StatusOK, eventResponse(t, testCase.event)), nil
+				case 2:
+					assertEventCallableRequest(t, request, "getEventInfo", `{"data":{"params":{"eventId":"event-example"},"amplitudeDeviceId":"MDEyMzQ1Njc4OWFiY2RlZg"}}`)
+					return jsonResponse(http.StatusOK, eventResponse(t, compatibleCancelEvent())), nil
+				case 3:
+					if testCase.httpErr != nil {
+						return nil, testCase.httpErr
+					}
+					return jsonResponse(http.StatusOK, `{"data":true}`), nil
+				default:
+					t.Fatalf("unexpected request %d", call)
+					return nil, nil
+				}
+			}}
+			argv := []string{"events", "cancel", "event-example"}
+			if testCase.httpErr == nil {
+				result := app.Execute(context.Background(), app.Request{Argv: argv}, dependencies)
+				if result.ExitCode != testCase.exitCode || !strings.Contains(result.Stdout, testCase.contains) {
+					t.Fatalf("result = %#v, want exit %d containing %q", result, testCase.exitCode, testCase.contains)
+				}
+				return
+			}
+			plan := app.Execute(context.Background(), app.Request{Argv: argv}, dependencies)
+			if plan.ExitCode != 0 {
+				t.Fatalf("plan = %#v", plan)
+			}
+			token := rsvpPlanToken(t, plan)
+			applied := app.Execute(context.Background(), app.Request{Argv: append(append([]string{}, argv...), "--apply", "--confirm", token)}, dependencies)
+			if applied.ExitCode != testCase.exitCode || !strings.Contains(applied.Stdout, testCase.contains) {
+				t.Fatalf("applied = %#v, want exit %d containing %q", applied, testCase.exitCode, testCase.contains)
+			}
+			if reused := app.Execute(context.Background(), app.Request{Argv: append(append([]string{}, argv...), "--apply", "--confirm", token)}, dependencies); reused.ExitCode != 7 {
+				t.Fatalf("reused = %#v, want stale consumed plan", reused)
+			}
+		})
+	}
+}
+
+func TestExecuteSchemaIncludesEventWriteCommands(t *testing.T) {
+	result := app.Execute(context.Background(), app.Request{Argv: []string{"schema"}}, app.Dependencies{})
+	var envelope struct {
+		Data struct {
+			Commands []string `json:"commands"`
+		} `json:"data"`
+	}
+	if json.Unmarshal([]byte(result.Stdout), &envelope) != nil || result.ExitCode != 0 {
+		t.Fatalf("schema = %#v", result)
+	}
+	for _, command := range []string{"events.create", "events.update", "events.cancel"} {
+		if !slices.Contains(envelope.Data.Commands, command) {
+			t.Fatalf("commands = %v, want %s", envelope.Data.Commands, command)
+		}
+	}
+}

--- a/internal/app/events_write_test.go
+++ b/internal/app/events_write_test.go
@@ -434,6 +434,71 @@ func TestExecuteEventUpdateRejectsDisallowedFieldsAndInvertedMergedRange(t *test
 	}
 }
 
+func TestExecuteEventWriteRejectsMalformedLinkFlag(t *testing.T) {
+	dependencies := eventWriteDependencies(&memoryFilesystem{files: map[string][]byte{}})
+	dependencies.HTTP = scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("must not call HTTP")
+	}}
+
+	result := app.Execute(context.Background(), app.Request{
+		Argv: []string{"events", "create", "--link", "missing-separator"},
+	}, dependencies)
+	if result.ExitCode != 2 || !strings.Contains(result.Stdout, `"code":"LINKS_INVALID"`) {
+		t.Fatalf("result = %#v, want malformed link input failure", result)
+	}
+}
+
+func TestExecuteEventUpdateFailsClosedWhenMergedRangeNeedsMissingStart(t *testing.T) {
+	files := &memoryFilesystem{files: map[string][]byte{
+		eventWriteCredentialsPath: []byte(eventWriteCredentials),
+	}}
+	dependencies := eventWriteDependencies(files)
+	event := compatibleUpdateEvent()
+	delete(event, "startDate")
+	dependencies.HTTP = scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+		assertEventCallableRequest(t, request, "getEventInfo", `{"data":{"params":{"eventId":"event-example"},"amplitudeDeviceId":"MDEyMzQ1Njc4OWFiY2RlZg"}}`)
+		return jsonResponse(http.StatusOK, eventResponse(t, event)), nil
+	}}
+
+	result := app.Execute(context.Background(), app.Request{
+		Argv: []string{"events", "update", "event-example", "--end", "2026-09-12T23:00:00Z"},
+	}, dependencies)
+	if result.ExitCode != 9 || !strings.Contains(result.Stdout, `"type":"contract.protocol_changed"`) {
+		t.Fatalf("result = %#v, want missing current start protocol failure", result)
+	}
+}
+
+func TestExecuteEventUpdateBindsAbsentCustomFields(t *testing.T) {
+	files := &memoryFilesystem{files: map[string][]byte{
+		eventWriteCredentialsPath: []byte(eventWriteCredentials),
+	}}
+	dependencies := eventWriteDependencies(files)
+	dependencies.MutationRandom = strings.NewReader(strings.Repeat("l", 32))
+	call := 0
+	dependencies.HTTP = scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+		call++
+		event := compatibleUpdateEvent()
+		if call == 2 {
+			event["customFields"] = []any{}
+		}
+		assertEventCallableRequest(t, request, "getEventInfo", `{"data":{"params":{"eventId":"event-example"},"amplitudeDeviceId":"MDEyMzQ1Njc4OWFiY2RlZg"}}`)
+		return jsonResponse(http.StatusOK, eventResponse(t, event)), nil
+	}}
+	argv := []string{"events", "update", "event-example", "--link", "Tickets=https://example.test/tickets"}
+
+	plan := app.Execute(context.Background(), app.Request{Argv: argv}, dependencies)
+	if plan.ExitCode != 0 {
+		t.Fatalf("plan = %#v, want absent target field bound", plan)
+	}
+	token := rsvpPlanToken(t, plan)
+	applied := app.Execute(context.Background(), app.Request{
+		Argv: append(append([]string{}, argv...), "--apply", "--plan", token),
+	}, dependencies)
+	if applied.ExitCode != 7 || !strings.Contains(applied.Stdout, `"type":"safety.plan_stale"`) {
+		t.Fatalf("applied = %#v, want changed target state stale failure", applied)
+	}
+}
+
 func TestExecuteEventCancelRequiresConfirmAndAppliesConsequentialPlan(t *testing.T) {
 	files := &memoryFilesystem{files: map[string][]byte{
 		eventWriteCredentialsPath: []byte(eventWriteCredentials),

--- a/internal/app/execute_test.go
+++ b/internal/app/execute_test.go
@@ -112,7 +112,7 @@ func TestExecuteEventsListProjectsReviewedUpcomingEventWithoutPrompting(t *testi
 		}},
 	})
 
-	const want = `{"ok":true,"data":{"items":[{"eventId":"event-example","title":"Example event","start":"2026-09-12T19:00:00-07:00","end":null,"timezone":"America/Los_Angeles","state":"active","userRole":"host","myRsvp":"going"}]},"meta":{"command":"events.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
+	const want = `{"ok":true,"data":{"items":[{"eventId":"event-example","title":"Example event","start":"2026-09-12T19:00:00-07:00","end":null,"timezone":"America/Los_Angeles","state":"active","userRole":"host","myRsvp":"going"}]},"meta":{"command":"events.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
 	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want reviewed upcoming event projection", result)
 	}
@@ -184,7 +184,7 @@ func TestExecuteEventsListRefreshesAndUsesTokenIdentityWithoutPrompting(t *testi
 		}},
 	})
 
-	const want = `{"ok":true,"data":{"items":[{"eventId":"event-example","title":null,"start":null,"end":null,"timezone":null,"state":null,"userRole":"host","myRsvp":null}]},"meta":{"command":"events.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
+	const want = `{"ok":true,"data":{"items":[{"eventId":"event-example","title":null,"start":null,"end":null,"timezone":null,"state":null,"userRole":"host","myRsvp":null}]},"meta":{"command":"events.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
 	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want refreshed identity projection", result)
 	}
@@ -747,7 +747,7 @@ func TestExecuteEventsGetProjectsReviewedDetailAndNullUnavailableFields(t *testi
 		}},
 	})
 
-	const want = `{"ok":true,"data":{"eventId":"event-example","title":"Example event","start":"2026-09-12T19:00:00-07:00","end":"2026-09-12T22:00:00-07:00","timezone":"America/Los_Angeles","state":"cancelled","userRole":null,"myRsvp":null,"description":null,"location":null,"address":null,"visibility":null,"guestLimit":null,"poster":null,"links":null},"meta":{"command":"events.get","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"eventId":"event-example","title":"Example event","start":"2026-09-12T19:00:00-07:00","end":"2026-09-12T22:00:00-07:00","timezone":"America/Los_Angeles","state":"cancelled","userRole":null,"myRsvp":null,"description":null,"location":null,"address":null,"visibility":null,"guestLimit":null,"poster":null,"links":null},"meta":{"command":"events.get","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want reviewed nullable event detail", result)
 	}
@@ -1115,7 +1115,7 @@ func TestExecutePostersListReturnsFirstLocalPage(t *testing.T) {
 		}},
 	}))
 
-	const want = `{"ok":true,"data":{"items":[{"posterId":"first","name":"First","url":"https://example.invalid/first.png","contentType":"image/png","width":1200,"height":630,"tags":["party"],"categories":["fun"]},{"posterId":"duplicate","name":"Duplicate","url":"https://example.invalid/duplicate.gif","contentType":"image/gif","width":null,"height":null,"tags":["dance"],"categories":[]},{"posterId":"duplicate","name":"Duplicate Again","url":"https://example.invalid/duplicate-2.gif","contentType":"image/gif","width":640,"height":480,"tags":[],"categories":["night"]}]},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
+	const want = `{"ok":true,"data":{"items":[{"posterId":"first","name":"First","url":"https://example.invalid/first.png","contentType":"image/png","width":1200,"height":630,"tags":["party"],"categories":["fun"]},{"posterId":"duplicate","name":"Duplicate","url":"https://example.invalid/duplicate.gif","contentType":"image/gif","width":null,"height":null,"tags":["dance"],"categories":[]},{"posterId":"duplicate","name":"Duplicate Again","url":"https://example.invalid/duplicate-2.gif","contentType":"image/gif","width":640,"height":480,"tags":[],"categories":["night"]}]},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -1521,7 +1521,7 @@ func TestExecutePostersListRejectsCursorWhenPayloadChanges(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, dependencies)
 
-	const want = `{"ok":false,"error":{"type":"state.conflict","code":"CURSOR_SNAPSHOT_CHANGED","message":"The poster catalog changed after this cursor was issued.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"state.conflict","code":"CURSOR_SNAPSHOT_CHANGED","message":"The poster catalog changed after this cursor was issued.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
 	if result.ExitCode != 6 {
 		t.Fatalf("exit code = %d, want 6", result.ExitCode)
 	}
@@ -1666,7 +1666,7 @@ func TestExecutePostersListRejectsUnexpectedSuccessContentType(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
 	const wantStderr = "partiful: poster catalog protocol changed\n"
 	if result.ExitCode != 9 {
 		t.Fatalf("exit code = %d, want 9", result.ExitCode)
@@ -1692,7 +1692,7 @@ func TestExecutePostersListRejectsMalformedCursorBeforeRemoteFailure(t *testing.
 		}},
 	}))
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_INVALID","message":"The cursor is malformed.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_INVALID","message":"The cursor is malformed.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -1747,7 +1747,7 @@ func TestExecutePostersSearchRejectsCursorWithDifferentNormalizedFilter(t *testi
 		Stdin: strings.NewReader(""),
 	}, dependencies)
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_FILTER_MISMATCH","message":"The cursor does not match this command and filters.","retryable":false,"details":{}},"meta":{"command":"posters.search","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_FILTER_MISMATCH","message":"The cursor does not match this command and filters.","retryable":false,"details":{}},"meta":{"command":"posters.search","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -1770,7 +1770,7 @@ func TestExecutePostersListMapsNetworkFailureToRemoteUnavailable(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"remote.unavailable","code":"POSTER_CATALOG_UNAVAILABLE","message":"The poster catalog is unavailable.","retryable":true,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"remote.unavailable","code":"POSTER_CATALOG_UNAVAILABLE","message":"The poster catalog is unavailable.","retryable":true,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
 	const wantStderr = "partiful: poster catalog unavailable\n"
 	if result.ExitCode != 8 {
 		t.Fatalf("exit code = %d, want 8", result.ExitCode)
@@ -1800,7 +1800,7 @@ func TestExecutePostersListFailsClosedOnReceivedNon200(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
 	const wantStderr = "partiful: poster catalog protocol changed\n"
 	if result.ExitCode != 9 {
 		t.Fatalf("exit code = %d, want 9", result.ExitCode)
@@ -1878,7 +1878,7 @@ func TestExecutePostersListFailsClosedOnMalformed200Body(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
 	if result.ExitCode != 9 {
 		t.Fatalf("exit code = %d, want 9", result.ExitCode)
 	}
@@ -1943,7 +1943,7 @@ func TestExecutePostersListRequiresMaxItemsWithAll(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"MAX_ITEMS_REQUIRED","message":"--all requires --max-items.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"MAX_ITEMS_REQUIRED","message":"--all requires --max-items.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -1965,7 +1965,7 @@ func TestExecutePostersListRejectsLimitWithAll(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"LIMIT_WITH_ALL","message":"--limit cannot be combined with --all.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"LIMIT_WITH_ALL","message":"--limit cannot be combined with --all.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -1983,7 +1983,7 @@ func TestExecutePostersListRejectsLimitAboveMaximum(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"LIMIT_INVALID","message":"Limit must be an integer from 1 to 100.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"LIMIT_INVALID","message":"Limit must be an integer from 1 to 100.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -1998,7 +1998,7 @@ func TestExecutePostersListRejectsEmptyCursor(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_INVALID","message":"The cursor is malformed.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_INVALID","message":"The cursor is malformed.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -2016,7 +2016,7 @@ func TestExecutePostersSearchRequiresNonEmptyQuery(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"QUERY_REQUIRED","message":"Search query must not be empty.","retryable":false,"details":{}},"meta":{"command":"posters.search","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"QUERY_REQUIRED","message":"Search query must not be empty.","retryable":false,"details":{}},"meta":{"command":"posters.search","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -2031,7 +2031,7 @@ func TestExecuteVersion(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":true,"data":{"version":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"},"meta":{"command":"version","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"version":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"},"meta":{"command":"version","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -2049,7 +2049,7 @@ func TestExecuteEventsListRequiresWhen(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"WHEN_INVALID","message":"--when must be upcoming or past.","retryable":false,"details":{}},"meta":{"command":"events.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"WHEN_INVALID","message":"--when must be upcoming or past.","retryable":false,"details":{}},"meta":{"command":"events.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -2071,14 +2071,14 @@ func TestExecutePrettyPrintsOneCompleteEnvelope(t *testing.T) {
   "ok": true,
   "data": {
     "version": "1.0.0",
-    "productContractRevision": "2026-08-12.3",
-    "remoteContractRevision": "2026-08-12.3"
+    "productContractRevision": "2026-08-12.4",
+    "remoteContractRevision": "2026-08-12.4"
   },
   "meta": {
     "command": "version",
     "cliVersion": "1.0.0",
-    "productContractRevision": "2026-08-12.3",
-    "remoteContractRevision": "2026-08-12.3",
+    "productContractRevision": "2026-08-12.4",
+    "remoteContractRevision": "2026-08-12.4",
     "warnings": []
   }
 }
@@ -2100,7 +2100,7 @@ func TestExecuteAcceptsNonInteractiveGlobalFlag(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":true,"data":{"version":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"},"meta":{"command":"version","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"version":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"},"meta":{"command":"version","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -2132,8 +2132,8 @@ func TestExecuteRejectsRepeatedScalarFlag(t *testing.T) {
   "meta": {
     "command": "version",
     "cliVersion": "1.0.0",
-    "productContractRevision": "2026-08-12.3",
-    "remoteContractRevision": "2026-08-12.3"
+    "productContractRevision": "2026-08-12.4",
+    "remoteContractRevision": "2026-08-12.4"
   }
 }
 `
@@ -2154,7 +2154,7 @@ func TestExecuteSchemaListsOnlyCompletedCatalog(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":true,"data":{"commands":["auth.login","auth.logout","auth.status","contacts.list","doctor","events.get","events.list","posters.list","posters.search","rsvp.get","rsvp.set","schema","version"]},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"commands":["auth.login","auth.logout","auth.status","contacts.list","doctor","events.cancel","events.create","events.get","events.list","events.update","posters.list","posters.search","rsvp.get","rsvp.set","schema","version"]},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -2172,7 +2172,7 @@ func TestExecuteSchemaProjectsExecutableDefinition(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":true,"data":{"command":"auth.status","positionals":[],"flags":[],"inputSchema":{"type":"object","additionalProperties":false},"successSchema":{"type":"object","additionalProperties":false,"required":["authenticated","tokenState","expiresAt"],"properties":{"authenticated":{"type":"boolean"},"expiresAt":{"type":["string","null"],"format":"date-time"},"tokenState":{"type":"string","enum":["healthy","expiring","expired","missing"]}}},"failureTypes":["usage.invalid","input.invalid","auth.expired","remote.unavailable","contract.protocol_changed","internal.failure"],"safety":{"kind":"local-mutation","planRequired":false,"confirmationRequired":false}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"command":"auth.status","positionals":[],"flags":[],"inputSchema":{"type":"object","additionalProperties":false},"successSchema":{"type":"object","additionalProperties":false,"required":["authenticated","tokenState","expiresAt"],"properties":{"authenticated":{"type":"boolean"},"expiresAt":{"type":["string","null"],"format":"date-time"},"tokenState":{"type":"string","enum":["healthy","expiring","expired","missing"]}}},"failureTypes":["usage.invalid","input.invalid","auth.expired","remote.unavailable","contract.protocol_changed","internal.failure"],"safety":{"kind":"local-mutation","planRequired":false,"confirmationRequired":false}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -2230,7 +2230,7 @@ func TestExecuteRejectsUnknownSchemaPathWithoutEchoingInput(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_SCHEMA_NOT_FOUND","message":"No completed command has that schema path.","retryable":false,"details":{}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_SCHEMA_NOT_FOUND","message":"No completed command has that schema path.","retryable":false,"details":{}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -2261,7 +2261,7 @@ func TestExecuteAuthStatusWhenCredentialsAreMissing(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"missing","expiresAt":null},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"missing","expiresAt":null},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -2279,7 +2279,7 @@ func TestExecuteAuthLoginRequiresPrivateTerminal(t *testing.T) {
 		Stdin: strings.NewReader("private-stdin-value"),
 	}, app.Dependencies{})
 
-	const wantStdout = `{"ok":false,"error":{"type":"auth.human_required","code":"PRIVATE_TERMINAL_REQUIRED","message":"Authentication login requires a private terminal.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"auth.human_required","code":"PRIVATE_TERMINAL_REQUIRED","message":"Authentication login requires a private terminal.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
 	const wantStderr = "partiful: private terminal required\n"
 	if result.ExitCode != 3 {
 		t.Fatalf("exit code = %d, want 3", result.ExitCode)
@@ -2338,7 +2338,7 @@ func TestExecuteAuthLoginRejectsEmptyPrivateInputBeforeHTTP(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"input.invalid","code":"AUTH_INPUT_INVALID","message":"Authentication input is invalid.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"input.invalid","code":"AUTH_INPUT_INVALID","message":"Authentication input is invalid.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
 	if result.ExitCode != 2 || result.Stdout != wantStdout {
 		t.Fatalf("result = %#v, want invalid private input failure", result)
 	}
@@ -2480,7 +2480,7 @@ func TestExecuteAuthLoginPersistsReviewedSessionWithoutRevealingPrivateValues(t 
 		}},
 	})
 
-	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T01:10:00Z"},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T01:10:00Z"},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want redacted login success", result)
 	}
@@ -2553,7 +2553,7 @@ func TestExecuteAuthLoginMapsReviewedWrongCodeWithoutEchoingIt(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"input.invalid","code":"AUTH_CODE_REJECTED","message":"The verification code was rejected.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"input.invalid","code":"AUTH_CODE_REJECTED","message":"The verification code was rejected.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
 	const wantStderr = "partiful: authentication code rejected\n"
 	if result.ExitCode != 2 || result.Stdout != wantStdout || result.Stderr != wantStderr {
 		t.Fatalf("result = %#v, want reviewed wrong-code failure", result)
@@ -2694,7 +2694,7 @@ func TestExecuteAuthLoginMapsRejectedCustomTokenToExpired(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"INVALID_CUSTOM_TOKEN","message":"Authentication expired during login. Start login again.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"INVALID_CUSTOM_TOKEN","message":"Authentication expired during login. Start login again.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
 	const wantStderr = "partiful: authentication expired\n"
 	if result.ExitCode != 3 || result.Stdout != wantStdout || result.Stderr != wantStderr {
 		t.Fatalf("result = %#v, want reviewed custom-token failure", result)
@@ -2881,7 +2881,7 @@ func TestExecuteAuthLoginFailsClosedOnMalformedReviewedSuccess(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"AUTH_PROTOCOL_CHANGED","message":"Authentication no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"AUTH_PROTOCOL_CHANGED","message":"Authentication no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
 	const wantStderr = "partiful: authentication protocol changed\n"
 	if result.ExitCode != 9 || result.Stdout != wantStdout || result.Stderr != wantStderr {
 		t.Fatalf("result = %#v, want protocol drift failure", result)
@@ -2978,7 +2978,7 @@ func TestExecuteAuthLoginMapsNoResponseWithoutLeakingTransportError(t *testing.T
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"remote.unavailable","code":"AUTH_SERVICE_UNAVAILABLE","message":"The authentication service is unavailable.","retryable":true,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"remote.unavailable","code":"AUTH_SERVICE_UNAVAILABLE","message":"The authentication service is unavailable.","retryable":true,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
 	const wantStderr = "partiful: authentication service unavailable\n"
 	if result.ExitCode != 8 || result.Stdout != wantStdout || result.Stderr != wantStderr {
 		t.Fatalf("result = %#v, want auth unavailable failure", result)
@@ -3032,7 +3032,7 @@ func TestExecuteAuthLoginAtomicPersistenceFailurePreservesExistingCredentials(t 
 		Argv: []string{"auth", "login"},
 	}, dependencies)
 
-	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIAL_STORE_UNAVAILABLE","message":"Local credential storage is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIAL_STORE_UNAVAILABLE","message":"Local credential storage is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
 	if result.ExitCode != 10 || result.Stdout != wantStdout {
 		t.Fatalf("result = %#v, want atomic persistence failure", result)
 	}
@@ -3144,7 +3144,7 @@ func TestExecuteContactsListTraversesReviewedPagesAndReturnsOnlyPublicFields(t *
 		}},
 	})
 
-	const want = `{"ok":true,"data":{"items":[{"displayName":"Alice Example","sharedEventCount":2}]},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
+	const want = `{"ok":true,"data":{"items":[{"displayName":"Alice Example","sharedEventCount":2}]},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
 	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want reviewed public contact collection", result)
 	}
@@ -3199,7 +3199,7 @@ func TestExecuteContactsListFiltersLocallyAfterFirstIdentityOccurrenceWins(t *te
 		}},
 	})
 
-	const want = `{"ok":true,"data":{"items":[{"displayName":"Alice First","sharedEventCount":1},{"displayName":"Second ALICE","sharedEventCount":3}]},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
+	const want = `{"ok":true,"data":{"items":[{"displayName":"Alice First","sharedEventCount":1},{"displayName":"Second ALICE","sharedEventCount":3}]},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
 	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want locally filtered first-occurrence contacts", result)
 	}
@@ -3509,7 +3509,7 @@ func TestExecuteContactsListAcceptsOpenReviewedResponseFields(t *testing.T) {
 		}},
 	})
 
-	const want = `{"ok":true,"data":{"items":[{"displayName":"Open Contact","sharedEventCount":4}]},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
+	const want = `{"ok":true,"data":{"items":[{"displayName":"Open Contact","sharedEventCount":4}]},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
 	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want reviewed open response traversal", result)
 	}
@@ -3622,7 +3622,7 @@ func TestExecuteContactsListAcceptsUnknownUnauthenticatedErrorFields(t *testing.
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"REMOTE_SESSION_UNAUTHENTICATED","message":"Stored authentication is no longer accepted. Log in again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"REMOTE_SESSION_UNAUTHENTICATED","message":"Stored authentication is no longer accepted. Log in again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
 	if result.ExitCode != 3 || result.Stdout != wantStdout {
 		t.Fatalf("result = %#v, want reviewed unauthenticated mapping", result)
 	}
@@ -3655,7 +3655,7 @@ func TestExecuteContactsListMapsReviewedUnauthenticatedResponseToExpired(t *test
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"REMOTE_SESSION_UNAUTHENTICATED","message":"Stored authentication is no longer accepted. Log in again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"REMOTE_SESSION_UNAUTHENTICATED","message":"Stored authentication is no longer accepted. Log in again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
 	if result.ExitCode != 3 || result.Stdout != wantStdout {
 		t.Fatalf("result = %#v, want reviewed unauthenticated mapping", result)
 	}
@@ -3791,7 +3791,7 @@ func TestExecuteContactsListRejectsCursorWhenContactCatalogChanges(t *testing.T)
 		Stdin: strings.NewReader(""),
 	}, dependencies)
 
-	const want = `{"ok":false,"error":{"type":"state.conflict","code":"CURSOR_SNAPSHOT_CHANGED","message":"The contact catalog changed after this cursor was issued.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"state.conflict","code":"CURSOR_SNAPSHOT_CHANGED","message":"The contact catalog changed after this cursor was issued.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
 	if result.ExitCode != 6 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want contact snapshot conflict", result)
 	}
@@ -3937,7 +3937,7 @@ func TestExecuteContactsListMapsRejectedRefreshWithoutAttemptingRead(t *testing.
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"INVALID_REFRESH_TOKEN","message":"Stored authentication has expired. Log in again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"INVALID_REFRESH_TOKEN","message":"Stored authentication has expired. Log in again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
 	if result.ExitCode != 3 || result.Stdout != wantStdout {
 		t.Fatalf("result = %#v, want rejected refresh failure", result)
 	}
@@ -3998,7 +3998,7 @@ func TestExecuteContactsListReportsUnavailableConfigurationBeforeProtectedRead(t
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CONFIG_DIRECTORY_UNAVAILABLE","message":"Local configuration directory is unavailable.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CONFIG_DIRECTORY_UNAVAILABLE","message":"Local configuration directory is unavailable.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
 	if result.ExitCode != 10 || result.Stdout != wantStdout {
 		t.Fatalf("result = %#v, want unavailable configuration failure", result)
 	}
@@ -4027,7 +4027,7 @@ func TestExecuteContactsListRequiresAuthenticationWithoutRemoteCall(t *testing.T
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"auth.required","code":"AUTHENTICATION_REQUIRED","message":"Authentication is required. Log in and try again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"auth.required","code":"AUTHENTICATION_REQUIRED","message":"Authentication is required. Log in and try again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
 	if result.ExitCode != 3 || result.Stdout != wantStdout {
 		t.Fatalf("result = %#v, want authentication requirement", result)
 	}
@@ -4178,7 +4178,7 @@ func TestExecuteAuthStatusRedactsHealthyCredentials(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T02:00:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T02:00:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -4212,7 +4212,7 @@ func TestExecuteAuthStatusReportsExpiringToken(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"expiring","expiresAt":"2026-08-11T00:04:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"expiring","expiresAt":"2026-08-11T00:04:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -4287,7 +4287,7 @@ func TestExecuteAuthStatusDeterministicallyRefreshesExpiringSession(t *testing.T
 	first := app.Execute(context.Background(), app.Request{
 		Argv: []string{"auth", "status"},
 	}, dependencies)
-	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T01:10:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T01:10:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[]}}` + "\n"
 	if first.ExitCode != 0 || first.Stdout != want || first.Stderr != "" {
 		t.Fatalf("first status = %#v, want refreshed healthy session", first)
 	}
@@ -4461,7 +4461,7 @@ func TestExecuteAuthStatusMapsReviewedInvalidRefreshTokenToExpired(t *testing.T)
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"INVALID_REFRESH_TOKEN","message":"Stored authentication has expired. Log in again.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"INVALID_REFRESH_TOKEN","message":"Stored authentication has expired. Log in again.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
 	const wantStderr = "partiful: authentication expired\n"
 	if result.ExitCode != 3 || result.Stdout != wantStdout || result.Stderr != wantStderr {
 		t.Fatalf("result = %#v, want reviewed invalid-refresh failure", result)
@@ -4580,7 +4580,7 @@ func TestExecuteAuthStatusReportsExpiredToken(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"expired","expiresAt":"2026-08-10T23:59:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"expired","expiresAt":"2026-08-10T23:59:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -4609,7 +4609,7 @@ func TestExecuteAuthStatusFailureDoesNotRevealCredentialContents(t *testing.T) {
 		},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIALS_INVALID","message":"Local credentials are invalid.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIALS_INVALID","message":"Local credentials are invalid.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
 	const wantStderr = "partiful: local operation failed\n"
 	if result.ExitCode != 10 {
 		t.Fatalf("exit code = %d, want 10", result.ExitCode)
@@ -4645,7 +4645,7 @@ func TestExecuteAuthLogoutAtomicallyRemovesCredentials(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, dependencies)
 
-	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"missing","expiresAt":null},"meta":{"command":"auth.logout","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"missing","expiresAt":null},"meta":{"command":"auth.logout","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -4724,7 +4724,7 @@ func TestExecuteAuthLogoutFailureLeavesCredentialsAvailableAndRedactsError(t *te
 		Stdin: strings.NewReader(""),
 	}, dependencies)
 
-	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIAL_STORE_UNAVAILABLE","message":"Local credential storage is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.logout","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIAL_STORE_UNAVAILABLE","message":"Local credential storage is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.logout","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
 	if result.ExitCode != 10 {
 		t.Fatalf("exit code = %d, want 10", result.ExitCode)
 	}
@@ -4761,7 +4761,7 @@ func TestExecuteDoctorReportsHealthyCredentialsWithoutPrivateData(t *testing.T) 
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":true,"checks":[{"name":"credentials","status":"pass","message":"Authentication credentials are available.","remediation":null}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":true,"checks":[{"name":"credentials","status":"pass","message":"Authentication credentials are available.","remediation":null}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -4794,7 +4794,7 @@ func TestExecuteDoctorReportsMissingCredentialsAsARedactedCheck(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials are missing.","remediation":"Establish authentication before using commands that require it."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials are missing.","remediation":"Establish authentication before using commands that require it."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -4823,7 +4823,7 @@ func TestExecuteDoctorWarnsWhenCredentialsExpireSoon(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":true,"checks":[{"name":"credentials","status":"warn","message":"Authentication credentials expire soon.","remediation":"Refresh authentication before the credentials expire."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":true,"checks":[{"name":"credentials","status":"warn","message":"Authentication credentials expire soon.","remediation":"Refresh authentication before the credentials expire."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -4852,7 +4852,7 @@ func TestExecuteDoctorFailsExpiredCredentialsCheck(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials have expired.","remediation":"Re-establish authentication."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials have expired.","remediation":"Re-establish authentication."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -4881,7 +4881,7 @@ func TestExecuteDoctorRedactsInvalidCredentialFile(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials are invalid.","remediation":"Remove the invalid credentials and re-establish authentication."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials are invalid.","remediation":"Remove the invalid credentials and re-establish authentication."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -4913,7 +4913,7 @@ func TestExecuteDoctorRedactsCredentialStorageFailure(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Credential storage is unavailable.","remediation":"Check local credential file permissions."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Credential storage is unavailable.","remediation":"Check local credential file permissions."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -5021,7 +5021,7 @@ func TestExecuteUsesDefinitionForFlagFailureCommandMetadata(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"FLAG_REPEATED","message":"A scalar flag cannot be repeated.","retryable":false,"details":{"flag":"--non-interactive"}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"FLAG_REPEATED","message":"A scalar flag cannot be repeated.","retryable":false,"details":{"flag":"--non-interactive"}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -5065,7 +5065,7 @@ func TestExecuteUsesKnownCommandMetadataForInvalidArity(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_NOT_FOUND","message":"Unknown command.","retryable":false,"details":{}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_NOT_FOUND","message":"Unknown command.","retryable":false,"details":{}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -5090,7 +5090,7 @@ func TestExecuteAuthStatusReportsConfigurationDirectoryFailure(t *testing.T) {
 		},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CONFIG_DIRECTORY_UNAVAILABLE","message":"Local configuration directory is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CONFIG_DIRECTORY_UNAVAILABLE","message":"Local configuration directory is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
 	if result.ExitCode != 10 {
 		t.Fatalf("exit code = %d, want 10", result.ExitCode)
 	}
@@ -5115,7 +5115,7 @@ func TestExecuteDoctorDiagnosesConfigurationDirectoryFailure(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Configuration directory is unavailable.","remediation":"Set a usable user configuration directory."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.3","remoteContractRevision":"2026-08-12.3","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Configuration directory is unavailable.","remediation":"Set a usable user configuration directory."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}

--- a/internal/app/execute_test.go
+++ b/internal/app/execute_test.go
@@ -4997,7 +4997,7 @@ func TestExecuteSchemaDescribesBothDiscoveryResultShapes(t *testing.T) {
 						"additionalProperties": false,
 						"required": ["kind", "planRequired", "confirmationRequired"],
 						"properties": {
-							"kind": {"type": "string", "enum": ["read-only", "local-mutation", "standard-mutation"]},
+							"kind": {"type": "string", "enum": ["read-only", "local-mutation", "standard-mutation", "consequential-action"]},
 							"planRequired": {"type": "boolean"},
 							"confirmationRequired": {"type": "boolean"}
 						}

--- a/internal/remote/event_writes.go
+++ b/internal/remote/event_writes.go
@@ -1,0 +1,496 @@
+package remote
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"sort"
+	"time"
+	"unicode/utf8"
+)
+
+const (
+	firestoreDocumentsHost     = "https://firestore.googleapis.com"
+	maximumEventWriteBodyBytes = 1 << 20
+)
+
+var firestoreIntegerPattern = regexp.MustCompile(`^-?[0-9]+$`)
+
+type PartifulPoster struct {
+	ID          string   `json:"id"`
+	Name        string   `json:"name"`
+	URL         string   `json:"url"`
+	BlurHash    *string  `json:"blurHash,omitempty"`
+	ContentType string   `json:"contentType"`
+	Height      *int     `json:"height"`
+	Width       *int     `json:"width"`
+	Tags        []string `json:"tags"`
+	Categories  []string `json:"categories"`
+}
+
+type PartifulPosterImage struct {
+	Source      string         `json:"source"`
+	Poster      PartifulPoster `json:"poster"`
+	URL         string         `json:"url"`
+	BlurHash    *string        `json:"blurHash"`
+	ContentType string         `json:"contentType"`
+	Name        string         `json:"name"`
+	Height      *int           `json:"height"`
+	Width       *int           `json:"width"`
+}
+
+type EventDisplaySettings struct {
+	Theme     string `json:"theme"`
+	Effect    string `json:"effect"`
+	TitleFont string `json:"titleFont"`
+}
+
+type EventLocationInfo struct {
+	Type  string `json:"type"`
+	Value string `json:"value"`
+}
+
+type EventCustomField struct {
+	Icon  string `json:"icon"`
+	Value string `json:"value"`
+	URL   string `json:"url"`
+}
+
+type CreateEventDraft struct {
+	Title                      string               `json:"title"`
+	StartDate                  string               `json:"startDate"`
+	EndDate                    *string              `json:"endDate,omitempty"`
+	Timezone                   string               `json:"timezone"`
+	GuestStatusCounts          map[string]int       `json:"guestStatusCounts"`
+	DisplaySettings            EventDisplaySettings `json:"displaySettings"`
+	Status                     string               `json:"status"`
+	RSVPButtonGlyphType        string               `json:"rsvpButtonGlyphType"`
+	Image                      PartifulPosterImage  `json:"image"`
+	ShowHostList               bool                 `json:"showHostList"`
+	ShowGuestCount             bool                 `json:"showGuestCount"`
+	ShowGuestList              bool                 `json:"showGuestList"`
+	ShowActivityTimestamps     bool                 `json:"showActivityTimestamps"`
+	DisplayInviteButton        bool                 `json:"displayInviteButton"`
+	Visibility                 string               `json:"visibility"`
+	AllowGuestPhotoUpload      bool                 `json:"allowGuestPhotoUpload"`
+	EnableGuestReminders       bool                 `json:"enableGuestReminders"`
+	RSVPsEnabled               bool                 `json:"rsvpsEnabled"`
+	AllowGuestsToInviteMutuals bool                 `json:"allowGuestsToInviteMutuals"`
+	Description                *string              `json:"description,omitempty"`
+	LocationInfo               *EventLocationInfo   `json:"locationInfo,omitempty"`
+	IsPublic                   *bool                `json:"isPublic,omitempty"`
+	MaxCapacity                *int                 `json:"maxCapacity,omitempty"`
+	EnableWaitlist             *bool                `json:"enableWaitlist,omitempty"`
+	CustomFields               []EventCustomField   `json:"customFields,omitempty"`
+}
+
+type CreateEventParams struct {
+	Event     CreateEventDraft `json:"event"`
+	CohostIDs []string         `json:"cohostIds"`
+}
+
+type CancelEventParams struct {
+	EventID                string `json:"eventId"`
+	CancellationMessage    string `json:"cancellationMessage"`
+	ShouldSkipNotifyGuests bool   `json:"shouldSkipNotifyGuests"`
+}
+
+type callableMutationRequest[T any] struct {
+	Data callableMutationRequestData[T] `json:"data"`
+}
+
+type callableMutationRequestData[T any] struct {
+	Params T   `json:"params"`
+	UserID any `json:"userId"`
+}
+
+type FirestoreWriteDocument struct {
+	Fields map[string]any `json:"fields"`
+}
+
+type FirestoreStringValue struct {
+	StringValue string `json:"stringValue"`
+}
+
+type FirestoreIntegerValue struct {
+	IntegerValue string `json:"integerValue"`
+}
+
+type FirestoreBooleanValue struct {
+	BooleanValue bool `json:"booleanValue"`
+}
+
+type FirestoreReferenceValue struct {
+	ReferenceValue string `json:"referenceValue"`
+}
+
+type FirestoreArray struct {
+	Values []any `json:"values"`
+}
+
+type FirestoreArrayValue struct {
+	ArrayValue FirestoreArray `json:"arrayValue"`
+}
+
+type FirestoreMap struct {
+	Fields map[string]any `json:"fields"`
+}
+
+type FirestoreMapValue struct {
+	MapValue FirestoreMap `json:"mapValue"`
+}
+
+func NewPartifulPosterImage(poster Poster) PartifulPosterImage {
+	catalogRecord := PartifulPoster{
+		ID:          poster.ID,
+		Name:        poster.Name,
+		URL:         poster.URL,
+		BlurHash:    poster.BlurHash,
+		ContentType: poster.ContentType,
+		Height:      poster.Height,
+		Width:       poster.Width,
+		Tags:        append([]string(nil), poster.Tags...),
+		Categories:  append([]string(nil), poster.Categories...),
+	}
+	return PartifulPosterImage{
+		Source:      "partiful_posters",
+		Poster:      catalogRecord,
+		URL:         poster.URL,
+		BlurHash:    poster.BlurHash,
+		ContentType: poster.ContentType,
+		Name:        poster.Name,
+		Height:      poster.Height,
+		Width:       poster.Width,
+	}
+}
+
+func (client Client) CreateEvent(
+	ctx context.Context,
+	accessToken string,
+	userID string,
+	params CreateEventParams,
+) (string, error) {
+	completion, err := callEventMutation(client, ctx, accessToken, "createEvent", userID, params)
+	if err != nil {
+		return "", err
+	}
+	var eventID string
+	if json.Unmarshal(completion, &eventID) != nil || eventID == "" {
+		return "", fmt.Errorf("%w: create event completion", ErrProtocolChanged)
+	}
+	return eventID, nil
+}
+
+func (client Client) CancelEvent(
+	ctx context.Context,
+	accessToken string,
+	userID string,
+	params CancelEventParams,
+) error {
+	_, err := callEventMutation(client, ctx, accessToken, "cancelEvent", userID, params)
+	return err
+}
+
+func callEventMutation[T any](
+	client Client,
+	ctx context.Context,
+	accessToken string,
+	operation string,
+	userID string,
+	params T,
+) (json.RawMessage, error) {
+	if client.HTTP == nil {
+		return nil, fmt.Errorf("%w: event write transport", ErrUnavailable)
+	}
+	var encodedUserID any
+	if userID != "" {
+		encodedUserID = userID
+	}
+	payload, _ := json.Marshal(callableMutationRequest[T]{
+		Data: callableMutationRequestData[T]{
+			Params: params,
+			UserID: encodedUserID,
+		},
+	})
+	request, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		partifulCallableHost+"/"+operation,
+		bytes.NewReader(payload),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("%w: event write request", ErrUnavailable)
+	}
+	request.Header.Set("Authorization", "Bearer "+accessToken)
+	request.Header.Set("Content-Type", "application/json")
+	response, err := client.HTTP.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("%w: event write request failed", ErrUnavailable)
+	}
+	if response == nil || response.Body == nil {
+		return nil, fmt.Errorf("%w: event write response", ErrProtocolChanged)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%w: event write status", ErrProtocolChanged)
+	}
+	if !eventJSONContentType(response.Header.Get("Content-Type")) {
+		return nil, fmt.Errorf("%w: event write content type", ErrProtocolChanged)
+	}
+	body, err := io.ReadAll(io.LimitReader(response.Body, maximumEventWriteBodyBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("%w: event write response read", ErrUnavailable)
+	}
+	if len(body) > maximumEventWriteBodyBytes || !utf8.Valid(body) {
+		return nil, fmt.Errorf("%w: event write response body", ErrProtocolChanged)
+	}
+	root, err := decodeEventObject(body)
+	if err != nil {
+		return nil, fmt.Errorf("%w: event write response body", ErrProtocolChanged)
+	}
+	if data, ok := root["data"]; ok {
+		return bytes.Clone(data), nil
+	}
+	if result, ok := root["result"]; ok {
+		return bytes.Clone(result), nil
+	}
+	return nil, fmt.Errorf("%w: event write completion", ErrProtocolChanged)
+}
+
+func (client Client) FirestorePatchEvent(
+	ctx context.Context,
+	accessToken string,
+	eventID string,
+	updateMask []string,
+	document FirestoreWriteDocument,
+) error {
+	if client.HTTP == nil {
+		return fmt.Errorf("%w: firestore transport", ErrUnavailable)
+	}
+	payload, _ := json.Marshal(document)
+	query := url.Values{}
+	query.Set("currentDocument.exists", "true")
+	for _, fieldPath := range updateMask {
+		query.Add("updateMask.fieldPaths", fieldPath)
+	}
+	request, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPatch,
+		firestoreDocumentsHost+"/v1/projects/getpartiful/databases/(default)/documents/events/"+url.PathEscape(eventID)+"?"+query.Encode(),
+		bytes.NewReader(payload),
+	)
+	if err != nil {
+		return fmt.Errorf("%w: firestore request", ErrUnavailable)
+	}
+	request.Header.Set("Authorization", "Bearer "+accessToken)
+	request.Header.Set("Content-Type", "application/json")
+	response, err := client.HTTP.Do(request)
+	if err != nil {
+		return fmt.Errorf("%w: firestore request failed", ErrUnavailable)
+	}
+	if response == nil || response.Body == nil {
+		return fmt.Errorf("%w: firestore response", ErrProtocolChanged)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("%w: firestore status", ErrProtocolChanged)
+	}
+	if !eventJSONContentType(response.Header.Get("Content-Type")) {
+		return fmt.Errorf("%w: firestore content type", ErrProtocolChanged)
+	}
+	body, err := io.ReadAll(io.LimitReader(response.Body, maximumEventWriteBodyBytes+1))
+	if err != nil {
+		return fmt.Errorf("%w: firestore response read", ErrUnavailable)
+	}
+	if len(body) > maximumEventWriteBodyBytes || !utf8.Valid(body) {
+		return fmt.Errorf("%w: firestore response body", ErrProtocolChanged)
+	}
+	if err := validateFirestoreDocument(body); err != nil {
+		return fmt.Errorf("%w: firestore document", ErrProtocolChanged)
+	}
+	return nil
+}
+
+func validateFirestoreDocument(body []byte) error {
+	root, err := decodeEventObject(body)
+	if err != nil {
+		return err
+	}
+	allowed := map[string]bool{
+		"name":       true,
+		"fields":     true,
+		"createTime": true,
+		"updateTime": true,
+	}
+	for key := range root {
+		if !allowed[key] {
+			return fmt.Errorf("unexpected document key")
+		}
+	}
+	if raw, ok := root["name"]; ok {
+		var value string
+		if json.Unmarshal(raw, &value) != nil {
+			return fmt.Errorf("invalid name")
+		}
+	}
+	for _, key := range []string{"createTime", "updateTime"} {
+		if raw, ok := root[key]; ok {
+			var value string
+			if json.Unmarshal(raw, &value) != nil {
+				return fmt.Errorf("invalid timestamp")
+			}
+			if _, err := time.Parse(time.RFC3339Nano, value); err != nil {
+				return fmt.Errorf("invalid timestamp")
+			}
+		}
+	}
+	if raw, ok := root["fields"]; ok {
+		fields, err := decodeEventObject(raw)
+		if err != nil {
+			return err
+		}
+		keys := make([]string, 0, len(fields))
+		for key := range fields {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			if err := validateFirestoreValue(fields[key]); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func validateFirestoreValue(raw json.RawMessage) error {
+	object, err := decodeEventObject(raw)
+	if err != nil {
+		return err
+	}
+	if len(object) != 1 {
+		return fmt.Errorf("firestore value must have one variant")
+	}
+	for key, value := range object {
+		switch key {
+		case "nullValue":
+			if !bytes.Equal(bytes.TrimSpace(value), []byte("null")) {
+				return fmt.Errorf("invalid null value")
+			}
+			return nil
+		case "booleanValue":
+			var decoded bool
+			if json.Unmarshal(value, &decoded) != nil {
+				return fmt.Errorf("invalid boolean value")
+			}
+			return nil
+		case "integerValue":
+			var decoded string
+			if json.Unmarshal(value, &decoded) != nil || !firestoreIntegerPattern.MatchString(decoded) {
+				return fmt.Errorf("invalid integer value")
+			}
+			return nil
+		case "doubleValue":
+			var numeric float64
+			if json.Unmarshal(value, &numeric) == nil {
+				return nil
+			}
+			var special string
+			if json.Unmarshal(value, &special) != nil ||
+				(special != "NaN" && special != "Infinity" && special != "-Infinity") {
+				return fmt.Errorf("invalid double value")
+			}
+			return nil
+		case "timestampValue":
+			var decoded string
+			if json.Unmarshal(value, &decoded) != nil {
+				return fmt.Errorf("invalid timestamp value")
+			}
+			if _, err := time.Parse(time.RFC3339Nano, decoded); err != nil {
+				return fmt.Errorf("invalid timestamp value")
+			}
+			return nil
+		case "stringValue", "bytesValue", "referenceValue":
+			var decoded string
+			if json.Unmarshal(value, &decoded) != nil {
+				return fmt.Errorf("invalid string-like value")
+			}
+			return nil
+		case "geoPointValue":
+			geoPoint, err := decodeEventObject(value)
+			if err != nil || len(geoPoint) != 2 {
+				return fmt.Errorf("invalid geopoint")
+			}
+			for _, field := range []string{"latitude", "longitude"} {
+				rawNumber, ok := geoPoint[field]
+				if !ok {
+					return fmt.Errorf("invalid geopoint")
+				}
+				var decoded float64
+				if json.Unmarshal(rawNumber, &decoded) != nil {
+					return fmt.Errorf("invalid geopoint")
+				}
+			}
+			return nil
+		case "arrayValue":
+			arrayObject, err := decodeEventObject(value)
+			if err != nil {
+				return err
+			}
+			for nestedKey := range arrayObject {
+				if nestedKey != "values" {
+					return fmt.Errorf("invalid array value")
+				}
+			}
+			rawValues, ok := arrayObject["values"]
+			if !ok {
+				return nil
+			}
+			if !isEventJSONKind(rawValues, '[') {
+				return fmt.Errorf("invalid array value")
+			}
+			var values []json.RawMessage
+			if json.Unmarshal(rawValues, &values) != nil || values == nil {
+				return fmt.Errorf("invalid array value")
+			}
+			for _, entry := range values {
+				if err := validateFirestoreValue(entry); err != nil {
+					return err
+				}
+			}
+			return nil
+		case "mapValue":
+			mapObject, err := decodeEventObject(value)
+			if err != nil {
+				return err
+			}
+			for nestedKey := range mapObject {
+				if nestedKey != "fields" {
+					return fmt.Errorf("invalid map value")
+				}
+			}
+			rawFields, ok := mapObject["fields"]
+			if !ok {
+				return nil
+			}
+			fields, err := decodeEventObject(rawFields)
+			if err != nil {
+				return err
+			}
+			for _, nested := range fields {
+				if err := validateFirestoreValue(nested); err != nil {
+					return err
+				}
+			}
+			return nil
+		default:
+			return fmt.Errorf("unknown firestore value variant")
+		}
+	}
+	return fmt.Errorf("missing firestore value variant")
+}

--- a/internal/remote/event_writes.go
+++ b/internal/remote/event_writes.go
@@ -235,7 +235,7 @@ func callEventMutation[T any](
 	if response == nil || response.Body == nil {
 		return nil, fmt.Errorf("%w: event write response", ErrProtocolChanged)
 	}
-	defer response.Body.Close()
+	defer func() { _ = response.Body.Close() }()
 	if response.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("%w: event write status", ErrProtocolChanged)
 	}
@@ -296,7 +296,7 @@ func (client Client) FirestorePatchEvent(
 	if response == nil || response.Body == nil {
 		return fmt.Errorf("%w: firestore response", ErrProtocolChanged)
 	}
-	defer response.Body.Close()
+	defer func() { _ = response.Body.Close() }()
 	if response.StatusCode != http.StatusOK {
 		return fmt.Errorf("%w: firestore status", ErrProtocolChanged)
 	}

--- a/internal/remote/events.go
+++ b/internal/remote/events.go
@@ -33,6 +33,9 @@ type Event struct {
 	OwnerIDsPresent bool
 	GuestPresent    bool
 	GuestStatus     *string
+	GuestCount      IntegerField
+	HasGuests       BooleanField
+	RawFields       map[string]json.RawMessage
 	Safeguards      EventSafeguards
 }
 
@@ -424,13 +427,40 @@ func decodeEventInfo(raw json.RawMessage) (Event, error) {
 	if err != nil {
 		return Event{}, err
 	}
+	var ownerIDs []string
+	ownerIDsPresent := false
+	if rawOwners, ok := object["ownerIds"]; ok {
+		ownerIDsPresent = true
+		if !isEventJSONKind(rawOwners, '[') ||
+			json.Unmarshal(rawOwners, &ownerIDs) != nil ||
+			ownerIDs == nil {
+			return Event{}, errors.New("event owners are invalid")
+		}
+	}
+	guestCount, err := eventIntegerField(object, "guestCount", false)
+	if err != nil {
+		return Event{}, err
+	}
+	hasGuests, err := eventBooleanField(object, "hasGuests", false)
+	if err != nil {
+		return Event{}, err
+	}
+	rawFields := make(map[string]json.RawMessage, len(object))
+	for name, raw := range object {
+		rawFields[name] = bytes.Clone(raw)
+	}
 	return Event{
-		Title:      title,
-		Start:      start,
-		End:        end,
-		Timezone:   timezone,
-		Status:     status,
-		Safeguards: safeguards,
+		Title:           title,
+		Start:           start,
+		End:             end,
+		Timezone:        timezone,
+		Status:          status,
+		OwnerIDs:        ownerIDs,
+		OwnerIDsPresent: ownerIDsPresent,
+		GuestCount:      guestCount,
+		HasGuests:       hasGuests,
+		RawFields:       rawFields,
+		Safeguards:      safeguards,
 	}, nil
 }
 

--- a/internal/remote/events.go
+++ b/internal/remote/events.go
@@ -437,7 +437,7 @@ func decodeEventInfo(raw json.RawMessage) (Event, error) {
 			return Event{}, errors.New("event owners are invalid")
 		}
 	}
-	guestCount, err := eventIntegerField(object, "guestCount", false)
+	guestCount, err := eventIntegerField(object, "guestCount", true)
 	if err != nil {
 		return Event{}, err
 	}

--- a/internal/remote/posters.go
+++ b/internal/remote/posters.go
@@ -36,6 +36,7 @@ type Poster struct {
 	ID          string
 	Name        string
 	URL         string
+	BlurHash    *string
 	ContentType string
 	Width       *int
 	Height      *int
@@ -125,11 +126,8 @@ func decodePoster(document map[string]json.RawMessage) (Poster, error) {
 	if err := decodeRequired(document, "contentType", &poster.ContentType); err != nil {
 		return Poster{}, err
 	}
-	if _, ok := document["blurHash"]; ok {
-		var blurHash string
-		if err := decodeRequired(document, "blurHash", &blurHash); err != nil {
-			return Poster{}, err
-		}
+	if err := decodeOptionalString(document, "blurHash", &poster.BlurHash); err != nil {
+		return Poster{}, err
 	}
 	if err := decodeNullableInteger(document, "width", &poster.Width); err != nil {
 		return Poster{}, err
@@ -171,5 +169,22 @@ func decodeNullableInteger(document map[string]json.RawMessage, field string, de
 		return ErrProtocolChanged
 	}
 	*destination = &integer
+	return nil
+}
+
+func decodeOptionalString(document map[string]json.RawMessage, field string, destination **string) error {
+	value, ok := document[field]
+	if !ok {
+		*destination = nil
+		return nil
+	}
+	if string(value) == "null" {
+		return ErrProtocolChanged
+	}
+	var decoded string
+	if err := json.Unmarshal(value, &decoded); err != nil {
+		return ErrProtocolChanged
+	}
+	*destination = &decoded
 	return nil
 }

--- a/spec/partiful.api-evidence.json
+++ b/spec/partiful.api-evidence.json
@@ -425,7 +425,7 @@
     "RSVP mutation failures, server-side rejection mappings, ticketing, application, waitlist, protected-event submission, and post-write RSVP business state remain unknown.",
     "Event-write endpoint business success, persisted Event state, post-write reads, unobserved errors and statuses, inaccessible-event permissions, cancellation delivery, and automatic retry safety remain unknown."
   ],
-  "status": "pending-delegated-review",
+  "status": "owner-reviewed",
   "claims": {
     "#/servers/0/url": {
       "classification": "typescript-derived-inference",

--- a/tests/remote-api-contract.test.js
+++ b/tests/remote-api-contract.test.js
@@ -484,7 +484,7 @@ describe('remote API contract', () => {
     expect(evidence.contractRevision).toBe('2026-08-12.4');
     expect(evidence.ownerReviewedBaseline).toBe('2026-08-12.3');
     expect(spec.info.version).toBe(evidence.contractRevision);
-    expect(evidence.status).toBe('pending-delegated-review');
+    expect(evidence.status).toBe('owner-reviewed');
     expect(evidence.sources.publicEventWriteMapping20260812)
       .toBe(`${eventWriteAssetResearchPath}#scope-and-provenance`);
     expect(citationResolves(evidence.sources.publicEventWriteMapping20260812))
@@ -499,8 +499,8 @@ describe('remote API contract', () => {
       .toBe(`${rsvpReadObservationPath}#scope-and-provenance`);
     expect(citationResolves(evidence.sources.rsvpReadObservation20260812)).toBe(true);
     const appSource = fs.readFileSync('internal/app/app.go', 'utf8');
-    expect(appSource).toContain('ProductContractRevision = "2026-08-12.3"');
-    expect(appSource).toContain('RemoteContractRevision  = "2026-08-12.3"');
+    expect(appSource).toContain('ProductContractRevision = "2026-08-12.4"');
+    expect(appSource).toContain('RemoteContractRevision  = "2026-08-12.4"');
     const ids = operations().map(({ operation }) => operation.operationId);
     expect(ids).toHaveLength(27);
     expect(new Set(ids).size).toBe(ids.length);
@@ -1568,10 +1568,10 @@ describe('remote API contract', () => {
   it('defines conservative nullable event reads and bounded local snapshots', () => {
     const product = fs.readFileSync(productContractPath, 'utf8');
     for (const expected of [
-      '**Status:** Proposed; pending delegated review',
+      '**Status:** Approved product contract',
       '**Product contract revision:** `2026-08-12.4`',
       '**Remote API contract revision:** `2026-08-12.4`',
-      '**Currently shipped Go revisions:** product and remote `2026-08-12.3`',
+      '**Currently shipped Go revisions:** product and remote `2026-08-12.4`',
       '`PUBLISHED` → `active`',
       '`CANCELED` → `cancelled`',
       '`UNSAVED` exists in the current first-party client vocabulary',
@@ -1616,8 +1616,8 @@ describe('remote API contract', () => {
     );
 
     const appSource = fs.readFileSync('internal/app/app.go', 'utf8');
-    expect(appSource).toContain('ProductContractRevision = "2026-08-12.3"');
-    expect(appSource).toContain('RemoteContractRevision  = "2026-08-12.3"');
+    expect(appSource).toContain('ProductContractRevision = "2026-08-12.4"');
+    expect(appSource).toContain('RemoteContractRevision  = "2026-08-12.4"');
   });
 
   it('defines evidence-backed RSVP planning and submitted-only completion', () => {
@@ -2148,14 +2148,14 @@ describe('remote API contract', () => {
       /"remoteContractRevision": "([^"]+)"/g,
     )].map((match) => match[1]);
 
-    expect(shippedRevision).toBe('2026-08-12.3');
+    expect(shippedRevision).toBe('2026-08-12.4');
     expect(documentedRevision).toBe('2026-08-12.4');
     expect(documentedProductRevision).toBe('2026-08-12.4');
     expect(new Set(envelopeRevisions)).toEqual(new Set([documentedRevision]));
     expect(spec.info.version).toBe(documentedRevision);
-    expect(evidence.status).toBe('pending-delegated-review');
-    expect(spec.info.version).not.toBe(shippedRevision);
-    expect(appSource).toContain('ProductContractRevision = "2026-08-12.3"');
+    expect(evidence.status).toBe('owner-reviewed');
+    expect(spec.info.version).toBe(shippedRevision);
+    expect(appSource).toContain('ProductContractRevision = "2026-08-12.4"');
     expect(productContract)
       .not.toContain('currently leaves every operation response status and body unknown');
     expect(contactResearch)


### PR DESCRIPTION
## Summary

Implements the evidence-backed Go event-write contract for #167.

- adds `events create`, `events update`, and confirmed `events cancel` through `app.Execute`
- uses persistent five-minute account/input/request/precondition-bound single-use plans
- validates exact create defaults, poster selection, update allowlists/date ranges, Firestore masks and preconditions, and cancel safeguards
- re-reads bound event facts before update/cancel dispatch and fails stale plans closed
- consumes plans before one mutation attempt with no automatic retry
- validates reviewed callable and Firestore completion shapes and returns submitted-only results
- promotes shipped contract revision to `2026-08-12.4`

No live Partiful mutation or credential access was used.

## Validation

- `go test -race ./...`
- `go vet ./...`
- `go build ./...`
- `go mod verify`
- `npm test -- tests/remote-api-contract.test.js`
- `npm run typecheck`
- privacy guard and diff check

Closes #167.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added event creation, updating, and cancellation workflows.
  * Added validation for event details, links, time zones, date ranges, ownership, and event state.
  * Added confirmation and safety checks for consequential actions.
  * Added support for submitting event changes and updating event records remotely.
  * Event details now include guest information and preserve additional event data.
* **Documentation**
  * Updated product and remote API contracts to approved, owner-reviewed revision `2026-08-12.4`.
* **Tests**
  * Added comprehensive coverage for event workflows, validation, safety checks, and contract consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->