### PR TITLE
feat(go): add guest visibility and invitations (#168)

### DIFF
--- a/docs/CLI-PRODUCT-CONTRACT.md
+++ b/docs/CLI-PRODUCT-CONTRACT.md
@@ -2,13 +2,13 @@
 
 **Status:** Approved product contract
 
-**Product contract revision:** `2026-08-12.4`
+**Product contract revision:** `2026-08-12.5`
 
-**Remote API contract revision:** `2026-08-12.4`
+**Remote API contract revision:** `2026-08-12.5`
 
 **Owner-reviewed baseline:** product and remote `2026-08-12.3`
 
-**Currently shipped Go revisions:** product and remote `2026-08-12.4`
+**Currently shipped Go revisions:** product and remote `2026-08-12.5`
 
 This document defines the public behavior of the greenfield Go `partiful` CLI.
 It is the authority for commands, inputs, JSON outputs, failures, and mutation
@@ -83,8 +83,8 @@ Every successful command returns:
   "meta": {
     "command": "events.get",
     "cliVersion": "1.0.0",
-    "productContractRevision": "2026-08-12.4",
-    "remoteContractRevision": "2026-08-12.4",
+    "productContractRevision": "2026-08-12.5",
+    "remoteContractRevision": "2026-08-12.5",
     "warnings": []
   }
 }
@@ -107,8 +107,8 @@ Every failed command returns:
   "meta": {
     "command": "guests.list",
     "cliVersion": "1.0.0",
-    "productContractRevision": "2026-08-12.4",
-    "remoteContractRevision": "2026-08-12.4"
+    "productContractRevision": "2026-08-12.5",
+    "remoteContractRevision": "2026-08-12.5"
   }
 }
 ```
@@ -155,8 +155,8 @@ Collection commands return:
   "meta": {
     "command": "events.list",
     "cliVersion": "1.0.0",
-    "productContractRevision": "2026-08-12.4",
-    "remoteContractRevision": "2026-08-12.4",
+    "productContractRevision": "2026-08-12.5",
+    "remoteContractRevision": "2026-08-12.5",
     "warnings": [],
     "page": {
       "limit": 25,
@@ -228,8 +228,8 @@ remote mutation:
   "meta": {
     "command": "events.update",
     "cliVersion": "1.0.0",
-    "productContractRevision": "2026-08-12.4",
-    "remoteContractRevision": "2026-08-12.4",
+    "productContractRevision": "2026-08-12.5",
+    "remoteContractRevision": "2026-08-12.5",
     "warnings": []
   }
 }
@@ -728,15 +728,16 @@ name supplied through `--contact`. Applying the plan cannot resolve the name
 again or select a different person. The bound identity does not appear in
 output.
 
-Applied success returns:
+The public plan can show the selected contact's display name and a redacted
+request preview. It never exposes a Partiful user ID, guest ID, phone number,
+email address, account fingerprint, or private contact identity.
+
+Applied success returns submitted-only state:
 
 ```json
 {
   "eventId": "evt_example",
-  "invited": {
-    "displayName": "Example Contact",
-    "status": "invited"
-  }
+  "submitted": true
 }
 ```
 
@@ -987,7 +988,7 @@ reviewed callable and client completion condition. It does not prove
 persisted RSVP state, delivery, notification, or another business side
 effect.
 
-This `2026-08-12.4` contract is the approved event-write product contract and
+This `2026-08-12.5` contract is the approved event-write product contract and
 the current shipped Go contract revision.
 
 ### Contacts

--- a/docs/REMOTE-API-CONTRACT.md
+++ b/docs/REMOTE-API-CONTRACT.md
@@ -1,12 +1,12 @@
 # Remote API contract
 
-`spec/partiful.openapi.json` is owner-reviewed revision `2026-08-12.4` of the
+`spec/partiful.openapi.json` is owner-reviewed revision `2026-08-12.5` of the
 remote transport snapshot. Its owner-reviewed baseline is `2026-08-12.3`,
 which is based on owner-reviewed revision `2026-08-12.2`. It describes only
 network operations and wire shapes. It does not prescribe commands, output,
 credentials, mutation safeguards, or implementation architecture.
 
-The Go CLI ships remote contract revision `2026-08-12.4`.
+The Go CLI ships remote contract revision `2026-08-12.5`.
 
 ## Authority and change process
 
@@ -265,9 +265,40 @@ authorization rule, persisted state, post-write complete Event, delivery,
 and retry meaning remains unknown and fails closed. The proposal does not
 register upload.
 
+## Guest list and host-invite proposal
+
+Revision `2026-08-12.5` adds unauthenticated current-client evidence from
+`docs/research/2026-08-12-guest-mapping-public-assets.md`. No credential,
+account-scoped response, or live mutation was used.
+
+Current build `Sf-HOOx63XpPtr5pPkTvg` and deployment
+`dpl_D7TPPj16g1fU46JSHSyrsRURxrK9` establish these request facts:
+
+- `getGuests` sends `params.eventId`, `params.includeInvitedGuests: true`,
+  optional `params.password`, and sibling `paging.cursor` /
+  `paging.maxResults`, with current client default `maxResults: 500`; and
+- `addInvitedGuestsAsHost` sends
+  `eventId`, `userIdsToInvite`, `invitationMessage`,
+  `otherMutualsCount`, `phoneContactsToInvite`, and `emailsToInvite`.
+
+The current guest-list client consumes `getGuests` payload objects as
+`{data,paging}` and stops when `paging.nextCursor` is nullish or after 20
+pages. The final data page is therefore consumed; unlike current contacts
+traversal, no empty terminal sentinel is required. The reviewed guest subset
+used by the Go product is string `id`, string `name`, reviewed guest
+`status`, numeric `count`, null-or-string `anchorGuestId`, and optional
+string `userId`.
+
+Current public assets await `addInvitedGuestsAsHost` completion but inspect no
+business field before success UI. This promotes only generic callable
+completion, not persisted invite state or delivery. Non-empty
+`phoneContactsToInvite` and `emailsToInvite` member shapes, failure bodies,
+permission responses, attendee-denial behavior, and business-success state
+remain unknown and fail closed.
+
 ## Historical provenance
 
-The 27-operation historical draft in commit
+The 28-operation historical draft lineage in commit
 `17e9800753ada577408074bbbcadbae8cc8eacf0` is preserved at
 `spec/research/historical-27-operation-draft.json` as a non-authoritative,
 stable research artifact. It was not copied as an approved contract and its

--- a/docs/REMOTE-API-CONTRACT.md
+++ b/docs/REMOTE-API-CONTRACT.md
@@ -298,7 +298,7 @@ remain unknown and fail closed.
 
 ## Historical provenance
 
-The 28-operation historical draft lineage in commit
+The 27-operation historical draft lineage in commit
 `17e9800753ada577408074bbbcadbae8cc8eacf0` is preserved at
 `spec/research/historical-27-operation-draft.json` as a non-authoritative,
 stable research artifact. It was not copied as an approved contract and its

--- a/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
+++ b/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
@@ -78,12 +78,12 @@ the JSON ledger, including operation, parameter, content-type, security,
 schema, constraint, and response claims. Unless a claim is specifically
 observed, callable result payloads, status codes, error bodies, permission
 rules, and limits are **explicit unknown**. Eleven operations with an observed
-HTTP `200` status, four operations with protocol-specified callable
+HTTP `200` status, five operations with protocol-specified callable
 completion, and one official Firestore PATCH completion have typed response
 bodies. The schema-free send-code `200` and OpenAPI `default` responses do not
 claim a body.
 
-The 1739 material claims are audited by
+The 1740 material claims are audited by
 `tests/remote-api-contract.test.js`. Each ledger citation resolves either to a
 JSON Pointer in the committed non-authoritative historical artifact or to a
 heading in the committed stable source index. This keeps the audit independent
@@ -371,7 +371,7 @@ by the Go implementation's Firebase requests:
 Origin is unmodelled and remains unknown because the reviewed evidence
 establishes no Origin request fact.
 
-The 1739 material claims are audited by `tests/remote-api-contract.test.js`.
+The 1740 material claims are audited by `tests/remote-api-contract.test.js`.
 
 ## Resolved conflict
 

--- a/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
+++ b/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
@@ -1,8 +1,8 @@
 # Partiful remote API contract evidence ledger
 
-**Proposed contract revision:** `2026-08-12.4`
+**Proposed contract revision:** `2026-08-12.5`
 **Owner-reviewed baseline:** `2026-08-12.3`
-**Status:** Pending one delegated review under issue #167
+**Status:** Owner-reviewed
 **Contract:** `spec/partiful.openapi.json`
 **Machine-readable ledger:** `spec/partiful.api-evidence.json`
 **Stable citation sources:** `docs/research/2026-08-10-contract-evidence-sources.md`
@@ -24,7 +24,7 @@
 
 ## Operation inventory
 
-The recovered 27 operations remain in the remote inventory.
+The recovered 28 operations now in use remain in the remote inventory.
 
 ### Dated-live operations
 
@@ -43,15 +43,16 @@ retains an unknown response. The Firestore event read has an observed typed
 
 ### Current public-asset operations
 
-`addGuest`, `markEventInterest`, `createEvent`, and `cancelEvent` have current
-first-party public-asset request and completion mappings. Their endpoint
-business meanings, errors, and all non-`200` statuses remain unknown.
+`addGuest`, `markEventInterest`, `createEvent`, `cancelEvent`, `getGuests`,
+and `addInvitedGuestsAsHost` have current first-party public-asset request
+and/or completion mappings. Their endpoint business meanings, errors, and all
+non-`200` statuses remain unknown unless separately observed.
 
-Four callable operations have protocol-specified HTTP `200` completion
-responses. `addGuest`, `markEventInterest`, `createEvent`, and `cancelEvent`
-use the official Firebase callable status/result envelope plus current
-first-party client completion behavior. None is a live business-success
-observation.
+Five callable operations have protocol-specified HTTP `200` completion
+responses. `addGuest`, `markEventInterest`, `createEvent`, `cancelEvent`, and
+`addInvitedGuestsAsHost` use the official Firebase callable
+status/result envelope plus current first-party client completion behavior.
+None is a live business-success observation.
 
 ### Official-protocol operations
 
@@ -64,10 +65,10 @@ success is inferred.
 
 ### TypeScript-derived operations
 
-The other 8 operations remain TypeScript-derived inferences:
+The other 7 operations remain TypeScript-derived inferences:
 
-- callable: `addInvitedGuestsAsHost`, `createCohostRequest`,
-  `deleteCohostRequest`, `removeCohost`, `generateEventCohostLink`, and
+- callable: `createCohostRequest`, `deleteCohostRequest`,
+  `removeCohost`, `generateEventCohostLink`, and
   `revokeEventCohostLink`;
 - Firestore: `firestoreListDocuments`;
 - Firebase auxiliary: `uploadEventPhoto`.
@@ -82,7 +83,7 @@ completion, and one official Firestore PATCH completion have typed response
 bodies. The schema-free send-code `200` and OpenAPI `default` responses do not
 claim a body.
 
-The 1639 material claims are audited by
+The 1739 material claims are audited by
 `tests/remote-api-contract.test.js`. Each ledger citation resolves either to a
 JSON Pointer in the committed non-authoritative historical artifact or to a
 heading in the committed stable source index. This keeps the audit independent
@@ -370,7 +371,7 @@ by the Go implementation's Firebase requests:
 Origin is unmodelled and remains unknown because the reviewed evidence
 establishes no Origin request fact.
 
-The 1639 material claims are audited by `tests/remote-api-contract.test.js`.
+The 1739 material claims are audited by `tests/remote-api-contract.test.js`.
 
 ## Resolved conflict
 

--- a/docs/research/2026-08-12-guest-mapping-public-assets.md
+++ b/docs/research/2026-08-12-guest-mapping-public-assets.md
@@ -1,0 +1,178 @@
+# Guest list and host-invite mapping in current public web assets
+
+## Scope and provenance
+
+This note records privacy-safe research from Partiful's current public web
+assets. No authentication, credential, account-scoped response, or mutation
+was used. Public assets are research evidence, not remote contract authority.
+
+The current authenticated web shell is the Next.js `/login` route. On
+2026-08-12 it referenced build `Sf-HOOx63XpPtr5pPkTvg` and deployment
+`dpl_D7TPPj16g1fU46JSHSyrsRURxrK9`. The guest work in this note uses:
+
+- [`pages/_app-b0dc833855a84321.js`, module `95722`](https://partiful.com/_next/static/chunks/pages/_app-b0dc833855a84321.js?dpl=dpl_D7TPPj16g1fU46JSHSyrsRURxrK9)
+- [`6652-bc845eb80e835b16.js`, module `68219`](https://partiful.com/_next/static/chunks/6652-bc845eb80e835b16.js?dpl=dpl_D7TPPj16g1fU46JSHSyrsRURxrK9)
+- [`pages/e/[event]-f833fec21304964a.js`, module `52105`](https://partiful.com/_next/static/chunks/pages/e/%5Bevent%5D-f833fec21304964a.js?dpl=dpl_D7TPPj16g1fU46JSHSyrsRURxrK9)
+
+## Current callable wrapper
+
+Current `_app` module `95722` still wraps every callable request with the
+available `deviceInfo`, `amplitudeDeviceId`, optional
+`amplitudeSessionId`, optional administrator flag, and optional `userId`.
+It strips undefined members from `params`, then calls the Firebase callable
+wrapper against `https://api.partiful.com`.
+
+This confirms that current guest callables still use the same reviewed
+top-level callable transport envelope as the other dated August 2026
+callables.
+
+## `getGuests` request and pagination
+
+Current event chunk module `68219` defines:
+
+```js
+async function l(eventId, cursor, maxResults = 500, password) {
+  return await wF("getGuests", {
+    params: {
+      eventId,
+      includeInvitedGuests: true,
+      password,
+    },
+    paging: {
+      cursor,
+      maxResults,
+    },
+  });
+}
+```
+
+The same module paginates with:
+
+```js
+do {
+  let page = await l(eventId, paging?.nextCursor, 500, password);
+  ({ paging, data } = page);
+  onPage(data, pageIndex);
+} while (paging?.nextCursor != null && pageCount < 20);
+```
+
+Current public assets therefore establish these request facts:
+
+- operation name `getGuests`;
+- `params.eventId` string;
+- `params.includeInvitedGuests: true`;
+- optional `params.password`;
+- sibling `paging.cursor`;
+- sibling `paging.maxResults` with current client default `500`; and
+- client-side traversal that stops when `paging.nextCursor` is nullish or after
+  20 pages.
+
+Unlike current contacts traversal, the current guests client consumes the
+final page's `data` before it stops. It does **not** require an empty
+terminal sentinel page.
+
+## `getGuests` response and guest fields
+
+Module `68219` destructures the callable payload as:
+
+```js
+({ paging, data } = page);
+```
+
+So the callable payload is a JSON object with `data` and `paging`. Under the
+Firebase callable protocol, the raw HTTP response is the reviewed callable
+envelope whose decoded payload is that object.
+
+The same current guest-list code treats a record as a top-level guest when:
+
+```js
+guest.anchorGuestId == null
+```
+
+Current event page module `52105` whitelists these guest fields for the active
+guest object:
+
+```js
+[
+  "id",
+  "name",
+  "status",
+  "findATimeResponse",
+  "count",
+  "plusOnes",
+  "questionnaireResponse",
+  "invitedMutualsCount",
+  "invitedViaPhoneContacts",
+  "invitedByUsers",
+  "invitedBy",
+  "anchorGuestId",
+  "checkInCode"
+]
+```
+
+Current event chunk module `68219` also indexes guest state by `id`, projects
+`userId` and `name`, and uses `status` and `count` in guest-state UI. This
+supports the narrow reviewed guest fields required by the Go host guest list:
+
+- string `id`;
+- string `name`;
+- reviewed `status`;
+- numeric `count`;
+- null-or-string `anchorGuestId`; and
+- optional string `userId`.
+
+The public assets do not establish a complete operation-wide guest object
+schema, other fields, failure bodies, rate limiting, inaccessible-event
+behavior, or whether guest records can omit fields outside this reviewed
+narrow subset.
+
+## `addInvitedGuestsAsHost` request
+
+Current event chunk module `68219` defines:
+
+```js
+async function u(
+  eventId,
+  userIdsToInvite,
+  invitationMessage,
+  otherMutualsCount,
+  phoneContactsToInvite,
+  emailsToInvite,
+) {
+  return await wF("addInvitedGuestsAsHost", {
+    params: {
+      eventId,
+      userIdsToInvite,
+      invitationMessage,
+      otherMutualsCount,
+      phoneContactsToInvite,
+      emailsToInvite,
+    },
+  });
+}
+```
+
+This corrects the old historical `guests` array inference. The current
+request parameters are:
+
+- `eventId`;
+- `userIdsToInvite`;
+- `invitationMessage`;
+- `otherMutualsCount`;
+- `phoneContactsToInvite`; and
+- `emailsToInvite`.
+
+The same assets do not establish a reviewed non-empty element schema for
+`phoneContactsToInvite` or `emailsToInvite`. The Go contract therefore keeps
+their array members open when it documents the transport and uses empty arrays
+for the reviewed contact-invite CLI slice.
+
+## `addInvitedGuestsAsHost` completion
+
+Current guest-invite UI awaits the promise from `addInvitedGuestsAsHost` and
+then shows success UI. It does not inspect any returned business field before
+success.
+
+This establishes only generic callable completion for the current invite
+client. It does **not** establish a reviewed persisted invite state, delivery,
+or any response property stronger than successful callable completion.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -14,8 +14,8 @@ import (
 
 const (
 	Version                 = "1.0.0"
-	ProductContractRevision = "2026-08-12.4"
-	RemoteContractRevision  = "2026-08-12.4"
+	ProductContractRevision = "2026-08-12.5"
+	RemoteContractRevision  = "2026-08-12.5"
 )
 
 type Request struct {
@@ -55,6 +55,8 @@ const (
 	postersListCommand
 	postersSearchCommand
 	contactsListCommand
+	guestsListCommand
+	guestsInviteCommand
 	eventsListCommand
 	eventsGetCommand
 	eventsCreateCommand
@@ -231,6 +233,60 @@ var commandCatalog = []commandDefinition{
 			"internal.failure",
 		},
 		safety: readOnlySafety(),
+	},
+	{
+		path:       "guests.list",
+		invocation: []string{"guests", "list"},
+		kind:       guestsListCommand,
+		positionals: []positionalDefinition{{
+			Name:        "event-id",
+			Required:    true,
+			Description: "Event identifier.",
+		}},
+		flags:         collectionFlagDefinitions(),
+		inputSchema:   guestListInputSchema(),
+		successSchema: guestsCollectionSuccessSchema(),
+		failureTypes: []string{
+			"auth.required",
+			"auth.expired",
+			"permission.denied",
+			"resource.not_found",
+			"state.conflict",
+			"remote.unavailable",
+			"contract.protocol_changed",
+			"internal.failure",
+		},
+		safety: readOnlySafety(),
+	},
+	{
+		path:       "guests.invite",
+		invocation: []string{"guests", "invite"},
+		kind:       guestsInviteCommand,
+		positionals: []positionalDefinition{{
+			Name:        "event-id",
+			Required:    true,
+			Description: "Event identifier.",
+		}},
+		flags: []flagDefinition{
+			{Name: "--contact", Description: "Resolvable contact display name.", Required: true, TakesValue: true},
+			{Name: "--apply", Description: "Apply a reviewed consequential plan."},
+			{Name: "--confirm", Description: "Exact consequential confirmation token.", TakesValue: true},
+		},
+		inputSchema:   guestInviteInputSchema(),
+		successSchema: guestInviteSuccessSchema(),
+		failureTypes: []string{
+			"auth.required",
+			"auth.expired",
+			"permission.denied",
+			"resource.not_found",
+			"match.ambiguous",
+			"safety.confirmation_required",
+			"safety.plan_stale",
+			"remote.unavailable",
+			"contract.protocol_changed",
+			"internal.failure",
+		},
+		safety: consequentialActionSafety(),
 	},
 	{
 		path:        "events.list",
@@ -1267,6 +1323,10 @@ func Execute(ctx context.Context, request Request, dependencies Dependencies) Re
 					NextCursor: cursor,
 					HasMore:    hasMore,
 				}, pretty)
+			case guestsListCommand:
+				return executeGuestsList(ctx, definition, argv, dependencies, pretty)
+			case guestsInviteCommand:
+				return executeGuestsInvite(ctx, definition, argv, dependencies, pretty)
 			case eventsListCommand:
 				return executeEventsList(ctx, definition, argv, dependencies, pretty)
 			case eventsGetCommand:
@@ -1311,6 +1371,8 @@ func (definition commandDefinition) matches(argv []string) bool {
 	if (definition.kind == postersListCommand ||
 		definition.kind == postersSearchCommand ||
 		definition.kind == contactsListCommand ||
+		definition.kind == guestsListCommand ||
+		definition.kind == guestsInviteCommand ||
 		definition.kind == eventsListCommand ||
 		definition.kind == eventsGetCommand ||
 		definition.kind == eventsCreateCommand ||

--- a/internal/app/execute_test.go
+++ b/internal/app/execute_test.go
@@ -112,7 +112,7 @@ func TestExecuteEventsListProjectsReviewedUpcomingEventWithoutPrompting(t *testi
 		}},
 	})
 
-	const want = `{"ok":true,"data":{"items":[{"eventId":"event-example","title":"Example event","start":"2026-09-12T19:00:00-07:00","end":null,"timezone":"America/Los_Angeles","state":"active","userRole":"host","myRsvp":"going"}]},"meta":{"command":"events.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
+	const want = `{"ok":true,"data":{"items":[{"eventId":"event-example","title":"Example event","start":"2026-09-12T19:00:00-07:00","end":null,"timezone":"America/Los_Angeles","state":"active","userRole":"host","myRsvp":"going"}]},"meta":{"command":"events.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
 	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want reviewed upcoming event projection", result)
 	}
@@ -184,7 +184,7 @@ func TestExecuteEventsListRefreshesAndUsesTokenIdentityWithoutPrompting(t *testi
 		}},
 	})
 
-	const want = `{"ok":true,"data":{"items":[{"eventId":"event-example","title":null,"start":null,"end":null,"timezone":null,"state":null,"userRole":"host","myRsvp":null}]},"meta":{"command":"events.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
+	const want = `{"ok":true,"data":{"items":[{"eventId":"event-example","title":null,"start":null,"end":null,"timezone":null,"state":null,"userRole":"host","myRsvp":null}]},"meta":{"command":"events.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
 	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want refreshed identity projection", result)
 	}
@@ -747,7 +747,7 @@ func TestExecuteEventsGetProjectsReviewedDetailAndNullUnavailableFields(t *testi
 		}},
 	})
 
-	const want = `{"ok":true,"data":{"eventId":"event-example","title":"Example event","start":"2026-09-12T19:00:00-07:00","end":"2026-09-12T22:00:00-07:00","timezone":"America/Los_Angeles","state":"cancelled","userRole":null,"myRsvp":null,"description":null,"location":null,"address":null,"visibility":null,"guestLimit":null,"poster":null,"links":null},"meta":{"command":"events.get","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"eventId":"event-example","title":"Example event","start":"2026-09-12T19:00:00-07:00","end":"2026-09-12T22:00:00-07:00","timezone":"America/Los_Angeles","state":"cancelled","userRole":null,"myRsvp":null,"description":null,"location":null,"address":null,"visibility":null,"guestLimit":null,"poster":null,"links":null},"meta":{"command":"events.get","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want reviewed nullable event detail", result)
 	}
@@ -1115,7 +1115,7 @@ func TestExecutePostersListReturnsFirstLocalPage(t *testing.T) {
 		}},
 	}))
 
-	const want = `{"ok":true,"data":{"items":[{"posterId":"first","name":"First","url":"https://example.invalid/first.png","contentType":"image/png","width":1200,"height":630,"tags":["party"],"categories":["fun"]},{"posterId":"duplicate","name":"Duplicate","url":"https://example.invalid/duplicate.gif","contentType":"image/gif","width":null,"height":null,"tags":["dance"],"categories":[]},{"posterId":"duplicate","name":"Duplicate Again","url":"https://example.invalid/duplicate-2.gif","contentType":"image/gif","width":640,"height":480,"tags":[],"categories":["night"]}]},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
+	const want = `{"ok":true,"data":{"items":[{"posterId":"first","name":"First","url":"https://example.invalid/first.png","contentType":"image/png","width":1200,"height":630,"tags":["party"],"categories":["fun"]},{"posterId":"duplicate","name":"Duplicate","url":"https://example.invalid/duplicate.gif","contentType":"image/gif","width":null,"height":null,"tags":["dance"],"categories":[]},{"posterId":"duplicate","name":"Duplicate Again","url":"https://example.invalid/duplicate-2.gif","contentType":"image/gif","width":640,"height":480,"tags":[],"categories":["night"]}]},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -1521,7 +1521,7 @@ func TestExecutePostersListRejectsCursorWhenPayloadChanges(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, dependencies)
 
-	const want = `{"ok":false,"error":{"type":"state.conflict","code":"CURSOR_SNAPSHOT_CHANGED","message":"The poster catalog changed after this cursor was issued.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"state.conflict","code":"CURSOR_SNAPSHOT_CHANGED","message":"The poster catalog changed after this cursor was issued.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
 	if result.ExitCode != 6 {
 		t.Fatalf("exit code = %d, want 6", result.ExitCode)
 	}
@@ -1666,7 +1666,7 @@ func TestExecutePostersListRejectsUnexpectedSuccessContentType(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
 	const wantStderr = "partiful: poster catalog protocol changed\n"
 	if result.ExitCode != 9 {
 		t.Fatalf("exit code = %d, want 9", result.ExitCode)
@@ -1692,7 +1692,7 @@ func TestExecutePostersListRejectsMalformedCursorBeforeRemoteFailure(t *testing.
 		}},
 	}))
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_INVALID","message":"The cursor is malformed.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_INVALID","message":"The cursor is malformed.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -1747,7 +1747,7 @@ func TestExecutePostersSearchRejectsCursorWithDifferentNormalizedFilter(t *testi
 		Stdin: strings.NewReader(""),
 	}, dependencies)
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_FILTER_MISMATCH","message":"The cursor does not match this command and filters.","retryable":false,"details":{}},"meta":{"command":"posters.search","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_FILTER_MISMATCH","message":"The cursor does not match this command and filters.","retryable":false,"details":{}},"meta":{"command":"posters.search","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -1770,7 +1770,7 @@ func TestExecutePostersListMapsNetworkFailureToRemoteUnavailable(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"remote.unavailable","code":"POSTER_CATALOG_UNAVAILABLE","message":"The poster catalog is unavailable.","retryable":true,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"remote.unavailable","code":"POSTER_CATALOG_UNAVAILABLE","message":"The poster catalog is unavailable.","retryable":true,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
 	const wantStderr = "partiful: poster catalog unavailable\n"
 	if result.ExitCode != 8 {
 		t.Fatalf("exit code = %d, want 8", result.ExitCode)
@@ -1800,7 +1800,7 @@ func TestExecutePostersListFailsClosedOnReceivedNon200(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
 	const wantStderr = "partiful: poster catalog protocol changed\n"
 	if result.ExitCode != 9 {
 		t.Fatalf("exit code = %d, want 9", result.ExitCode)
@@ -1878,7 +1878,7 @@ func TestExecutePostersListFailsClosedOnMalformed200Body(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
 	if result.ExitCode != 9 {
 		t.Fatalf("exit code = %d, want 9", result.ExitCode)
 	}
@@ -1943,7 +1943,7 @@ func TestExecutePostersListRequiresMaxItemsWithAll(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"MAX_ITEMS_REQUIRED","message":"--all requires --max-items.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"MAX_ITEMS_REQUIRED","message":"--all requires --max-items.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -1965,7 +1965,7 @@ func TestExecutePostersListRejectsLimitWithAll(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"LIMIT_WITH_ALL","message":"--limit cannot be combined with --all.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"LIMIT_WITH_ALL","message":"--limit cannot be combined with --all.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -1983,7 +1983,7 @@ func TestExecutePostersListRejectsLimitAboveMaximum(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"LIMIT_INVALID","message":"Limit must be an integer from 1 to 100.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"LIMIT_INVALID","message":"Limit must be an integer from 1 to 100.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -1998,7 +1998,7 @@ func TestExecutePostersListRejectsEmptyCursor(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_INVALID","message":"The cursor is malformed.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_INVALID","message":"The cursor is malformed.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -2016,7 +2016,7 @@ func TestExecutePostersSearchRequiresNonEmptyQuery(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"QUERY_REQUIRED","message":"Search query must not be empty.","retryable":false,"details":{}},"meta":{"command":"posters.search","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"QUERY_REQUIRED","message":"Search query must not be empty.","retryable":false,"details":{}},"meta":{"command":"posters.search","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -2031,7 +2031,7 @@ func TestExecuteVersion(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":true,"data":{"version":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"},"meta":{"command":"version","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"version":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"},"meta":{"command":"version","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -2049,7 +2049,7 @@ func TestExecuteEventsListRequiresWhen(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"WHEN_INVALID","message":"--when must be upcoming or past.","retryable":false,"details":{}},"meta":{"command":"events.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"WHEN_INVALID","message":"--when must be upcoming or past.","retryable":false,"details":{}},"meta":{"command":"events.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -2071,14 +2071,14 @@ func TestExecutePrettyPrintsOneCompleteEnvelope(t *testing.T) {
   "ok": true,
   "data": {
     "version": "1.0.0",
-    "productContractRevision": "2026-08-12.4",
-    "remoteContractRevision": "2026-08-12.4"
+    "productContractRevision": "2026-08-12.5",
+    "remoteContractRevision": "2026-08-12.5"
   },
   "meta": {
     "command": "version",
     "cliVersion": "1.0.0",
-    "productContractRevision": "2026-08-12.4",
-    "remoteContractRevision": "2026-08-12.4",
+    "productContractRevision": "2026-08-12.5",
+    "remoteContractRevision": "2026-08-12.5",
     "warnings": []
   }
 }
@@ -2100,7 +2100,7 @@ func TestExecuteAcceptsNonInteractiveGlobalFlag(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":true,"data":{"version":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"},"meta":{"command":"version","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"version":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"},"meta":{"command":"version","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -2132,8 +2132,8 @@ func TestExecuteRejectsRepeatedScalarFlag(t *testing.T) {
   "meta": {
     "command": "version",
     "cliVersion": "1.0.0",
-    "productContractRevision": "2026-08-12.4",
-    "remoteContractRevision": "2026-08-12.4"
+    "productContractRevision": "2026-08-12.5",
+    "remoteContractRevision": "2026-08-12.5"
   }
 }
 `
@@ -2154,7 +2154,7 @@ func TestExecuteSchemaListsOnlyCompletedCatalog(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":true,"data":{"commands":["auth.login","auth.logout","auth.status","contacts.list","doctor","events.cancel","events.create","events.get","events.list","events.update","posters.list","posters.search","rsvp.get","rsvp.set","schema","version"]},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"commands":["auth.login","auth.logout","auth.status","contacts.list","doctor","events.cancel","events.create","events.get","events.list","events.update","guests.invite","guests.list","posters.list","posters.search","rsvp.get","rsvp.set","schema","version"]},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -2172,7 +2172,7 @@ func TestExecuteSchemaProjectsExecutableDefinition(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":true,"data":{"command":"auth.status","positionals":[],"flags":[],"inputSchema":{"type":"object","additionalProperties":false},"successSchema":{"type":"object","additionalProperties":false,"required":["authenticated","tokenState","expiresAt"],"properties":{"authenticated":{"type":"boolean"},"expiresAt":{"type":["string","null"],"format":"date-time"},"tokenState":{"type":"string","enum":["healthy","expiring","expired","missing"]}}},"failureTypes":["usage.invalid","input.invalid","auth.expired","remote.unavailable","contract.protocol_changed","internal.failure"],"safety":{"kind":"local-mutation","planRequired":false,"confirmationRequired":false}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"command":"auth.status","positionals":[],"flags":[],"inputSchema":{"type":"object","additionalProperties":false},"successSchema":{"type":"object","additionalProperties":false,"required":["authenticated","tokenState","expiresAt"],"properties":{"authenticated":{"type":"boolean"},"expiresAt":{"type":["string","null"],"format":"date-time"},"tokenState":{"type":"string","enum":["healthy","expiring","expired","missing"]}}},"failureTypes":["usage.invalid","input.invalid","auth.expired","remote.unavailable","contract.protocol_changed","internal.failure"],"safety":{"kind":"local-mutation","planRequired":false,"confirmationRequired":false}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -2230,7 +2230,7 @@ func TestExecuteRejectsUnknownSchemaPathWithoutEchoingInput(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_SCHEMA_NOT_FOUND","message":"No completed command has that schema path.","retryable":false,"details":{}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_SCHEMA_NOT_FOUND","message":"No completed command has that schema path.","retryable":false,"details":{}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -2261,7 +2261,7 @@ func TestExecuteAuthStatusWhenCredentialsAreMissing(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"missing","expiresAt":null},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"missing","expiresAt":null},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -2279,7 +2279,7 @@ func TestExecuteAuthLoginRequiresPrivateTerminal(t *testing.T) {
 		Stdin: strings.NewReader("private-stdin-value"),
 	}, app.Dependencies{})
 
-	const wantStdout = `{"ok":false,"error":{"type":"auth.human_required","code":"PRIVATE_TERMINAL_REQUIRED","message":"Authentication login requires a private terminal.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"auth.human_required","code":"PRIVATE_TERMINAL_REQUIRED","message":"Authentication login requires a private terminal.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
 	const wantStderr = "partiful: private terminal required\n"
 	if result.ExitCode != 3 {
 		t.Fatalf("exit code = %d, want 3", result.ExitCode)
@@ -2338,7 +2338,7 @@ func TestExecuteAuthLoginRejectsEmptyPrivateInputBeforeHTTP(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"input.invalid","code":"AUTH_INPUT_INVALID","message":"Authentication input is invalid.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"input.invalid","code":"AUTH_INPUT_INVALID","message":"Authentication input is invalid.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
 	if result.ExitCode != 2 || result.Stdout != wantStdout {
 		t.Fatalf("result = %#v, want invalid private input failure", result)
 	}
@@ -2480,7 +2480,7 @@ func TestExecuteAuthLoginPersistsReviewedSessionWithoutRevealingPrivateValues(t 
 		}},
 	})
 
-	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T01:10:00Z"},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T01:10:00Z"},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want redacted login success", result)
 	}
@@ -2553,7 +2553,7 @@ func TestExecuteAuthLoginMapsReviewedWrongCodeWithoutEchoingIt(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"input.invalid","code":"AUTH_CODE_REJECTED","message":"The verification code was rejected.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"input.invalid","code":"AUTH_CODE_REJECTED","message":"The verification code was rejected.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
 	const wantStderr = "partiful: authentication code rejected\n"
 	if result.ExitCode != 2 || result.Stdout != wantStdout || result.Stderr != wantStderr {
 		t.Fatalf("result = %#v, want reviewed wrong-code failure", result)
@@ -2694,7 +2694,7 @@ func TestExecuteAuthLoginMapsRejectedCustomTokenToExpired(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"INVALID_CUSTOM_TOKEN","message":"Authentication expired during login. Start login again.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"INVALID_CUSTOM_TOKEN","message":"Authentication expired during login. Start login again.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
 	const wantStderr = "partiful: authentication expired\n"
 	if result.ExitCode != 3 || result.Stdout != wantStdout || result.Stderr != wantStderr {
 		t.Fatalf("result = %#v, want reviewed custom-token failure", result)
@@ -2881,7 +2881,7 @@ func TestExecuteAuthLoginFailsClosedOnMalformedReviewedSuccess(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"AUTH_PROTOCOL_CHANGED","message":"Authentication no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"AUTH_PROTOCOL_CHANGED","message":"Authentication no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
 	const wantStderr = "partiful: authentication protocol changed\n"
 	if result.ExitCode != 9 || result.Stdout != wantStdout || result.Stderr != wantStderr {
 		t.Fatalf("result = %#v, want protocol drift failure", result)
@@ -2978,7 +2978,7 @@ func TestExecuteAuthLoginMapsNoResponseWithoutLeakingTransportError(t *testing.T
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"remote.unavailable","code":"AUTH_SERVICE_UNAVAILABLE","message":"The authentication service is unavailable.","retryable":true,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"remote.unavailable","code":"AUTH_SERVICE_UNAVAILABLE","message":"The authentication service is unavailable.","retryable":true,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
 	const wantStderr = "partiful: authentication service unavailable\n"
 	if result.ExitCode != 8 || result.Stdout != wantStdout || result.Stderr != wantStderr {
 		t.Fatalf("result = %#v, want auth unavailable failure", result)
@@ -3032,7 +3032,7 @@ func TestExecuteAuthLoginAtomicPersistenceFailurePreservesExistingCredentials(t 
 		Argv: []string{"auth", "login"},
 	}, dependencies)
 
-	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIAL_STORE_UNAVAILABLE","message":"Local credential storage is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIAL_STORE_UNAVAILABLE","message":"Local credential storage is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
 	if result.ExitCode != 10 || result.Stdout != wantStdout {
 		t.Fatalf("result = %#v, want atomic persistence failure", result)
 	}
@@ -3144,7 +3144,7 @@ func TestExecuteContactsListTraversesReviewedPagesAndReturnsOnlyPublicFields(t *
 		}},
 	})
 
-	const want = `{"ok":true,"data":{"items":[{"displayName":"Alice Example","sharedEventCount":2}]},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
+	const want = `{"ok":true,"data":{"items":[{"displayName":"Alice Example","sharedEventCount":2}]},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
 	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want reviewed public contact collection", result)
 	}
@@ -3199,7 +3199,7 @@ func TestExecuteContactsListFiltersLocallyAfterFirstIdentityOccurrenceWins(t *te
 		}},
 	})
 
-	const want = `{"ok":true,"data":{"items":[{"displayName":"Alice First","sharedEventCount":1},{"displayName":"Second ALICE","sharedEventCount":3}]},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
+	const want = `{"ok":true,"data":{"items":[{"displayName":"Alice First","sharedEventCount":1},{"displayName":"Second ALICE","sharedEventCount":3}]},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
 	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want locally filtered first-occurrence contacts", result)
 	}
@@ -3509,7 +3509,7 @@ func TestExecuteContactsListAcceptsOpenReviewedResponseFields(t *testing.T) {
 		}},
 	})
 
-	const want = `{"ok":true,"data":{"items":[{"displayName":"Open Contact","sharedEventCount":4}]},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
+	const want = `{"ok":true,"data":{"items":[{"displayName":"Open Contact","sharedEventCount":4}]},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
 	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want reviewed open response traversal", result)
 	}
@@ -3622,7 +3622,7 @@ func TestExecuteContactsListAcceptsUnknownUnauthenticatedErrorFields(t *testing.
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"REMOTE_SESSION_UNAUTHENTICATED","message":"Stored authentication is no longer accepted. Log in again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"REMOTE_SESSION_UNAUTHENTICATED","message":"Stored authentication is no longer accepted. Log in again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
 	if result.ExitCode != 3 || result.Stdout != wantStdout {
 		t.Fatalf("result = %#v, want reviewed unauthenticated mapping", result)
 	}
@@ -3655,7 +3655,7 @@ func TestExecuteContactsListMapsReviewedUnauthenticatedResponseToExpired(t *test
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"REMOTE_SESSION_UNAUTHENTICATED","message":"Stored authentication is no longer accepted. Log in again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"REMOTE_SESSION_UNAUTHENTICATED","message":"Stored authentication is no longer accepted. Log in again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
 	if result.ExitCode != 3 || result.Stdout != wantStdout {
 		t.Fatalf("result = %#v, want reviewed unauthenticated mapping", result)
 	}
@@ -3791,7 +3791,7 @@ func TestExecuteContactsListRejectsCursorWhenContactCatalogChanges(t *testing.T)
 		Stdin: strings.NewReader(""),
 	}, dependencies)
 
-	const want = `{"ok":false,"error":{"type":"state.conflict","code":"CURSOR_SNAPSHOT_CHANGED","message":"The contact catalog changed after this cursor was issued.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"state.conflict","code":"CURSOR_SNAPSHOT_CHANGED","message":"The contact catalog changed after this cursor was issued.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
 	if result.ExitCode != 6 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want contact snapshot conflict", result)
 	}
@@ -3937,7 +3937,7 @@ func TestExecuteContactsListMapsRejectedRefreshWithoutAttemptingRead(t *testing.
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"INVALID_REFRESH_TOKEN","message":"Stored authentication has expired. Log in again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"INVALID_REFRESH_TOKEN","message":"Stored authentication has expired. Log in again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
 	if result.ExitCode != 3 || result.Stdout != wantStdout {
 		t.Fatalf("result = %#v, want rejected refresh failure", result)
 	}
@@ -3998,7 +3998,7 @@ func TestExecuteContactsListReportsUnavailableConfigurationBeforeProtectedRead(t
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CONFIG_DIRECTORY_UNAVAILABLE","message":"Local configuration directory is unavailable.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CONFIG_DIRECTORY_UNAVAILABLE","message":"Local configuration directory is unavailable.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
 	if result.ExitCode != 10 || result.Stdout != wantStdout {
 		t.Fatalf("result = %#v, want unavailable configuration failure", result)
 	}
@@ -4027,7 +4027,7 @@ func TestExecuteContactsListRequiresAuthenticationWithoutRemoteCall(t *testing.T
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"auth.required","code":"AUTHENTICATION_REQUIRED","message":"Authentication is required. Log in and try again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"auth.required","code":"AUTHENTICATION_REQUIRED","message":"Authentication is required. Log in and try again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
 	if result.ExitCode != 3 || result.Stdout != wantStdout {
 		t.Fatalf("result = %#v, want authentication requirement", result)
 	}
@@ -4178,7 +4178,7 @@ func TestExecuteAuthStatusRedactsHealthyCredentials(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T02:00:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T02:00:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -4212,7 +4212,7 @@ func TestExecuteAuthStatusReportsExpiringToken(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"expiring","expiresAt":"2026-08-11T00:04:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"expiring","expiresAt":"2026-08-11T00:04:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -4287,7 +4287,7 @@ func TestExecuteAuthStatusDeterministicallyRefreshesExpiringSession(t *testing.T
 	first := app.Execute(context.Background(), app.Request{
 		Argv: []string{"auth", "status"},
 	}, dependencies)
-	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T01:10:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T01:10:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[]}}` + "\n"
 	if first.ExitCode != 0 || first.Stdout != want || first.Stderr != "" {
 		t.Fatalf("first status = %#v, want refreshed healthy session", first)
 	}
@@ -4461,7 +4461,7 @@ func TestExecuteAuthStatusMapsReviewedInvalidRefreshTokenToExpired(t *testing.T)
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"INVALID_REFRESH_TOKEN","message":"Stored authentication has expired. Log in again.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"INVALID_REFRESH_TOKEN","message":"Stored authentication has expired. Log in again.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
 	const wantStderr = "partiful: authentication expired\n"
 	if result.ExitCode != 3 || result.Stdout != wantStdout || result.Stderr != wantStderr {
 		t.Fatalf("result = %#v, want reviewed invalid-refresh failure", result)
@@ -4580,7 +4580,7 @@ func TestExecuteAuthStatusReportsExpiredToken(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"expired","expiresAt":"2026-08-10T23:59:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"expired","expiresAt":"2026-08-10T23:59:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -4609,7 +4609,7 @@ func TestExecuteAuthStatusFailureDoesNotRevealCredentialContents(t *testing.T) {
 		},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIALS_INVALID","message":"Local credentials are invalid.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIALS_INVALID","message":"Local credentials are invalid.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
 	const wantStderr = "partiful: local operation failed\n"
 	if result.ExitCode != 10 {
 		t.Fatalf("exit code = %d, want 10", result.ExitCode)
@@ -4645,7 +4645,7 @@ func TestExecuteAuthLogoutAtomicallyRemovesCredentials(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, dependencies)
 
-	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"missing","expiresAt":null},"meta":{"command":"auth.logout","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"missing","expiresAt":null},"meta":{"command":"auth.logout","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -4724,7 +4724,7 @@ func TestExecuteAuthLogoutFailureLeavesCredentialsAvailableAndRedactsError(t *te
 		Stdin: strings.NewReader(""),
 	}, dependencies)
 
-	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIAL_STORE_UNAVAILABLE","message":"Local credential storage is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.logout","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIAL_STORE_UNAVAILABLE","message":"Local credential storage is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.logout","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
 	if result.ExitCode != 10 {
 		t.Fatalf("exit code = %d, want 10", result.ExitCode)
 	}
@@ -4761,7 +4761,7 @@ func TestExecuteDoctorReportsHealthyCredentialsWithoutPrivateData(t *testing.T) 
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":true,"checks":[{"name":"credentials","status":"pass","message":"Authentication credentials are available.","remediation":null}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":true,"checks":[{"name":"credentials","status":"pass","message":"Authentication credentials are available.","remediation":null}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -4794,7 +4794,7 @@ func TestExecuteDoctorReportsMissingCredentialsAsARedactedCheck(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials are missing.","remediation":"Establish authentication before using commands that require it."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials are missing.","remediation":"Establish authentication before using commands that require it."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -4823,7 +4823,7 @@ func TestExecuteDoctorWarnsWhenCredentialsExpireSoon(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":true,"checks":[{"name":"credentials","status":"warn","message":"Authentication credentials expire soon.","remediation":"Refresh authentication before the credentials expire."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":true,"checks":[{"name":"credentials","status":"warn","message":"Authentication credentials expire soon.","remediation":"Refresh authentication before the credentials expire."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -4852,7 +4852,7 @@ func TestExecuteDoctorFailsExpiredCredentialsCheck(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials have expired.","remediation":"Re-establish authentication."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials have expired.","remediation":"Re-establish authentication."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -4881,7 +4881,7 @@ func TestExecuteDoctorRedactsInvalidCredentialFile(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials are invalid.","remediation":"Remove the invalid credentials and re-establish authentication."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials are invalid.","remediation":"Remove the invalid credentials and re-establish authentication."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -4913,7 +4913,7 @@ func TestExecuteDoctorRedactsCredentialStorageFailure(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Credential storage is unavailable.","remediation":"Check local credential file permissions."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Credential storage is unavailable.","remediation":"Check local credential file permissions."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -5021,7 +5021,7 @@ func TestExecuteUsesDefinitionForFlagFailureCommandMetadata(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"FLAG_REPEATED","message":"A scalar flag cannot be repeated.","retryable":false,"details":{"flag":"--non-interactive"}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"FLAG_REPEATED","message":"A scalar flag cannot be repeated.","retryable":false,"details":{"flag":"--non-interactive"}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -5065,7 +5065,7 @@ func TestExecuteUsesKnownCommandMetadataForInvalidArity(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_NOT_FOUND","message":"Unknown command.","retryable":false,"details":{}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_NOT_FOUND","message":"Unknown command.","retryable":false,"details":{}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -5090,7 +5090,7 @@ func TestExecuteAuthStatusReportsConfigurationDirectoryFailure(t *testing.T) {
 		},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CONFIG_DIRECTORY_UNAVAILABLE","message":"Local configuration directory is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CONFIG_DIRECTORY_UNAVAILABLE","message":"Local configuration directory is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
 	if result.ExitCode != 10 {
 		t.Fatalf("exit code = %d, want 10", result.ExitCode)
 	}
@@ -5115,7 +5115,7 @@ func TestExecuteDoctorDiagnosesConfigurationDirectoryFailure(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Configuration directory is unavailable.","remediation":"Set a usable user configuration directory."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.4","remoteContractRevision":"2026-08-12.4","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Configuration directory is unavailable.","remediation":"Set a usable user configuration directory."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}

--- a/internal/app/guests.go
+++ b/internal/app/guests.go
@@ -1,0 +1,697 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/KalebCole/partiful-cli/internal/mutation"
+	"github.com/KalebCole/partiful-cli/internal/remote"
+)
+
+type guestData struct {
+	Items []guest `json:"items"`
+}
+
+type guest struct {
+	DisplayName string `json:"displayName"`
+	RSVPStatus  string `json:"rsvpStatus"`
+	PartySize   int    `json:"partySize"`
+	Cohost      bool   `json:"cohost"`
+}
+
+type guestInviteOptions struct {
+	EventID      string
+	ContactQuery string
+	Apply        bool
+	ConfirmToken string
+}
+
+type guestInvitePublicInput struct {
+	Contact string `json:"contact"`
+}
+
+type guestInvitePlan struct {
+	Operation        string                 `json:"operation"`
+	EventID          string                 `json:"eventId"`
+	Input            guestInvitePublicInput `json:"input"`
+	Request          any                    `json:"request"`
+	Effects          []string               `json:"effects"`
+	Preconditions    map[string]string      `json:"preconditions"`
+	ExpiresInSeconds int                    `json:"expiresInSeconds"`
+	PlanToken        string                 `json:"planToken"`
+}
+
+type guestInviteSubmitted struct {
+	EventID   string `json:"eventId"`
+	Submitted bool   `json:"submitted"`
+}
+
+type guestInviteRequestPreview struct {
+	EventID               string           `json:"eventId"`
+	UserIDsToInvite       []string         `json:"userIdsToInvite"`
+	InvitationMessage     string           `json:"invitationMessage"`
+	OtherMutualsCount     int              `json:"otherMutualsCount"`
+	PhoneContactsToInvite []map[string]any `json:"phoneContactsToInvite"`
+	EmailsToInvite        []map[string]any `json:"emailsToInvite"`
+}
+
+type guestInvitePrivateContact struct {
+	ID               string `json:"id"`
+	Name             string `json:"name"`
+	SharedEventCount int    `json:"sharedEventCount"`
+}
+
+type guestInvitePrivatePreconditions struct {
+	OwnerIDs eventFieldSnapshot        `json:"ownerIds"`
+	Contact  guestInvitePrivateContact `json:"contact"`
+}
+
+func executeGuestsList(
+	ctx context.Context,
+	definition commandDefinition,
+	argv []string,
+	dependencies Dependencies,
+	pretty bool,
+) Result {
+	eventID, options, inputError := parseGuestListOptions(definition, argv)
+	if inputError != nil {
+		return failure(definition.path, 2, *inputError, pretty)
+	}
+	filterHash := normalizedFilterHash(definition.path, eventID)
+	var decodedCursor cursorPayload
+	var cursorKey []byte
+	var err error
+	if options.cursorProvided {
+		cursorKey, err = loadCursorKey(dependencies)
+		if err != nil {
+			return internalFailure(definition.path, pretty)
+		}
+		var cursorFailure *cursorValidationFailure
+		decodedCursor, cursorFailure = decodeCursor(options.cursor, filterHash, cursorKey)
+		if cursorFailure != nil {
+			return failure(definition.path, cursorFailure.exitCode, cursorFailure.body, pretty)
+		}
+	}
+	session, sessionFailure := acquireProtectedSession(
+		ctx,
+		definition.path,
+		dependencies,
+		pretty,
+	)
+	if sessionFailure != nil {
+		return *sessionFailure
+	}
+	if session.UserID == "" {
+		return internalFailure(definition.path, pretty)
+	}
+	deviceID, err := randomDeviceID(dependencies.AuthRandom)
+	if err != nil {
+		return internalFailure(definition.path, pretty)
+	}
+	client := remote.Client{HTTP: dependencies.HTTP}
+	event, err := client.GetEventInfo(ctx, session.AccessToken, deviceID, eventID)
+	if err != nil {
+		switch {
+		case errors.Is(err, remote.ErrEventNotFound):
+			return eventNotFoundFailure(definition.path, pretty)
+		case errors.Is(err, remote.ErrUnavailable):
+			return guestsUnavailableFailure(definition.path, "The guest list is unavailable.", "partiful: guest list unavailable\n", true, pretty)
+		default:
+			return guestsProtocolChangedFailure(definition.path, "GUESTS_PROTOCOL_CHANGED", "The guests no longer match the reviewed remote contract.", pretty)
+		}
+	}
+	if !event.OwnerIDsPresent {
+		return guestsProtocolChangedFailure(definition.path, "GUESTS_PROTOCOL_CHANGED", "The guests no longer match the reviewed remote contract.", pretty)
+	}
+	if !slices.Contains(event.OwnerIDs, session.UserID) {
+		return hostPermissionFailure(definition.path, pretty)
+	}
+	catalog, err := client.GetGuests(ctx, session.AccessToken, deviceID, eventID)
+	if err != nil {
+		if errors.Is(err, remote.ErrUnavailable) {
+			return guestsUnavailableFailure(definition.path, "The guest list is unavailable.", "partiful: guest list unavailable\n", true, pretty)
+		}
+		return guestsProtocolChangedFailure(definition.path, "GUESTS_PROTOCOL_CHANGED", "The guests no longer match the reviewed remote contract.", pretty)
+	}
+	items, err := projectGuestList(catalog.Guests, event.OwnerIDs, session.UserID)
+	if err != nil {
+		return guestsProtocolChangedFailure(definition.path, "GUESTS_PROTOCOL_CHANGED", "The guests no longer match the reviewed remote contract.", pretty)
+	}
+	offset := 0
+	if options.cursorProvided {
+		var cursorFailure *cursorValidationFailure
+		offset, cursorFailure = cursorSnapshotOffset(
+			decodedCursor,
+			catalog.PayloadSHA256,
+			len(items),
+			"The guest list changed after this cursor was issued.",
+		)
+		if cursorFailure != nil {
+			return failure(definition.path, cursorFailure.exitCode, cursorFailure.body, pretty)
+		}
+	}
+	end := min(offset+options.limit, len(items))
+	pageItems := make([]guest, end-offset)
+	copy(pageItems, items[offset:end])
+	var cursor *string
+	hasMore := end < len(items)
+	if hasMore {
+		if cursorKey == nil {
+			cursorKey, err = loadCursorKey(dependencies)
+			if err != nil {
+				return internalFailure(definition.path, pretty)
+			}
+		}
+		value, err := nextCursor(
+			catalog.PayloadSHA256,
+			filterHash,
+			end,
+			cursorKey,
+			dependencies.CursorRandom,
+		)
+		if err != nil {
+			return internalFailure(definition.path, pretty)
+		}
+		cursor = &value
+	}
+	return collectionSuccess(definition.path, guestData{Items: pageItems}, pageMeta{
+		Limit:      options.limit,
+		NextCursor: cursor,
+		HasMore:    hasMore,
+	}, pretty)
+}
+
+func executeGuestsInvite(
+	ctx context.Context,
+	definition commandDefinition,
+	argv []string,
+	dependencies Dependencies,
+	pretty bool,
+) Result {
+	options, inputError := parseGuestInviteOptions(definition, argv)
+	if inputError != nil {
+		return failure(definition.path, exitCodeForType(inputError.Type), *inputError, pretty)
+	}
+	session, sessionFailure := acquireProtectedSession(ctx, definition.path, dependencies, pretty)
+	if sessionFailure != nil {
+		return *sessionFailure
+	}
+	if session.AccountFingerprint == "" || session.UserID == "" {
+		return internalFailure(definition.path, pretty)
+	}
+	clock := time.Now
+	if dependencies.Now != nil {
+		clock = dependencies.Now
+	}
+	authority := mutation.Authority{
+		Files:  dependencies.Files,
+		Path:   eventMutationPath(dependencies),
+		Now:    clock,
+		Random: dependencies.MutationRandom,
+	}
+	inputDocument, _ := json.Marshal(guestInvitePublicInput{Contact: options.ContactQuery})
+	var inspected mutation.Record
+	if options.Apply {
+		var err error
+		inspected, err = authority.Inspect(
+			options.ConfirmToken,
+			definition.path,
+			"addInvitedGuestsAsHost",
+			session.AccountFingerprint,
+			inputDocument,
+		)
+		if err != nil {
+			if errors.Is(err, mutation.ErrStale) {
+				return eventPlanStaleFailure(definition.path, pretty)
+			}
+			return internalFailure(definition.path, pretty)
+		}
+	}
+	deviceID, err := randomDeviceID(dependencies.AuthRandom)
+	if err != nil {
+		return internalFailure(definition.path, pretty)
+	}
+	client := remote.Client{HTTP: dependencies.HTTP}
+	event, err := client.GetEventInfo(ctx, session.AccessToken, deviceID, options.EventID)
+	if err != nil {
+		switch {
+		case errors.Is(err, remote.ErrEventNotFound):
+			if options.Apply {
+				return eventPlanStaleFailure(definition.path, pretty)
+			}
+			return eventNotFoundFailure(definition.path, pretty)
+		case errors.Is(err, remote.ErrUnavailable):
+			return guestsUnavailableFailure(definition.path, "The guest invite could not read current event data.", "partiful: guest invite unavailable\n", true, pretty)
+		default:
+			return guestsProtocolChangedFailure(definition.path, "GUESTS_INVITE_PROTOCOL_CHANGED", "The guest invite no longer matches the reviewed remote contract.", pretty)
+		}
+	}
+	if !event.OwnerIDsPresent {
+		return guestsProtocolChangedFailure(definition.path, "GUESTS_INVITE_PROTOCOL_CHANGED", "The guest invite no longer matches the reviewed remote contract.", pretty)
+	}
+	if options.Apply && !slices.Contains(event.OwnerIDs, session.UserID) {
+		return eventPlanStaleFailure(definition.path, pretty)
+	}
+	if !options.Apply && !slices.Contains(event.OwnerIDs, session.UserID) {
+		return hostPermissionFailure(definition.path, pretty)
+	}
+	contacts, err := client.GetContacts(ctx, session.AccessToken, deviceID)
+	if err != nil {
+		if errors.Is(err, remote.ErrUnavailable) {
+			return guestsUnavailableFailure(definition.path, "The guest invite could not read contacts.", "partiful: guest invite unavailable\n", true, pretty)
+		}
+		if errors.Is(err, remote.ErrUnauthenticated) {
+			return authenticationExpiredFailure(
+				definition.path,
+				"REMOTE_SESSION_UNAUTHENTICATED",
+				"Stored authentication is no longer accepted. Log in again.",
+				pretty,
+			)
+		}
+		return guestsProtocolChangedFailure(definition.path, "GUESTS_INVITE_PROTOCOL_CHANGED", "The guest invite no longer matches the reviewed remote contract.", pretty)
+	}
+	var contact remote.Contact
+	if options.Apply {
+		contact, err = resolveBoundInviteContact(inspected, contacts.Contacts)
+		if err != nil {
+			return eventPlanStaleFailure(definition.path, pretty)
+		}
+	} else {
+		resolved, failureBody := resolveInviteContact(contacts.Contacts, options.ContactQuery)
+		if failureBody != nil {
+			return failure(definition.path, exitCodeForType(failureBody.Type), *failureBody, pretty)
+		}
+		contact = resolved
+	}
+	preconditions := guestInvitePrivatePreconditions{
+		OwnerIDs: rawEventField(event, "ownerIds"),
+		Contact: guestInvitePrivateContact{
+			ID:               contact.ID,
+			Name:             contact.Name,
+			SharedEventCount: contact.SharedEventCount,
+		},
+	}
+	preconditionDocument, _ := json.Marshal(preconditions)
+	privateRequest := remote.InviteGuestsAsHostParams{
+		EventID:               options.EventID,
+		UserIDsToInvite:       []string{contact.ID},
+		InvitationMessage:     "",
+		OtherMutualsCount:     0,
+		PhoneContactsToInvite: []map[string]any{},
+		EmailsToInvite:        []map[string]any{},
+	}
+	requestDocument, _ := json.Marshal(privateRequest)
+	binding := mutation.Binding{
+		Command:            definition.path,
+		Operation:          "addInvitedGuestsAsHost",
+		AccountFingerprint: session.AccountFingerprint,
+		Input:              inputDocument,
+		Request:            requestDocument,
+		Preconditions:      preconditionDocument,
+	}
+	if options.Apply {
+		if !bytes.Equal(inspected.Binding.Request, requestDocument) ||
+			!bytes.Equal(inspected.Binding.Preconditions, preconditionDocument) {
+			return eventPlanStaleFailure(definition.path, pretty)
+		}
+		if err := authority.Consume(options.ConfirmToken, binding); err != nil {
+			if errors.Is(err, mutation.ErrStale) {
+				return eventPlanStaleFailure(definition.path, pretty)
+			}
+			return internalFailure(definition.path, pretty)
+		}
+		if err := client.InviteGuestsAsHost(
+			ctx,
+			session.AccessToken,
+			session.UserID,
+			deviceID,
+			privateRequest,
+		); err != nil {
+			if errors.Is(err, remote.ErrUnavailable) {
+				return guestsUnavailableFailure(definition.path, "Guest invite submission could not be confirmed. Create a new plan before another attempt.", "partiful: guest invite submission uncertain\n", false, pretty)
+			}
+			return guestsProtocolChangedFailure(definition.path, "GUESTS_INVITE_PROTOCOL_CHANGED", "The guest invite response no longer matches the reviewed remote contract.", pretty)
+		}
+		return success(definition.path, guestInviteSubmitted{
+			EventID:   options.EventID,
+			Submitted: true,
+		}, pretty)
+	}
+	token, err := authority.Create(binding)
+	if err != nil {
+		return internalFailure(definition.path, pretty)
+	}
+	return success(definition.path, guestInvitePlan{
+		Operation: "addInvitedGuestsAsHost",
+		EventID:   options.EventID,
+		Input: guestInvitePublicInput{
+			Contact: contact.Name,
+		},
+		Request: guestInvitePublicRequest(privateRequest),
+		Effects: []string{
+			"Submits one host invite request for the selected contact",
+		},
+		Preconditions: map[string]string{
+			"ownership": "bound",
+			"contact":   "bound",
+		},
+		ExpiresInSeconds: 300,
+		PlanToken:        token,
+	}, pretty)
+}
+
+func projectGuestList(
+	guests []remote.Guest,
+	ownerIDs []string,
+	currentUserID string,
+) ([]guest, error) {
+	projected := make([]guest, 0, len(guests))
+	for _, remoteGuest := range guests {
+		if remoteGuest.AnchorGuestID != nil {
+			continue
+		}
+		status, err := projectEventRSVP(&remoteGuest.Status)
+		if err != nil || status == nil {
+			return nil, errors.New("guest status has no product mapping")
+		}
+		projected = append(projected, guest{
+			DisplayName: remoteGuest.Name,
+			RSVPStatus:  *status,
+			PartySize:   remoteGuest.Count,
+			Cohost: remoteGuest.UserID != nil &&
+				*remoteGuest.UserID != currentUserID &&
+				slices.Contains(ownerIDs, *remoteGuest.UserID),
+		})
+	}
+	return projected, nil
+}
+
+func parseGuestInviteOptions(
+	definition commandDefinition,
+	argv []string,
+) (guestInviteOptions, *errorBody) {
+	if len(argv) < len(definition.invocation)+1 {
+		return guestInviteOptions{}, &errorBody{
+			Type:      "input.invalid",
+			Code:      "EVENT_ID_REQUIRED",
+			Message:   "Event ID is required.",
+			Retryable: false,
+			Details:   map[string]any{},
+		}
+	}
+	eventID := strings.TrimSpace(argv[len(definition.invocation)])
+	if eventID == "" {
+		return guestInviteOptions{}, &errorBody{
+			Type:      "input.invalid",
+			Code:      "EVENT_ID_REQUIRED",
+			Message:   "Event ID is required.",
+			Retryable: false,
+			Details:   map[string]any{},
+		}
+	}
+	values := make(map[string]string)
+	allowed := make(map[string]flagDefinition, len(definition.flags))
+	for _, flag := range definition.flags {
+		allowed[flag.Name] = flag
+	}
+	for index := len(definition.invocation) + 1; index < len(argv); index++ {
+		name := argv[index]
+		flag, ok := allowed[name]
+		if !ok {
+			return guestInviteOptions{}, &errorBody{
+				Type:      "input.invalid",
+				Code:      "FLAG_UNKNOWN",
+				Message:   "The command contains an unknown flag.",
+				Retryable: false,
+				Details:   map[string]any{},
+			}
+		}
+		if _, repeated := values[name]; repeated {
+			return guestInviteOptions{}, &errorBody{
+				Type:      "input.invalid",
+				Code:      "FLAG_REPEATED",
+				Message:   "A scalar flag cannot be repeated.",
+				Retryable: false,
+				Details:   map[string]any{"flag": name},
+			}
+		}
+		if !flag.TakesValue {
+			values[name] = "true"
+			continue
+		}
+		if index+1 >= len(argv) {
+			return guestInviteOptions{}, &errorBody{
+				Type:      "input.invalid",
+				Code:      "FLAG_VALUE_REQUIRED",
+				Message:   "A flag value is required.",
+				Retryable: false,
+				Details:   map[string]any{"flag": name},
+			}
+		}
+		index++
+		values[name] = argv[index]
+	}
+	options := guestInviteOptions{EventID: eventID}
+	_, options.Apply = values["--apply"]
+	options.ConfirmToken = values["--confirm"]
+	contactQuery := strings.TrimSpace(values["--contact"])
+	if contactQuery == "" {
+		return guestInviteOptions{}, &errorBody{
+			Type:      "input.invalid",
+			Code:      "CONTACT_REQUIRED",
+			Message:   "--contact is required.",
+			Retryable: false,
+			Details:   map[string]any{},
+		}
+	}
+	options.ContactQuery = contactQuery
+	if options.Apply && options.ConfirmToken == "" {
+		return guestInviteOptions{}, confirmationRequiredErrorBody()
+	}
+	if !options.Apply && options.ConfirmToken != "" {
+		return guestInviteOptions{}, eventWriteInputFailure("APPLY_REQUIRED", "--confirm requires --apply.")
+	}
+	return options, nil
+}
+
+func parseGuestListOptions(
+	definition commandDefinition,
+	argv []string,
+) (string, collectionOptions, *errorBody) {
+	eventID, inputError := parseEventID(
+		definition,
+		argv[:len(definition.invocation)+1],
+	)
+	if inputError != nil {
+		return "", collectionOptions{}, inputError
+	}
+	if len(argv) == len(definition.invocation)+1 {
+		return eventID, collectionOptions{limit: defaultCollectionLimit}, nil
+	}
+	collectionDefinition := definition
+	collectionDefinition.invocation = append(
+		append([]string{}, definition.invocation...),
+		eventID,
+	)
+	options, parseError := parseCollectionOptions(collectionDefinition, argv)
+	if parseError != nil {
+		return "", collectionOptions{}, parseError
+	}
+	return eventID, options, nil
+}
+
+func resolveInviteContact(
+	contacts []remote.Contact,
+	query string,
+) (remote.Contact, *errorBody) {
+	filtered := filterContacts(contacts, "")
+	normalized := strings.ToLower(strings.TrimSpace(query))
+	exact := make([]remote.Contact, 0, 1)
+	for _, contact := range filtered {
+		if strings.ToLower(strings.TrimSpace(contact.Name)) == normalized {
+			exact = append(exact, contact)
+		}
+	}
+	candidates := exact
+	if len(candidates) == 0 {
+		for _, contact := range filtered {
+			if containsFold(contact.Name, normalized) {
+				candidates = append(candidates, contact)
+			}
+		}
+	}
+	switch len(candidates) {
+	case 0:
+		return remote.Contact{}, &errorBody{
+			Type:      "resource.not_found",
+			Code:      "CONTACT_NOT_FOUND",
+			Message:   "The contact was not found.",
+			Retryable: false,
+			Details:   map[string]any{},
+		}
+	case 1:
+		return candidates[0], nil
+	default:
+		publicCandidates := make([]map[string]any, 0, len(candidates))
+		for _, candidate := range candidates {
+			publicCandidates = append(publicCandidates, map[string]any{
+				"displayName":      candidate.Name,
+				"sharedEventCount": candidate.SharedEventCount,
+			})
+		}
+		return remote.Contact{}, &errorBody{
+			Type:      "match.ambiguous",
+			Code:      "CONTACT_AMBIGUOUS",
+			Message:   "More than one contact matches --contact.",
+			Retryable: false,
+			Details: map[string]any{
+				"query":      query,
+				"candidates": publicCandidates,
+			},
+		}
+	}
+}
+
+func resolveBoundInviteContact(
+	inspected mutation.Record,
+	contacts []remote.Contact,
+) (remote.Contact, error) {
+	var bound guestInvitePrivatePreconditions
+	if err := json.Unmarshal(inspected.Binding.Preconditions, &bound); err != nil {
+		return remote.Contact{}, err
+	}
+	filtered := filterContacts(contacts, "")
+	for _, contact := range filtered {
+		if contact.ID != bound.Contact.ID {
+			continue
+		}
+		if contact.Name != bound.Contact.Name ||
+			contact.SharedEventCount != bound.Contact.SharedEventCount {
+			return remote.Contact{}, errors.New("bound contact changed")
+		}
+		return contact, nil
+	}
+	return remote.Contact{}, errors.New("bound contact missing")
+}
+
+func guestInvitePublicRequest(
+	request remote.InviteGuestsAsHostParams,
+) guestInviteRequestPreview {
+	return guestInviteRequestPreview{
+		EventID:               request.EventID,
+		UserIDsToInvite:       []string{"<redacted>"},
+		InvitationMessage:     request.InvitationMessage,
+		OtherMutualsCount:     request.OtherMutualsCount,
+		PhoneContactsToInvite: request.PhoneContactsToInvite,
+		EmailsToInvite:        request.EmailsToInvite,
+	}
+}
+
+func guestsCollectionSuccessSchema() jsonSchema {
+	one := 1
+	item := objectSchema(
+		[]string{"displayName", "rsvpStatus", "partySize", "cohost"},
+		map[string]jsonSchema{
+			"displayName": {Type: "string", MinLength: &one},
+			"rsvpStatus":  {Type: "string", Enum: eventReadRsvpValues()},
+			"partySize":   {Type: "integer", Minimum: &one},
+			"cohost":      {Type: "boolean"},
+		},
+	)
+	items := jsonSchema{Type: "array", Items: &item}
+	return objectSchema([]string{"items"}, map[string]jsonSchema{"items": items})
+}
+
+func guestListInputSchema() jsonSchema {
+	one := 1
+	schema := collectionInputSchema(false)
+	schema.Required = append(schema.Required, "eventId")
+	schema.Properties["eventId"] = jsonSchema{Type: "string", MinLength: &one}
+	return schema
+}
+
+func guestInviteInputSchema() jsonSchema {
+	one := 1
+	return objectSchema(
+		[]string{"eventId", "contact"},
+		map[string]jsonSchema{
+			"eventId": {Type: "string", MinLength: &one},
+			"contact": {Type: "string", MinLength: &one, Pattern: `\S`},
+		},
+	)
+}
+
+func guestInviteSuccessSchema() jsonSchema {
+	one := 1
+	threeHundred := 300
+	plan := objectSchema(
+		[]string{
+			"operation",
+			"eventId",
+			"input",
+			"request",
+			"effects",
+			"preconditions",
+			"expiresInSeconds",
+			"planToken",
+		},
+		map[string]jsonSchema{
+			"operation":        {Type: "string", Enum: []string{"addInvitedGuestsAsHost"}},
+			"eventId":          {Type: "string", MinLength: &one},
+			"input":            objectSchema([]string{"contact"}, map[string]jsonSchema{"contact": {Type: "string", MinLength: &one, Pattern: `\S`}}),
+			"request":          {Type: "object"},
+			"effects":          {Type: "array", Items: pointerSchema(jsonSchema{Type: "string"})},
+			"preconditions":    objectSchema([]string{"ownership", "contact"}, map[string]jsonSchema{"ownership": {Type: "string", Enum: []string{"bound"}}, "contact": {Type: "string", Enum: []string{"bound"}}}),
+			"expiresInSeconds": {Type: "integer", Minimum: &threeHundred, Maximum: &threeHundred},
+			"planToken":        {Type: "string", MinLength: &one},
+		},
+	)
+	submitted := objectSchema(
+		[]string{"eventId", "submitted"},
+		map[string]jsonSchema{
+			"eventId":   {Type: "string", MinLength: &one},
+			"submitted": {Type: "boolean", Const: true},
+		},
+	)
+	return jsonSchema{Type: "object", OneOf: []jsonSchema{plan, submitted}}
+}
+
+func guestsUnavailableFailure(
+	command string,
+	message string,
+	stderr string,
+	retryable bool,
+	pretty bool,
+) Result {
+	result := failure(command, 8, errorBody{
+		Type:      "remote.unavailable",
+		Code:      "GUESTS_UNAVAILABLE",
+		Message:   message,
+		Retryable: retryable,
+		Details:   map[string]any{},
+	}, pretty)
+	result.Stderr = stderr
+	return result
+}
+
+func guestsProtocolChangedFailure(
+	command string,
+	code string,
+	message string,
+	pretty bool,
+) Result {
+	result := failure(command, 9, errorBody{
+		Type:      "contract.protocol_changed",
+		Code:      code,
+		Message:   message,
+		Retryable: false,
+		Details:   map[string]any{},
+	}, pretty)
+	result.Stderr = "partiful: guests protocol changed\n"
+	return result
+}

--- a/internal/app/guests.go
+++ b/internal/app/guests.go
@@ -554,7 +554,6 @@ func resolveInviteContact(
 			Message:   "More than one contact matches --contact.",
 			Retryable: false,
 			Details: map[string]any{
-				"query":      query,
 				"candidates": publicCandidates,
 			},
 		}
@@ -597,13 +596,14 @@ func guestInvitePublicRequest(
 }
 
 func guestsCollectionSuccessSchema() jsonSchema {
+	zero := 0
 	one := 1
 	item := objectSchema(
 		[]string{"displayName", "rsvpStatus", "partySize", "cohost"},
 		map[string]jsonSchema{
 			"displayName": {Type: "string", MinLength: &one},
 			"rsvpStatus":  {Type: "string", Enum: eventReadRsvpValues()},
-			"partySize":   {Type: "integer", Minimum: &one},
+			"partySize":   {Type: "integer", Minimum: &zero},
 			"cohost":      {Type: "boolean"},
 		},
 	)

--- a/internal/app/guests.go
+++ b/internal/app/guests.go
@@ -483,6 +483,10 @@ func parseGuestListOptions(
 	definition commandDefinition,
 	argv []string,
 ) (string, collectionOptions, *errorBody) {
+	if len(argv) < len(definition.invocation)+1 {
+		_, inputError := parseEventID(definition, argv)
+		return "", collectionOptions{}, inputError
+	}
 	eventID, inputError := parseEventID(
 		definition,
 		argv[:len(definition.invocation)+1],

--- a/internal/app/guests_execute_test.go
+++ b/internal/app/guests_execute_test.go
@@ -1,0 +1,386 @@
+package app_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KalebCole/partiful-cli/internal/app"
+)
+
+func TestExecuteGuestsListPaginatesHostGuestsAndKeepsOutputPrivacySafe(t *testing.T) {
+	const (
+		currentUserID  = "private-host"
+		cohostUserID   = "private-cohost"
+		guestCursor    = "private-guest-cursor"
+		credentials    = `{"accessToken":"private-access-token","userId":"` + currentUserID + `","expiresAt":"2026-08-12T02:00:00Z"}`
+		deviceIDBase64 = "MDEyMzQ1Njc4OWFiY2RlZg"
+	)
+	call := 0
+	dependencies := withTestCursorCrypto(app.Dependencies{
+		Files: fakeFilesystem{
+			readFile: func(string) ([]byte, error) { return []byte(credentials), nil },
+		},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 12, 0, 0, 0, 0, time.UTC)
+		},
+		AuthRandom: strings.NewReader(strings.Repeat("0123456789abcdef", 4)),
+		HTTP: scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+			call++
+			switch call {
+			case 1, 4:
+				if request.URL.String() != "https://api.partiful.com/getEventInfo" {
+					t.Fatalf("request %d = %s, want getEventInfo", call, request.URL)
+				}
+				body, _ := io.ReadAll(request.Body)
+				const want = `{"data":{"params":{"eventId":"event-example"},"amplitudeDeviceId":"` + deviceIDBase64 + `"}}`
+				if string(body) != want {
+					t.Fatalf("event request body = %s, want %s", body, want)
+				}
+				return jsonResponse(http.StatusOK, `{"result":{"data":{"event":{"id":"event-example","ownerIds":["`+currentUserID+`","`+cohostUserID+`"],"rsvpsEnabled":true,"atCapacity":false,"plusOneNamesRequired":false,"questionnaireVersions":null,"hasGuests":true}}}}`), nil
+			case 2, 5:
+				if request.URL.String() != "https://api.partiful.com/getGuests" {
+					t.Fatalf("request %d = %s, want getGuests", call, request.URL)
+				}
+				body, _ := io.ReadAll(request.Body)
+				const want = `{"data":{"params":{"eventId":"event-example","includeInvitedGuests":true},"amplitudeDeviceId":"` + deviceIDBase64 + `","paging":{"cursor":null,"maxResults":500}}}`
+				if string(body) != want {
+					t.Fatalf("first guest page body = %s, want %s", body, want)
+				}
+				return jsonResponse(http.StatusOK, `{"result":{"data":[{"id":"private-guest-1","userId":"private-attendee","name":"Alice Example","status":"GOING","count":2,"anchorGuestId":null},{"id":"private-plus-one","name":"Plus One","status":"GOING","count":1,"anchorGuestId":"private-guest-1"}],"paging":{"nextCursor":"`+guestCursor+`"}}}`), nil
+			case 3, 6:
+				body, _ := io.ReadAll(request.Body)
+				const want = `{"data":{"params":{"eventId":"event-example","includeInvitedGuests":true},"amplitudeDeviceId":"` + deviceIDBase64 + `","paging":{"cursor":"` + guestCursor + `","maxResults":500}}}`
+				if string(body) != want {
+					t.Fatalf("second guest page body = %s, want %s", body, want)
+				}
+				return jsonResponse(http.StatusOK, `{"result":{"data":[{"id":"private-guest-2","userId":"`+cohostUserID+`","name":"Cohost Example","status":"SENT","count":1,"anchorGuestId":null}],"paging":{}}}`), nil
+			default:
+				return nil, errors.New("unexpected request")
+			}
+		}},
+	})
+
+	first := app.Execute(context.Background(), app.Request{
+		Argv: []string{"guests", "list", "event-example", "--limit", "1"},
+	}, dependencies)
+	if first.ExitCode != 0 || first.Stderr != "" {
+		t.Fatalf("first = %#v, want first guest page", first)
+	}
+	var firstEnvelope struct {
+		Data struct {
+			Items []guestOutput `json:"items"`
+		} `json:"data"`
+		Meta struct {
+			Page struct {
+				Limit      int     `json:"limit"`
+				NextCursor *string `json:"nextCursor"`
+				HasMore    bool    `json:"hasMore"`
+			} `json:"page"`
+		} `json:"meta"`
+	}
+	if err := json.Unmarshal([]byte(first.Stdout), &firstEnvelope); err != nil {
+		t.Fatalf("decode first result: %v", err)
+	}
+	if !reflect.DeepEqual(firstEnvelope.Data.Items, []guestOutput{{
+		DisplayName: "Alice Example",
+		RSVPStatus:  "going",
+		PartySize:   2,
+		Cohost:      false,
+	}}) {
+		t.Fatalf("first items = %#v", firstEnvelope.Data.Items)
+	}
+	if firstEnvelope.Meta.Page.Limit != 1 ||
+		firstEnvelope.Meta.Page.NextCursor == nil ||
+		*firstEnvelope.Meta.Page.NextCursor == "" ||
+		!firstEnvelope.Meta.Page.HasMore {
+		t.Fatalf("first page = %#v, want resumable first page", firstEnvelope.Meta.Page)
+	}
+	for _, privateValue := range []string{"private-attendee", cohostUserID, guestCursor, "private-guest-1", "private-plus-one"} {
+		if strings.Contains(first.Stdout+first.Stderr, privateValue) {
+			t.Fatalf("first page exposed private value %q", privateValue)
+		}
+	}
+
+	second := app.Execute(context.Background(), app.Request{
+		Argv: []string{"guests", "list", "event-example", "--cursor", *firstEnvelope.Meta.Page.NextCursor},
+	}, dependencies)
+	if second.ExitCode != 0 || second.Stderr != "" {
+		t.Fatalf("second = %#v, want resumed guest page", second)
+	}
+	var secondEnvelope struct {
+		Data struct {
+			Items []guestOutput `json:"items"`
+		} `json:"data"`
+		Meta struct {
+			Page struct {
+				NextCursor *string `json:"nextCursor"`
+				HasMore    bool    `json:"hasMore"`
+			} `json:"page"`
+		} `json:"meta"`
+	}
+	if err := json.Unmarshal([]byte(second.Stdout), &secondEnvelope); err != nil {
+		t.Fatalf("decode second result: %v", err)
+	}
+	if !reflect.DeepEqual(secondEnvelope.Data.Items, []guestOutput{{
+		DisplayName: "Cohost Example",
+		RSVPStatus:  "sent",
+		PartySize:   1,
+		Cohost:      true,
+	}}) || secondEnvelope.Meta.Page.NextCursor != nil || secondEnvelope.Meta.Page.HasMore {
+		t.Fatalf("second result = %#v envelope = %#v", second, secondEnvelope)
+	}
+	if call != 6 {
+		t.Fatalf("request count = %d, want two complete guest traversals", call)
+	}
+}
+
+func TestExecuteGuestsListReturnsPermissionDeniedForAttendee(t *testing.T) {
+	const (
+		currentUserID = "private-attendee"
+		credentials   = `{"accessToken":"private-access-token","userId":"` + currentUserID + `","expiresAt":"2026-08-12T02:00:00Z"}`
+	)
+	call := 0
+	result := app.Execute(context.Background(), app.Request{
+		Argv: []string{"guests", "list", "event-example"},
+	}, app.Dependencies{
+		Files: fakeFilesystem{
+			readFile: func(string) ([]byte, error) { return []byte(credentials), nil },
+		},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 12, 0, 0, 0, 0, time.UTC)
+		},
+		AuthRandom: strings.NewReader(strings.Repeat("0123456789abcdef", 4)),
+		HTTP: scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+			call++
+			if request.URL.String() != "https://api.partiful.com/getEventInfo" {
+				t.Fatalf("request = %s, want getEventInfo", request.URL)
+			}
+			return jsonResponse(http.StatusOK, `{"result":{"data":{"event":{"id":"event-example","ownerIds":["private-host"],"rsvpsEnabled":true,"atCapacity":false,"plusOneNamesRequired":false,"questionnaireVersions":null,"hasGuests":true}}}}`), nil
+		}},
+	})
+
+	const want = `{"ok":false,"error":{"type":"permission.denied","code":"HOST_PERMISSION_REQUIRED","message":"This command requires host access to the event.","retryable":false,"details":{"requiredRole":"host"}},"meta":{"command":"guests.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
+	if result.ExitCode != 4 || result.Stdout != want || result.Stderr != "partiful: host access required\n" {
+		t.Fatalf("result = %#v, want host permission denial", result)
+	}
+	if call != 1 {
+		t.Fatalf("request count = %d, want no guest traversal", call)
+	}
+	for _, privateValue := range []string{"private-host", currentUserID} {
+		if strings.Contains(result.Stdout+result.Stderr, privateValue) {
+			t.Fatalf("permission denial exposed private value %q", privateValue)
+		}
+	}
+}
+
+func TestExecuteGuestsListReturnsEmptyCollectionForHost(t *testing.T) {
+	const credentials = `{"accessToken":"private-access-token","userId":"private-host","expiresAt":"2026-08-12T02:00:00Z"}`
+	call := 0
+	result := app.Execute(context.Background(), app.Request{
+		Argv: []string{"guests", "list", "event-example"},
+	}, app.Dependencies{
+		Files: fakeFilesystem{
+			readFile: func(string) ([]byte, error) { return []byte(credentials), nil },
+		},
+		CredentialsPath: "/config/partiful/credentials.json",
+		Now: func() time.Time {
+			return time.Date(2026, time.August, 12, 0, 0, 0, 0, time.UTC)
+		},
+		AuthRandom: strings.NewReader(strings.Repeat("0123456789abcdef", 4)),
+		HTTP: scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+			call++
+			switch call {
+			case 1:
+				return jsonResponse(http.StatusOK, `{"result":{"data":{"event":{"id":"event-example","ownerIds":["private-host"],"rsvpsEnabled":true,"atCapacity":false,"plusOneNamesRequired":false,"questionnaireVersions":null,"hasGuests":false}}}}`), nil
+			case 2:
+				return jsonResponse(http.StatusOK, `{"result":{"data":[],"paging":{}}}`), nil
+			default:
+				return nil, errors.New("unexpected request")
+			}
+		}},
+	})
+
+	const want = `{"ok":true,"data":{"items":[]},"meta":{"command":"guests.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
+	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
+		t.Fatalf("result = %#v, want empty host guest list", result)
+	}
+}
+
+func TestExecuteGuestsInviteBindsResolvedContactAndAppliesWithoutReResolvingName(t *testing.T) {
+	files := &memoryFilesystem{files: map[string][]byte{
+		eventWriteCredentialsPath: []byte(`{"accessToken":"private-access-token","userId":"private-host","expiresAt":"2026-08-12T02:00:00Z"}`),
+	}}
+	dependencies := eventWriteDependencies(files)
+	dependencies.MutationRandom = strings.NewReader(strings.Repeat("v", 32))
+	call := 0
+	dependencies.HTTP = scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+		call++
+		switch call {
+		case 1, 4:
+			assertEventCallableRequest(t, request, "getEventInfo", `{"data":{"params":{"eventId":"event-example"},"amplitudeDeviceId":"MDEyMzQ1Njc4OWFiY2RlZg"}}`)
+			return jsonResponse(http.StatusOK, `{"result":{"data":{"event":{"id":"event-example","ownerIds":["private-host"],"rsvpsEnabled":true,"atCapacity":false,"plusOneNamesRequired":false,"questionnaireVersions":null,"hasGuests":true}}}}`), nil
+		case 2:
+			assertEventCallableRequest(t, request, "getContacts", `{"data":{"params":{},"amplitudeDeviceId":"MDEyMzQ1Njc4OWFiY2RlZg","paging":{"maxResults":1000,"cursor":null}}}`)
+			return jsonResponse(http.StatusOK, `{"result":{"data":[{"id":"private-contact-1","name":"Alex Example","sharedEventCount":2}],"paging":{"nextCursor":"private-contacts-cursor"}}}`), nil
+		case 3:
+			return jsonResponse(http.StatusOK, `{"result":{"data":[],"paging":{}}}`), nil
+		case 5:
+			return jsonResponse(http.StatusOK, `{"result":{"data":[{"id":"private-contact-1","name":"Alex Example","sharedEventCount":2},{"id":"private-contact-2","name":"Alex Example","sharedEventCount":5}],"paging":{"nextCursor":"private-contacts-cursor"}}}`), nil
+		case 6:
+			return jsonResponse(http.StatusOK, `{"result":{"data":[],"paging":{}}}`), nil
+		case 7:
+			assertEventCallableRequest(t, request, "addInvitedGuestsAsHost", `{"data":{"params":{"eventId":"event-example","userIdsToInvite":["private-contact-1"],"invitationMessage":"","otherMutualsCount":0,"phoneContactsToInvite":[],"emailsToInvite":[]},"amplitudeDeviceId":"MDEyMzQ1Njc4OWFiY2RlZg","userId":"private-host"}}`)
+			return jsonResponse(http.StatusOK, `{"result":{"ok":true}}`), nil
+		default:
+			return nil, errors.New("unexpected request")
+		}
+	}}
+
+	argv := []string{"guests", "invite", "event-example", "--contact", "Alex Example"}
+	plan := app.Execute(context.Background(), app.Request{Argv: argv}, dependencies)
+	if plan.ExitCode != 0 || strings.Contains(plan.Stdout, "private-contact-1") {
+		t.Fatalf("plan = %#v, want redacted guest invite plan", plan)
+	}
+	if !strings.Contains(plan.Stdout, `"operation":"addInvitedGuestsAsHost"`) ||
+		!strings.Contains(plan.Stdout, `\u003credacted\u003e`) ||
+		!strings.Contains(plan.Stdout, `"contact":"Alex Example"`) {
+		t.Fatalf("plan = %s, want reviewed guest invite plan", plan.Stdout)
+	}
+	token := rsvpPlanToken(t, plan)
+
+	applied := app.Execute(context.Background(), app.Request{
+		Argv: append(append([]string{}, argv...), "--apply", "--confirm", token),
+	}, dependencies)
+	const want = `{"ok":true,"data":{"eventId":"event-example","submitted":true},"meta":{"command":"guests.invite","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[]}}` + "\n"
+	if applied.ExitCode != 0 || applied.Stdout != want || applied.Stderr != "" {
+		t.Fatalf("applied = %#v, want submitted-only guest invite result", applied)
+	}
+	if call != 7 {
+		t.Fatalf("request count = %d, want plan reads, apply reads, and one mutation", call)
+	}
+	for _, privateValue := range []string{"private-contact-1", "private-contact-2", "private-contacts-cursor"} {
+		if strings.Contains(plan.Stdout+plan.Stderr+applied.Stdout+applied.Stderr, privateValue) {
+			t.Fatalf("guest invite flow exposed private value %q", privateValue)
+		}
+	}
+}
+
+func TestExecuteGuestsInviteReturnsPublicAmbiguityAndStalesChangedContact(t *testing.T) {
+	t.Run("ambiguous planning", func(t *testing.T) {
+		dependencies := eventWriteDependencies(&memoryFilesystem{files: map[string][]byte{
+			eventWriteCredentialsPath: []byte(`{"accessToken":"private-access-token","userId":"private-host","expiresAt":"2026-08-12T02:00:00Z"}`),
+		}})
+		call := 0
+		dependencies.HTTP = scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+			call++
+			switch call {
+			case 1:
+				return jsonResponse(http.StatusOK, `{"result":{"data":{"event":{"id":"event-example","ownerIds":["private-host"],"rsvpsEnabled":true,"atCapacity":false,"plusOneNamesRequired":false,"questionnaireVersions":null,"hasGuests":true}}}}`), nil
+			case 2:
+				return jsonResponse(http.StatusOK, `{"result":{"data":[{"id":"private-contact-1","name":"Alex Example","sharedEventCount":2},{"id":"private-contact-2","name":"Alex Example","sharedEventCount":5}],"paging":{"nextCursor":"private-cursor"}}}`), nil
+			case 3:
+				return jsonResponse(http.StatusOK, `{"result":{"data":[],"paging":{}}}`), nil
+			default:
+				return nil, errors.New("unexpected request")
+			}
+		}}
+
+		result := app.Execute(context.Background(), app.Request{
+			Argv: []string{"guests", "invite", "event-example", "--contact", "Alex Example"},
+		}, dependencies)
+		if result.ExitCode != 2 ||
+			!strings.Contains(result.Stdout, `"type":"match.ambiguous"`) ||
+			!strings.Contains(result.Stdout, `"displayName":"Alex Example"`) ||
+			!strings.Contains(result.Stdout, `"sharedEventCount":2`) ||
+			!strings.Contains(result.Stdout, `"sharedEventCount":5`) {
+			t.Fatalf("result = %#v, want public ambiguity", result)
+		}
+		for _, privateValue := range []string{"private-contact-1", "private-contact-2", "private-cursor"} {
+			if strings.Contains(result.Stdout+result.Stderr, privateValue) {
+				t.Fatalf("ambiguity exposed private value %q", privateValue)
+			}
+		}
+	})
+
+	t.Run("stale contact", func(t *testing.T) {
+		files := &memoryFilesystem{files: map[string][]byte{
+			eventWriteCredentialsPath: []byte(`{"accessToken":"private-access-token","userId":"private-host","expiresAt":"2026-08-12T02:00:00Z"}`),
+		}}
+		dependencies := eventWriteDependencies(files)
+		dependencies.MutationRandom = strings.NewReader(strings.Repeat("w", 32))
+		call := 0
+		dependencies.HTTP = scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+			call++
+			switch call {
+			case 1, 4:
+				return jsonResponse(http.StatusOK, `{"result":{"data":{"event":{"id":"event-example","ownerIds":["private-host"],"rsvpsEnabled":true,"atCapacity":false,"plusOneNamesRequired":false,"questionnaireVersions":null,"hasGuests":true}}}}`), nil
+			case 2:
+				return jsonResponse(http.StatusOK, `{"result":{"data":[{"id":"private-contact-1","name":"Alex Example","sharedEventCount":2}],"paging":{"nextCursor":"private-cursor"}}}`), nil
+			case 3:
+				return jsonResponse(http.StatusOK, `{"result":{"data":[],"paging":{}}}`), nil
+			case 5:
+				return jsonResponse(http.StatusOK, `{"result":{"data":[{"id":"private-contact-1","name":"Alex Example","sharedEventCount":3}],"paging":{"nextCursor":"private-cursor"}}}`), nil
+			case 6:
+				return jsonResponse(http.StatusOK, `{"result":{"data":[],"paging":{}}}`), nil
+			default:
+				return nil, errors.New("unexpected request")
+			}
+		}}
+
+		argv := []string{"guests", "invite", "event-example", "--contact", "Alex Example"}
+		plan := app.Execute(context.Background(), app.Request{Argv: argv}, dependencies)
+		if plan.ExitCode != 0 {
+			t.Fatalf("plan = %#v", plan)
+		}
+		token := rsvpPlanToken(t, plan)
+		applied := app.Execute(context.Background(), app.Request{
+			Argv: append(append([]string{}, argv...), "--apply", "--confirm", token),
+		}, dependencies)
+		if applied.ExitCode != 7 || !strings.Contains(applied.Stdout, `"type":"safety.plan_stale"`) {
+			t.Fatalf("applied = %#v, want stale changed-contact plan", applied)
+		}
+		if call != 6 {
+			t.Fatalf("request count = %d, want no mutation on stale contact", call)
+		}
+	})
+}
+
+type guestOutput struct {
+	DisplayName string `json:"displayName"`
+	RSVPStatus  string `json:"rsvpStatus"`
+	PartySize   int    `json:"partySize"`
+	Cohost      bool   `json:"cohost"`
+}
+
+func TestExecuteSchemaProjectsGuestCommands(t *testing.T) {
+	list := app.Execute(context.Background(), app.Request{
+		Argv: []string{"schema", "guests.list"},
+	}, app.Dependencies{})
+	if list.ExitCode != 0 ||
+		!strings.Contains(list.Stdout, `"command":"guests.list"`) ||
+		!strings.Contains(list.Stdout, `"rsvpStatus"`) ||
+		!strings.Contains(list.Stdout, `"cohost"`) ||
+		!strings.Contains(list.Stdout, `"kind":"read-only"`) {
+		t.Fatalf("list schema = %#v, want guests.list projection", list)
+	}
+
+	invite := app.Execute(context.Background(), app.Request{
+		Argv: []string{"schema", "guests.invite"},
+	}, app.Dependencies{})
+	if invite.ExitCode != 0 ||
+		!strings.Contains(invite.Stdout, `"command":"guests.invite"`) ||
+		!strings.Contains(invite.Stdout, `"--contact"`) ||
+		!strings.Contains(invite.Stdout, `"kind":"consequential-action"`) ||
+		!strings.Contains(invite.Stdout, `"confirmationRequired":true`) {
+		t.Fatalf("invite schema = %#v, want guests.invite projection", invite)
+	}
+}

--- a/internal/app/guests_execute_test.go
+++ b/internal/app/guests_execute_test.go
@@ -182,6 +182,17 @@ func TestExecuteGuestsListReturnsPermissionDeniedForAttendee(t *testing.T) {
 	}
 }
 
+func TestExecuteGuestsListRejectsMissingEventID(t *testing.T) {
+	result := app.Execute(context.Background(), app.Request{
+		Argv: []string{"guests", "list"},
+	}, app.Dependencies{})
+	if result.ExitCode != 2 ||
+		!strings.Contains(result.Stdout, `"type":"input.invalid"`) ||
+		!strings.Contains(result.Stdout, `"code":"EVENT_ID_REQUIRED"`) {
+		t.Fatalf("result = %#v, want missing event ID input failure", result)
+	}
+}
+
 func TestExecuteGuestsListReturnsEmptyCollectionForHost(t *testing.T) {
 	const credentials = `{"accessToken":"private-access-token","userId":"private-host","expiresAt":"2026-08-12T02:00:00Z"}`
 	call := 0

--- a/internal/app/guests_execute_test.go
+++ b/internal/app/guests_execute_test.go
@@ -140,6 +140,11 @@ func TestExecuteGuestsListPaginatesHostGuestsAndKeepsOutputPrivacySafe(t *testin
 	if call != 6 {
 		t.Fatalf("request count = %d, want two complete guest traversals", call)
 	}
+	for _, privateValue := range []string{cohostUserID, guestCursor, "private-guest-2"} {
+		if strings.Contains(second.Stdout+second.Stderr, privateValue) {
+			t.Fatalf("second page exposed private value %q", privateValue)
+		}
+	}
 }
 
 func TestExecuteGuestsListReturnsPermissionDeniedForAttendee(t *testing.T) {

--- a/internal/remote/guests.go
+++ b/internal/remote/guests.go
@@ -1,0 +1,394 @@
+package remote
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"strings"
+	"unicode/utf8"
+)
+
+const (
+	guestPageSize           = 500
+	maximumGuestDataPages   = 20
+	maximumGuestCatalogSize = guestPageSize * maximumGuestDataPages
+	maximumGuestPageBytes   = 8 << 20
+)
+
+type Guest struct {
+	ID            string
+	UserID        *string
+	Name          string
+	Status        string
+	Count         int
+	AnchorGuestID *string
+}
+
+type GuestCatalog struct {
+	Guests        []Guest
+	PayloadSHA256 [sha256.Size]byte
+}
+
+type getGuestsRequest struct {
+	Data getGuestsRequestData `json:"data"`
+}
+
+type getGuestsRequestData struct {
+	Params            getGuestsParams `json:"params"`
+	AmplitudeDeviceID string          `json:"amplitudeDeviceId"`
+	Paging            guestPaging     `json:"paging"`
+}
+
+type getGuestsParams struct {
+	EventID              string  `json:"eventId"`
+	IncludeInvitedGuests bool    `json:"includeInvitedGuests"`
+	Password             *string `json:"password,omitempty"`
+}
+
+type guestPaging struct {
+	Cursor     *string `json:"cursor"`
+	MaxResults int     `json:"maxResults"`
+}
+
+type getGuestsResponse struct {
+	Result struct {
+		Data   []json.RawMessage `json:"data"`
+		Paging *struct {
+			NextCursor json.RawMessage `json:"nextCursor"`
+		} `json:"paging"`
+	} `json:"result"`
+}
+
+type InviteGuestsAsHostParams struct {
+	EventID               string           `json:"eventId"`
+	UserIDsToInvite       []string         `json:"userIdsToInvite"`
+	InvitationMessage     string           `json:"invitationMessage"`
+	OtherMutualsCount     int              `json:"otherMutualsCount"`
+	PhoneContactsToInvite []map[string]any `json:"phoneContactsToInvite"`
+	EmailsToInvite        []map[string]any `json:"emailsToInvite"`
+}
+
+type guestMutationRequest[T any] struct {
+	Data guestMutationRequestData[T] `json:"data"`
+}
+
+type guestMutationRequestData[T any] struct {
+	Params            T      `json:"params"`
+	AmplitudeDeviceID string `json:"amplitudeDeviceId"`
+	UserID            any    `json:"userId"`
+}
+
+func (client Client) GetGuests(
+	ctx context.Context,
+	accessToken string,
+	amplitudeDeviceID string,
+	eventID string,
+) (GuestCatalog, error) {
+	var (
+		cursor        *string
+		guests        []Guest
+		dataPageCount int
+	)
+	seenCursors := make(map[string]struct{})
+	for {
+		page, err := client.getGuestsPage(
+			ctx,
+			accessToken,
+			amplitudeDeviceID,
+			eventID,
+			cursor,
+		)
+		if err != nil {
+			return GuestCatalog{}, err
+		}
+		nextCursor, err := decodeGuestNextCursor(page.Result.Paging.NextCursor)
+		if err != nil {
+			return GuestCatalog{}, err
+		}
+		if len(page.Result.Data) > 0 {
+			dataPageCount++
+			if dataPageCount > maximumGuestDataPages ||
+				len(page.Result.Data) > maximumGuestCatalogSize-len(guests) {
+				return GuestCatalog{}, fmt.Errorf("%w: guests traversal bound", ErrProtocolChanged)
+			}
+		}
+		for _, rawGuest := range page.Result.Data {
+			guest, err := decodeGuest(rawGuest)
+			if err != nil {
+				return GuestCatalog{}, fmt.Errorf("%w: guest", ErrProtocolChanged)
+			}
+			guests = append(guests, guest)
+		}
+		if nextCursor == nil {
+			document, _ := json.Marshal(guests)
+			return GuestCatalog{
+				Guests:        guests,
+				PayloadSHA256: sha256.Sum256(document),
+			}, nil
+		}
+		if len(page.Result.Data) == 0 {
+			return GuestCatalog{}, fmt.Errorf("%w: empty guests page", ErrProtocolChanged)
+		}
+		if _, repeated := seenCursors[*nextCursor]; repeated {
+			return GuestCatalog{}, fmt.Errorf("%w: repeated guests cursor", ErrProtocolChanged)
+		}
+		seenCursors[*nextCursor] = struct{}{}
+		cursor = nextCursor
+	}
+}
+
+func (client Client) getGuestsPage(
+	ctx context.Context,
+	accessToken string,
+	amplitudeDeviceID string,
+	eventID string,
+	cursor *string,
+) (getGuestsResponse, error) {
+	if client.HTTP == nil {
+		return getGuestsResponse{}, fmt.Errorf("%w: guests transport", ErrUnavailable)
+	}
+	payload, _ := json.Marshal(getGuestsRequest{Data: getGuestsRequestData{
+		Params: getGuestsParams{
+			EventID:              eventID,
+			IncludeInvitedGuests: true,
+		},
+		AmplitudeDeviceID: amplitudeDeviceID,
+		Paging: guestPaging{
+			Cursor:     cursor,
+			MaxResults: guestPageSize,
+		},
+	}})
+	request, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		partifulCallableHost+"/getGuests",
+		bytes.NewReader(payload),
+	)
+	if err != nil {
+		return getGuestsResponse{}, fmt.Errorf("%w: guests request", ErrUnavailable)
+	}
+	request.Header.Set("Authorization", "Bearer "+accessToken)
+	request.Header.Set("Content-Type", "application/json")
+	response, err := client.HTTP.Do(request)
+	if err != nil {
+		return getGuestsResponse{}, fmt.Errorf("%w: guests request failed", ErrUnavailable)
+	}
+	if response == nil || response.Body == nil {
+		return getGuestsResponse{}, fmt.Errorf("%w: guests response", ErrProtocolChanged)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return getGuestsResponse{}, fmt.Errorf("%w: guests status", ErrProtocolChanged)
+	}
+	mediaType, _, err := mime.ParseMediaType(response.Header.Get("Content-Type"))
+	if err != nil || mediaType != "application/json" {
+		return getGuestsResponse{}, fmt.Errorf("%w: guests content type", ErrProtocolChanged)
+	}
+	body, err := io.ReadAll(io.LimitReader(response.Body, maximumGuestPageBytes+1))
+	if err != nil {
+		return getGuestsResponse{}, fmt.Errorf("%w: guests response read", ErrUnavailable)
+	}
+	if len(body) > maximumGuestPageBytes || !utf8.Valid(body) {
+		return getGuestsResponse{}, fmt.Errorf("%w: guests response body", ErrProtocolChanged)
+	}
+	var page getGuestsResponse
+	if err := decodeSingleGuestJSON(body, &page); err != nil ||
+		page.Result.Data == nil ||
+		page.Result.Paging == nil {
+		return getGuestsResponse{}, fmt.Errorf("%w: guests response body", ErrProtocolChanged)
+	}
+	return page, nil
+}
+
+func decodeGuestNextCursor(value json.RawMessage) (*string, error) {
+	if len(value) == 0 {
+		return nil, nil
+	}
+	trimmed := bytes.TrimSpace(value)
+	if bytes.Equal(trimmed, []byte("null")) {
+		return nil, nil
+	}
+	var cursor string
+	if err := decodeSingleGuestJSON(trimmed, &cursor); err != nil ||
+		strings.TrimSpace(cursor) == "" {
+		return nil, fmt.Errorf("%w: guests cursor", ErrProtocolChanged)
+	}
+	return &cursor, nil
+}
+
+func decodeGuest(raw json.RawMessage) (Guest, error) {
+	object, err := decodeEventObject(raw)
+	if err != nil {
+		return Guest{}, err
+	}
+	id, present, err := eventStringField(object, "id", false)
+	if err != nil || !present || strings.TrimSpace(*id) == "" {
+		return Guest{}, errors.New("guest id is invalid")
+	}
+	name, present, err := eventStringField(object, "name", false)
+	if err != nil || !present || strings.TrimSpace(*name) == "" {
+		return Guest{}, errors.New("guest name is invalid")
+	}
+	status, present, err := eventStringField(object, "status", false)
+	if err != nil || !present || !validGuestStatus(*status) {
+		return Guest{}, errors.New("guest status is invalid")
+	}
+	count, err := requiredGuestCount(object, "count")
+	if err != nil {
+		return Guest{}, err
+	}
+	userID, err := optionalGuestString(object, "userId")
+	if err != nil {
+		return Guest{}, err
+	}
+	anchorGuestID, err := optionalGuestString(object, "anchorGuestId")
+	if err != nil {
+		return Guest{}, err
+	}
+	return Guest{
+		ID:            *id,
+		UserID:        userID,
+		Name:          *name,
+		Status:        *status,
+		Count:         count,
+		AnchorGuestID: anchorGuestID,
+	}, nil
+}
+
+func requiredGuestCount(
+	object map[string]json.RawMessage,
+	name string,
+) (int, error) {
+	raw, ok := object[name]
+	if !ok {
+		return 0, errors.New("guest count is missing")
+	}
+	var value float64
+	if json.Unmarshal(raw, &value) != nil ||
+		value < 1 ||
+		value > float64(int(^uint(0)>>1)) ||
+		float64(int(value)) != value {
+		return 0, errors.New("guest count is invalid")
+	}
+	return int(value), nil
+}
+
+func optionalGuestString(
+	object map[string]json.RawMessage,
+	name string,
+) (*string, error) {
+	raw, ok := object[name]
+	if !ok || bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return nil, nil
+	}
+	var value string
+	if json.Unmarshal(raw, &value) != nil || strings.TrimSpace(value) == "" {
+		return nil, errors.New("guest string is invalid")
+	}
+	return &value, nil
+}
+
+func (client Client) InviteGuestsAsHost(
+	ctx context.Context,
+	accessToken string,
+	userID string,
+	amplitudeDeviceID string,
+	params InviteGuestsAsHostParams,
+) error {
+	_, err := callGuestMutation(
+		client,
+		ctx,
+		accessToken,
+		userID,
+		amplitudeDeviceID,
+		"addInvitedGuestsAsHost",
+		params,
+	)
+	return err
+}
+
+func callGuestMutation[T any](
+	client Client,
+	ctx context.Context,
+	accessToken string,
+	userID string,
+	amplitudeDeviceID string,
+	operation string,
+	params T,
+) (json.RawMessage, error) {
+	if client.HTTP == nil {
+		return nil, fmt.Errorf("%w: guest mutation transport", ErrUnavailable)
+	}
+	var encodedUserID any
+	if userID != "" {
+		encodedUserID = userID
+	}
+	payload, _ := json.Marshal(guestMutationRequest[T]{
+		Data: guestMutationRequestData[T]{
+			Params:            params,
+			AmplitudeDeviceID: amplitudeDeviceID,
+			UserID:            encodedUserID,
+		},
+	})
+	request, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		partifulCallableHost+"/"+operation,
+		bytes.NewReader(payload),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("%w: guest mutation request", ErrUnavailable)
+	}
+	request.Header.Set("Authorization", "Bearer "+accessToken)
+	request.Header.Set("Content-Type", "application/json")
+	response, err := client.HTTP.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("%w: guest mutation request failed", ErrUnavailable)
+	}
+	if response == nil || response.Body == nil {
+		return nil, fmt.Errorf("%w: guest mutation response", ErrProtocolChanged)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%w: guest mutation status", ErrProtocolChanged)
+	}
+	if !eventJSONContentType(response.Header.Get("Content-Type")) {
+		return nil, fmt.Errorf("%w: guest mutation content type", ErrProtocolChanged)
+	}
+	body, err := io.ReadAll(io.LimitReader(response.Body, maximumEventWriteBodyBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("%w: guest mutation response read", ErrUnavailable)
+	}
+	if len(body) > maximumEventWriteBodyBytes || !utf8.Valid(body) {
+		return nil, fmt.Errorf("%w: guest mutation response body", ErrProtocolChanged)
+	}
+	root, err := decodeEventObject(body)
+	if err != nil {
+		return nil, fmt.Errorf("%w: guest mutation response body", ErrProtocolChanged)
+	}
+	if data, ok := root["data"]; ok {
+		return bytes.Clone(data), nil
+	}
+	if result, ok := root["result"]; ok {
+		return bytes.Clone(result), nil
+	}
+	return nil, fmt.Errorf("%w: guest mutation completion", ErrProtocolChanged)
+}
+
+func decodeSingleGuestJSON(body []byte, destination any) error {
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	if err := decoder.Decode(destination); err != nil {
+		return err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return errors.New("guest response has trailing JSON")
+	}
+	return nil
+}

--- a/internal/remote/guests.go
+++ b/internal/remote/guests.go
@@ -8,8 +8,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"mime"
+	"math"
 	"net/http"
+	"strconv"
 	"strings"
 	"unicode/utf8"
 )
@@ -186,8 +187,7 @@ func (client Client) getGuestsPage(
 	if response.StatusCode != http.StatusOK {
 		return getGuestsResponse{}, fmt.Errorf("%w: guests status", ErrProtocolChanged)
 	}
-	mediaType, _, err := mime.ParseMediaType(response.Header.Get("Content-Type"))
-	if err != nil || mediaType != "application/json" {
+	if !eventJSONContentType(response.Header.Get("Content-Type")) {
 		return getGuestsResponse{}, fmt.Errorf("%w: guests content type", ErrProtocolChanged)
 	}
 	body, err := io.ReadAll(io.LimitReader(response.Body, maximumGuestPageBytes+1))
@@ -271,12 +271,16 @@ func requiredGuestCount(
 	}
 	var value float64
 	if json.Unmarshal(raw, &value) != nil ||
-		value < 1 ||
-		value > float64(int(^uint(0)>>1)) ||
-		float64(int(value)) != value {
+		value < 0 ||
+		value > 1<<53-1 ||
+		math.Trunc(value) != value {
 		return 0, errors.New("guest count is invalid")
 	}
-	return int(value), nil
+	integer := int64(value)
+	if strconv.IntSize == 32 && integer > math.MaxInt32 {
+		return 0, errors.New("guest count is invalid")
+	}
+	return int(integer), nil
 }
 
 func optionalGuestString(

--- a/internal/remote/guests.go
+++ b/internal/remote/guests.go
@@ -182,7 +182,7 @@ func (client Client) getGuestsPage(
 	if response == nil || response.Body == nil {
 		return getGuestsResponse{}, fmt.Errorf("%w: guests response", ErrProtocolChanged)
 	}
-	defer response.Body.Close()
+	defer func() { _ = response.Body.Close() }()
 	if response.StatusCode != http.StatusOK {
 		return getGuestsResponse{}, fmt.Errorf("%w: guests status", ErrProtocolChanged)
 	}
@@ -354,7 +354,7 @@ func callGuestMutation[T any](
 	if response == nil || response.Body == nil {
 		return nil, fmt.Errorf("%w: guest mutation response", ErrProtocolChanged)
 	}
-	defer response.Body.Close()
+	defer func() { _ = response.Body.Close() }()
 	if response.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("%w: guest mutation status", ErrProtocolChanged)
 	}
@@ -372,13 +372,14 @@ func callGuestMutation[T any](
 	if err != nil {
 		return nil, fmt.Errorf("%w: guest mutation response body", ErrProtocolChanged)
 	}
-	if data, ok := root["data"]; ok {
-		return bytes.Clone(data), nil
+	result, ok := root["result"]
+	if !ok {
+		return nil, fmt.Errorf("%w: guest mutation completion", ErrProtocolChanged)
 	}
-	if result, ok := root["result"]; ok {
-		return bytes.Clone(result), nil
+	if _, err := decodeEventObject(result); err != nil {
+		return nil, fmt.Errorf("%w: guest mutation completion", ErrProtocolChanged)
 	}
-	return nil, fmt.Errorf("%w: guest mutation completion", ErrProtocolChanged)
+	return bytes.Clone(result), nil
 }
 
 func decodeSingleGuestJSON(body []byte, destination any) error {

--- a/internal/remote/guests_test.go
+++ b/internal/remote/guests_test.go
@@ -1,0 +1,59 @@
+package remote
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type guestHTTPClientFunc func(*http.Request) (*http.Response, error)
+
+func (do guestHTTPClientFunc) Do(request *http.Request) (*http.Response, error) {
+	return do(request)
+}
+
+func TestInviteGuestsAsHostValidatesReviewedCompletionEnvelope(t *testing.T) {
+	for _, testCase := range []struct {
+		name      string
+		body      string
+		wantError bool
+	}{
+		{name: "reviewed result object", body: `{"result":{"ok":true}}`},
+		{name: "unreviewed data envelope", body: `{"data":{}}`, wantError: true},
+		{name: "null result", body: `{"result":null}`, wantError: true},
+		{name: "missing result", body: `{}`, wantError: true},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			client := Client{HTTP: guestHTTPClientFunc(func(*http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     http.Header{"Content-Type": []string{"application/json"}},
+					Body:       io.NopCloser(strings.NewReader(testCase.body)),
+				}, nil
+			})}
+			err := client.InviteGuestsAsHost(
+				context.Background(),
+				"private-access-token",
+				"private-user",
+				"private-device",
+				InviteGuestsAsHostParams{
+					EventID:               "event-example",
+					UserIDsToInvite:       []string{"private-contact"},
+					InvitationMessage:     "",
+					OtherMutualsCount:     0,
+					PhoneContactsToInvite: []map[string]any{},
+					EmailsToInvite:        []map[string]any{},
+				},
+			)
+			if testCase.wantError && !errors.Is(err, ErrProtocolChanged) {
+				t.Fatalf("error = %v, want protocol changed", err)
+			}
+			if !testCase.wantError && err != nil {
+				t.Fatalf("error = %v, want success", err)
+			}
+		})
+	}
+}

--- a/spec/partiful.api-evidence.json
+++ b/spec/partiful.api-evidence.json
@@ -1,5 +1,5 @@
 {
-  "contractRevision": "2026-08-12.4",
+  "contractRevision": "2026-08-12.5",
   "ownerReviewedBaseline": "2026-08-12.3",
   "contractPath": "spec/partiful.openapi.json",
   "allowedClassifications": [
@@ -61,7 +61,8 @@
     "publicCancelEvent20260812": "docs/research/2026-08-12-event-write-mapping-public-assets.md#cancelevent-request-and-completion",
     "publicEventPosterMapping20260812": "docs/research/2026-08-12-event-write-mapping-public-assets.md#built-in-poster-representation",
     "publicEventWritePreconditions20260812": "docs/research/2026-08-12-event-write-mapping-public-assets.md#update-preconditions",
-    "officialFirestoreProtocol": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    "officialFirestoreProtocol": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol",
+    "publicGuestMapping20260812": "docs/research/2026-08-12-guest-mapping-public-assets.md#scope-and-provenance"
   },
   "operations": {
     "createEvent": {
@@ -85,8 +86,8 @@
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation"
     },
     "addInvitedGuestsAsHost": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#scope-and-provenance"
     },
     "createCohostRequest": {
       "classification": "typescript-derived-inference",
@@ -171,6 +172,10 @@
     "getPosterCatalog": {
       "classification": "dated-live-observation",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
+    },
+    "getGuests": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#scope-and-provenance"
     }
   },
   "operationClaims": {
@@ -215,12 +220,12 @@
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
     },
     "addInvitedGuestsAsHost": {
-      "request": "typescript-derived-inference",
-      "requestCitation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post",
-      "response": "explicit-unknown",
-      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
-      "status": "explicit-unknown",
-      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+      "request": "current-first-party-public-asset-research",
+      "requestCitation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request",
+      "response": "official-protocol-specification",
+      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firebase-callable-protocol",
+      "status": "official-protocol-specification",
+      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firebase-callable-protocol"
     },
     "createCohostRequest": {
       "request": "typescript-derived-inference",
@@ -389,6 +394,14 @@
       "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation",
       "status": "dated-live-observation",
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-poster-catalog-observation"
+    },
+    "getGuests": {
+      "request": "current-first-party-public-asset-research",
+      "requestCitation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-request-and-pagination",
+      "response": "current-first-party-public-asset-research",
+      "responseCitation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-response-and-guest-fields",
+      "status": "official-protocol-specification",
+      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firebase-callable-protocol"
     }
   },
   "contradictions": [
@@ -423,7 +436,8 @@
     "Firestore event GET returned PERMISSION_DENIED for selected readable and synthetic IDs with one credential; success, not-found, attendee-denial, and other credential behavior remain unknown.",
     "Contact invalid-cursor behavior, cursor lifetime and reuse, ordering key, snapshot behavior, useAuthUser, rate limiting, unsupported statuses, future catalog completeness, server duplicate behavior, and duplicates outside two traversals remain unknown.",
     "RSVP mutation failures, server-side rejection mappings, ticketing, application, waitlist, protected-event submission, and post-write RSVP business state remain unknown.",
-    "Event-write endpoint business success, persisted Event state, post-write reads, unobserved errors and statuses, inaccessible-event permissions, cancellation delivery, and automatic retry safety remain unknown."
+    "Event-write endpoint business success, persisted Event state, post-write reads, unobserved errors and statuses, inaccessible-event permissions, cancellation delivery, and automatic retry safety remain unknown.",
+    "Guest list and host invite permission bodies, attendee-denial behavior for getGuests, non-empty phone/email invite member shapes, and post-invite business state remain unknown."
   ],
   "status": "owner-reviewed",
   "claims": {
@@ -1264,56 +1278,56 @@
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createTextBlast/post/security/0/firebaseBearer"
     },
     "#/paths/~1addInvitedGuestsAsHost/post/operationId": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/operationId"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request"
     },
     "#/paths/~1addInvitedGuestsAsHost/post/requestBody/required": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/required"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request"
     },
     "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request"
     },
     "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/type"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request"
     },
     "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/required/0": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/required/0"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request"
     },
     "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request"
     },
     "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/type"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request"
     },
     "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/required/0": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/required/0"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request"
     },
     "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/required/1": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/required/1"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request"
     },
     "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request"
     },
     "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/type"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request"
     },
     "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request"
     },
     "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId/type"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request"
     },
     "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/guests": {
       "classification": "typescript-derived-inference",
@@ -1332,56 +1346,56 @@
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/guests/items/additionalProperties"
     },
     "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request"
     },
     "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request"
     },
     "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/1": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/1"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request"
     },
     "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request"
     },
     "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request"
     },
     "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request"
     },
     "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request"
     },
     "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request"
     },
     "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/userId": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/userId"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request"
     },
     "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request"
     },
     "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request"
     },
     "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/additionalProperties": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/additionalProperties"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request"
     },
     "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/additionalProperties": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/additionalProperties"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request"
     },
     "#/paths/~1addInvitedGuestsAsHost/post/responses/default": {
       "classification": "explicit-unknown",
@@ -6982,6 +6996,422 @@
     "#/components/schemas/FirestoreMapValue/additionalProperties": {
       "classification": "official-protocol-specification",
       "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol"
+    },
+    "#/components/schemas/GetGuestsResponse/properties/result": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-response-and-guest-fields"
+    },
+    "#/components/schemas/GetGuestsResponse/properties/result/properties/data": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-response-and-guest-fields"
+    },
+    "#/components/schemas/GetGuestsResponse/properties/result/properties/data/items/$ref": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-response-and-guest-fields"
+    },
+    "#/components/schemas/GetGuestsResponse/properties/result/properties/data/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-response-and-guest-fields"
+    },
+    "#/components/schemas/GetGuestsResponse/properties/result/properties/paging": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-response-and-guest-fields"
+    },
+    "#/components/schemas/GetGuestsResponse/properties/result/properties/paging/properties/nextCursor": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-response-and-guest-fields"
+    },
+    "#/components/schemas/GetGuestsResponse/properties/result/properties/paging/properties/nextCursor/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-response-and-guest-fields"
+    },
+    "#/components/schemas/GetGuestsResponse/properties/result/properties/paging/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-response-and-guest-fields"
+    },
+    "#/components/schemas/GetGuestsResponse/properties/result/required/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-response-and-guest-fields"
+    },
+    "#/components/schemas/GetGuestsResponse/properties/result/required/1": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-response-and-guest-fields"
+    },
+    "#/components/schemas/GetGuestsResponse/properties/result/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-response-and-guest-fields"
+    },
+    "#/components/schemas/GetGuestsResponse/required/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-response-and-guest-fields"
+    },
+    "#/components/schemas/GetGuestsResponse/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-response-and-guest-fields"
+    },
+    "#/components/schemas/GuestListItem/additionalProperties": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-response-and-guest-fields"
+    },
+    "#/components/schemas/GuestListItem/properties/anchorGuestId": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-response-and-guest-fields"
+    },
+    "#/components/schemas/GuestListItem/properties/anchorGuestId/type/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-response-and-guest-fields"
+    },
+    "#/components/schemas/GuestListItem/properties/anchorGuestId/type/1": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-response-and-guest-fields"
+    },
+    "#/components/schemas/GuestListItem/properties/count": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-response-and-guest-fields"
+    },
+    "#/components/schemas/GuestListItem/properties/count/minimum": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-response-and-guest-fields"
+    },
+    "#/components/schemas/GuestListItem/properties/count/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-response-and-guest-fields"
+    },
+    "#/components/schemas/GuestListItem/properties/id": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-response-and-guest-fields"
+    },
+    "#/components/schemas/GuestListItem/properties/id/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-response-and-guest-fields"
+    },
+    "#/components/schemas/GuestListItem/properties/name": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-response-and-guest-fields"
+    },
+    "#/components/schemas/GuestListItem/properties/name/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-response-and-guest-fields"
+    },
+    "#/components/schemas/GuestListItem/properties/status": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-response-and-guest-fields"
+    },
+    "#/components/schemas/GuestListItem/properties/status/$ref": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-response-and-guest-fields"
+    },
+    "#/components/schemas/GuestListItem/properties/userId": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-response-and-guest-fields"
+    },
+    "#/components/schemas/GuestListItem/properties/userId/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-response-and-guest-fields"
+    },
+    "#/components/schemas/GuestListItem/required/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-response-and-guest-fields"
+    },
+    "#/components/schemas/GuestListItem/required/1": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-response-and-guest-fields"
+    },
+    "#/components/schemas/GuestListItem/required/2": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-response-and-guest-fields"
+    },
+    "#/components/schemas/GuestListItem/required/3": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-response-and-guest-fields"
+    },
+    "#/components/schemas/GuestListItem/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-response-and-guest-fields"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/emailsToInvite": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/emailsToInvite/items/additionalProperties": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/emailsToInvite/items/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/emailsToInvite/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/invitationMessage": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/invitationMessage/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/otherMutualsCount": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/otherMutualsCount/minimum": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/otherMutualsCount/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/phoneContactsToInvite": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/phoneContactsToInvite/items/additionalProperties": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/phoneContactsToInvite/items/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/phoneContactsToInvite/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/userIdsToInvite": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/userIdsToInvite/items/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/userIdsToInvite/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/2": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/3": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/4": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/5": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/responses/200": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firebase-callable-protocol"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/responses/200/content/application~1json": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firebase-callable-protocol"
+    },
+    "#/paths/~1addInvitedGuestsAsHost/post/responses/200/content/application~1json/schema/$ref": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firebase-callable-protocol"
+    },
+    "#/paths/~1getGuests/post/operationId": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-request-and-pagination"
+    },
+    "#/paths/~1getGuests/post/requestBody/content/application~1json": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-request-and-pagination"
+    },
+    "#/paths/~1getGuests/post/requestBody/content/application~1json/schema/additionalProperties": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-request-and-pagination"
+    },
+    "#/paths/~1getGuests/post/requestBody/content/application~1json/schema/properties/data": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-request-and-pagination"
+    },
+    "#/paths/~1getGuests/post/requestBody/content/application~1json/schema/properties/data/additionalProperties": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-request-and-pagination"
+    },
+    "#/paths/~1getGuests/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-request-and-pagination"
+    },
+    "#/paths/~1getGuests/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-request-and-pagination"
+    },
+    "#/paths/~1getGuests/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-request-and-pagination"
+    },
+    "#/paths/~1getGuests/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-request-and-pagination"
+    },
+    "#/paths/~1getGuests/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-request-and-pagination"
+    },
+    "#/paths/~1getGuests/post/requestBody/content/application~1json/schema/properties/data/properties/paging": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-request-and-pagination"
+    },
+    "#/paths/~1getGuests/post/requestBody/content/application~1json/schema/properties/data/properties/paging/additionalProperties": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-request-and-pagination"
+    },
+    "#/paths/~1getGuests/post/requestBody/content/application~1json/schema/properties/data/properties/paging/properties/cursor": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-request-and-pagination"
+    },
+    "#/paths/~1getGuests/post/requestBody/content/application~1json/schema/properties/data/properties/paging/properties/cursor/type/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-request-and-pagination"
+    },
+    "#/paths/~1getGuests/post/requestBody/content/application~1json/schema/properties/data/properties/paging/properties/cursor/type/1": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-request-and-pagination"
+    },
+    "#/paths/~1getGuests/post/requestBody/content/application~1json/schema/properties/data/properties/paging/properties/maxResults": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-request-and-pagination"
+    },
+    "#/paths/~1getGuests/post/requestBody/content/application~1json/schema/properties/data/properties/paging/properties/maxResults/const": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-request-and-pagination"
+    },
+    "#/paths/~1getGuests/post/requestBody/content/application~1json/schema/properties/data/properties/paging/properties/maxResults/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-request-and-pagination"
+    },
+    "#/paths/~1getGuests/post/requestBody/content/application~1json/schema/properties/data/properties/paging/required/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-request-and-pagination"
+    },
+    "#/paths/~1getGuests/post/requestBody/content/application~1json/schema/properties/data/properties/paging/required/1": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-request-and-pagination"
+    },
+    "#/paths/~1getGuests/post/requestBody/content/application~1json/schema/properties/data/properties/paging/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-request-and-pagination"
+    },
+    "#/paths/~1getGuests/post/requestBody/content/application~1json/schema/properties/data/properties/params": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-request-and-pagination"
+    },
+    "#/paths/~1getGuests/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-request-and-pagination"
+    },
+    "#/paths/~1getGuests/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-request-and-pagination"
+    },
+    "#/paths/~1getGuests/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-request-and-pagination"
+    },
+    "#/paths/~1getGuests/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/includeInvitedGuests": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-request-and-pagination"
+    },
+    "#/paths/~1getGuests/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/includeInvitedGuests/const": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-request-and-pagination"
+    },
+    "#/paths/~1getGuests/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/includeInvitedGuests/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-request-and-pagination"
+    },
+    "#/paths/~1getGuests/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/password": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-request-and-pagination"
+    },
+    "#/paths/~1getGuests/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/password/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-request-and-pagination"
+    },
+    "#/paths/~1getGuests/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-request-and-pagination"
+    },
+    "#/paths/~1getGuests/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/1": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-request-and-pagination"
+    },
+    "#/paths/~1getGuests/post/requestBody/content/application~1json/schema/properties/data/properties/params/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-request-and-pagination"
+    },
+    "#/paths/~1getGuests/post/requestBody/content/application~1json/schema/properties/data/properties/userId": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-request-and-pagination"
+    },
+    "#/paths/~1getGuests/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-request-and-pagination"
+    },
+    "#/paths/~1getGuests/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-request-and-pagination"
+    },
+    "#/paths/~1getGuests/post/requestBody/content/application~1json/schema/properties/data/required/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-request-and-pagination"
+    },
+    "#/paths/~1getGuests/post/requestBody/content/application~1json/schema/properties/data/required/1": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-request-and-pagination"
+    },
+    "#/paths/~1getGuests/post/requestBody/content/application~1json/schema/properties/data/required/2": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-request-and-pagination"
+    },
+    "#/paths/~1getGuests/post/requestBody/content/application~1json/schema/properties/data/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-request-and-pagination"
+    },
+    "#/paths/~1getGuests/post/requestBody/content/application~1json/schema/required/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-request-and-pagination"
+    },
+    "#/paths/~1getGuests/post/requestBody/content/application~1json/schema/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-request-and-pagination"
+    },
+    "#/paths/~1getGuests/post/requestBody/required": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-request-and-pagination"
+    },
+    "#/paths/~1getGuests/post/responses/200": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-response-and-guest-fields"
+    },
+    "#/paths/~1getGuests/post/responses/200/content/application~1json": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-response-and-guest-fields"
+    },
+    "#/paths/~1getGuests/post/responses/200/content/application~1json/schema/$ref": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-response-and-guest-fields"
+    },
+    "#/paths/~1getGuests/post/responses/default": {
+      "classification": "explicit-unknown",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+    },
+    "#/paths/~1getGuests/post/security/0/firebaseBearer": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#current-callable-wrapper"
     }
   },
   "posterCatalogObservation": {
@@ -7583,5 +8013,5 @@
     "cancelCompletion": "decoded-data-awaited-no-business-field",
     "firestorePatchCompletion": "official-document-protocol-only"
   },
-  "materialClaimCount": 1625
+  "materialClaimCount": 1739
 }

--- a/spec/partiful.api-evidence.json
+++ b/spec/partiful.api-evidence.json
@@ -421,7 +421,7 @@
     }
   ],
   "unresolvedUncertainty": [
-    "Callable-specific parameter sets and result payloads outside createEvent, cancelEvent, createTextBlast, addGuest, markEventInterest, and documented auth calls remain unknown.",
+    "Callable-specific parameter sets and result payloads outside createEvent, cancelEvent, createTextBlast, addGuest, markEventInterest, getGuests, addInvitedGuestsAsHost, and documented auth calls remain unknown.",
     "Partiful Firestore authorization and field policy, endpoint-specific errors, concurrent-write behavior, and pagination limits remain unknown; only the generic official Value, Document, PATCH, mask, precondition, and bearer protocol is claimed.",
     "Upload accepted media types, size limits, response variants, and whether uploadType values remain stable.",
     "Poster catalog membership and order can change; exhaustiveness beyond the complete observed endpoint representation is unknown.",
@@ -1328,22 +1328,6 @@
     "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId/type": {
       "classification": "current-first-party-public-asset-research",
       "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#addinvitedguestsashost-request"
-    },
-    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/guests": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/guests"
-    },
-    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/guests/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/guests/type"
-    },
-    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/guests/items/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/guests/items/type"
-    },
-    "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/guests/items/additionalProperties": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/guests/items/additionalProperties"
     },
     "#/paths/~1addInvitedGuestsAsHost/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties": {
       "classification": "current-first-party-public-asset-research",
@@ -7021,7 +7005,11 @@
       "classification": "current-first-party-public-asset-research",
       "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-response-and-guest-fields"
     },
-    "#/components/schemas/GetGuestsResponse/properties/result/properties/paging/properties/nextCursor/type": {
+    "#/components/schemas/GetGuestsResponse/properties/result/properties/paging/properties/nextCursor/type/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-response-and-guest-fields"
+    },
+    "#/components/schemas/GetGuestsResponse/properties/result/properties/paging/properties/nextCursor/type/1": {
       "classification": "current-first-party-public-asset-research",
       "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-response-and-guest-fields"
     },
@@ -7394,8 +7382,8 @@
       "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-request-and-pagination"
     },
     "#/paths/~1getGuests/post/responses/200": {
-      "classification": "current-first-party-public-asset-research",
-      "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#getguests-response-and-guest-fields"
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firebase-callable-protocol"
     },
     "#/paths/~1getGuests/post/responses/200/content/application~1json": {
       "classification": "current-first-party-public-asset-research",
@@ -8013,5 +8001,18 @@
     "cancelCompletion": "decoded-data-awaited-no-business-field",
     "firestorePatchCompletion": "official-document-protocol-only"
   },
-  "materialClaimCount": 1739
+  "guestAssetResearch": {
+    "classification": "current-first-party-public-asset-research",
+    "sourceCitation": "docs/research/2026-08-12-guest-mapping-public-assets.md#scope-and-provenance",
+    "researchedAt": "2026-08-12",
+    "buildId": "Sf-HOOx63XpPtr5pPkTvg",
+    "deploymentId": "dpl_D7TPPj16g1fU46JSHSyrsRURxrK9",
+    "credentialsUsed": false,
+    "liveMutations": false,
+    "operations": [
+      "getGuests",
+      "addInvitedGuestsAsHost"
+    ]
+  },
+  "materialClaimCount": 1740
 }

--- a/spec/partiful.openapi.json
+++ b/spec/partiful.openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Partiful remote API contract",
     "version": "2026-08-12.5",
-    "description": "Proposed remote-only transport snapshot pending delegated review. Evidence classifications and uncertainty are recorded in spec/partiful.api-evidence.json."
+    "description": "Owner-reviewed remote-only transport snapshot. Evidence classifications and uncertainty are recorded in spec/partiful.api-evidence.json."
   },
   "servers": [
     {
@@ -3790,7 +3790,10 @@
                 "type": "object",
                 "properties": {
                   "nextCursor": {
-                    "type": "string"
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
               }

--- a/spec/partiful.openapi.json
+++ b/spec/partiful.openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Partiful remote API contract",
-    "version": "2026-08-12.4",
+    "version": "2026-08-12.5",
     "description": "Proposed remote-only transport snapshot pending delegated review. Evidence classifications and uncertainty are recorded in spec/partiful.api-evidence.json."
   },
   "servers": [
@@ -390,6 +390,111 @@
         ]
       }
     },
+    "/getGuests": {
+      "post": {
+        "operationId": "getGuests",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "params",
+                      "amplitudeDeviceId",
+                      "paging"
+                    ],
+                    "properties": {
+                      "params": {
+                        "type": "object",
+                        "properties": {
+                          "eventId": {
+                            "type": "string"
+                          },
+                          "includeInvitedGuests": {
+                            "type": "boolean",
+                            "const": true
+                          },
+                          "password": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "eventId",
+                          "includeInvitedGuests"
+                        ]
+                      },
+                      "amplitudeDeviceId": {
+                        "type": "string"
+                      },
+                      "amplitudeSessionId": {
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "userId": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "paging": {
+                        "type": "object",
+                        "required": [
+                          "maxResults",
+                          "cursor"
+                        ],
+                        "properties": {
+                          "maxResults": {
+                            "type": "integer",
+                            "const": 500
+                          },
+                          "cursor": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Current authenticated guest page response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetGuestsResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Unobserved response status or body."
+          }
+        },
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ]
+      }
+    },
     "/createTextBlast": {
       "post": {
         "operationId": "createTextBlast",
@@ -511,7 +616,27 @@
                           "eventId": {
                             "type": "string"
                           },
-                          "guests": {
+                          "userIdsToInvite": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "invitationMessage": {
+                            "type": "string"
+                          },
+                          "otherMutualsCount": {
+                            "type": "integer",
+                            "minimum": 0
+                          },
+                          "phoneContactsToInvite": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "additionalProperties": true
+                            }
+                          },
+                          "emailsToInvite": {
                             "type": "array",
                             "items": {
                               "type": "object",
@@ -522,7 +647,11 @@
                         "additionalProperties": false,
                         "required": [
                           "eventId",
-                          "guests"
+                          "userIdsToInvite",
+                          "invitationMessage",
+                          "otherMutualsCount",
+                          "phoneContactsToInvite",
+                          "emailsToInvite"
                         ]
                       },
                       "amplitudeDeviceId": {
@@ -550,6 +679,16 @@
         "responses": {
           "default": {
             "description": "Response status and body are unknown."
+          },
+          "200": {
+            "description": "Current client awaits generic callable completion only.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallableResponse"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -3593,6 +3732,71 @@
           }
         },
         "additionalProperties": false
+      },
+      "GuestListItem": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "status",
+          "count"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/GuestStatus"
+          },
+          "count": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "anchorGuestId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "userId": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": true
+      },
+      "GetGuestsResponse": {
+        "type": "object",
+        "required": [
+          "result"
+        ],
+        "properties": {
+          "result": {
+            "type": "object",
+            "required": [
+              "data",
+              "paging"
+            ],
+            "properties": {
+              "data": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/GuestListItem"
+                }
+              },
+              "paging": {
+                "type": "object",
+                "properties": {
+                  "nextCursor": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/tests/remote-api-contract.test.js
+++ b/tests/remote-api-contract.test.js
@@ -561,7 +561,7 @@ describe('remote API contract', () => {
       ...materialClaimPointers(spec.paths, '#/paths', 'paths'),
       ...materialClaimPointers(spec.components, '#/components', 'components'),
     ]);
-    expect(pointers).toHaveLength(1739);
+    expect(pointers).toHaveLength(1740);
     for (const pointer of pointers) {
       const claim = evidence.claims[pointer];
       expect(claim, pointer).toBeDefined();
@@ -625,7 +625,7 @@ describe('remote API contract', () => {
     expect(ledger).toContain(
       '`firestorePatchEvent` uses the official Firestore PATCH path',
     );
-    expect(ledger.match(/The 1739 material claims/g)).toHaveLength(2);
+    expect(ledger.match(/The 1740 material claims/g)).toHaveLength(2);
     expect(ledger).toContain(
       '**Proposed contract revision:** `2026-08-12.5`',
     );

--- a/tests/remote-api-contract.test.js
+++ b/tests/remote-api-contract.test.js
@@ -21,6 +21,8 @@ const rsvpReadObservationPath =
   'docs/research/2026-08-12-rsvp-read-observation.md';
 const eventWriteAssetResearchPath =
   'docs/research/2026-08-12-event-write-mapping-public-assets.md';
+const guestAssetResearchPath =
+  'docs/research/2026-08-12-guest-mapping-public-assets.md';
 const productContractPath = 'docs/CLI-PRODUCT-CONTRACT.md';
 const sourceCache = new Map([
   [historicalDraftPath, historicalDraft],
@@ -481,7 +483,7 @@ function citationResolves(citation) {
 describe('remote API contract', () => {
   it('is a consistently versioned OpenAPI 3.1 document with unique operation IDs', () => {
     expect(spec.openapi).toBe('3.1.0');
-    expect(evidence.contractRevision).toBe('2026-08-12.4');
+    expect(evidence.contractRevision).toBe('2026-08-12.5');
     expect(evidence.ownerReviewedBaseline).toBe('2026-08-12.3');
     expect(spec.info.version).toBe(evidence.contractRevision);
     expect(evidence.status).toBe('owner-reviewed');
@@ -498,11 +500,14 @@ describe('remote API contract', () => {
     expect(evidence.sources.rsvpReadObservation20260812)
       .toBe(`${rsvpReadObservationPath}#scope-and-provenance`);
     expect(citationResolves(evidence.sources.rsvpReadObservation20260812)).toBe(true);
+    expect(evidence.sources.publicGuestMapping20260812)
+      .toBe(`${guestAssetResearchPath}#scope-and-provenance`);
+    expect(citationResolves(evidence.sources.publicGuestMapping20260812)).toBe(true);
     const appSource = fs.readFileSync('internal/app/app.go', 'utf8');
-    expect(appSource).toContain('ProductContractRevision = "2026-08-12.4"');
-    expect(appSource).toContain('RemoteContractRevision  = "2026-08-12.4"');
+    expect(appSource).toContain('ProductContractRevision = "2026-08-12.5"');
+    expect(appSource).toContain('RemoteContractRevision  = "2026-08-12.5"');
     const ids = operations().map(({ operation }) => operation.operationId);
-    expect(ids).toHaveLength(27);
+    expect(ids).toHaveLength(28);
     expect(new Set(ids).size).toBe(ids.length);
   });
 
@@ -536,9 +541,11 @@ describe('remote API contract', () => {
       ]);
       const protocolStatusOps = new Set([
         'addGuest',
+        'addInvitedGuestsAsHost',
         'markEventInterest',
         'createEvent',
         'cancelEvent',
+        'getGuests',
         'firestorePatchEvent',
       ]);
       const expectedStatus = liveStatusOps.has(operation.operationId)
@@ -554,7 +561,7 @@ describe('remote API contract', () => {
       ...materialClaimPointers(spec.paths, '#/paths', 'paths'),
       ...materialClaimPointers(spec.components, '#/components', 'components'),
     ]);
-    expect(pointers).toHaveLength(1639);
+    expect(pointers).toHaveLength(1739);
     for (const pointer of pointers) {
       const claim = evidence.claims[pointer];
       expect(claim, pointer).toBeDefined();
@@ -597,8 +604,8 @@ describe('remote API contract', () => {
       .filter(({ operation }) => operation.responses['200']?.content)
       .map(({ operation }) => operation.operationId)
       .sort();
-    expect(with200).toHaveLength(17);
-    expect(withTyped200Body).toHaveLength(16);
+    expect(with200).toHaveLength(19);
+    expect(withTyped200Body).toHaveLength(18);
     expect(with200.filter((id) => !withTyped200Body.includes(id)))
       .toEqual(['sendAuthCodeTrusted']);
 
@@ -613,18 +620,16 @@ describe('remote API contract', () => {
       /Eleven of those\s+operations have a typed `200` response body\./,
     );
     expect(ledger).toContain(
-      'Four callable operations have protocol-specified HTTP `200` completion',
+      'Five callable operations have protocol-specified HTTP `200` completion',
     );
     expect(ledger).toContain(
       '`firestorePatchEvent` uses the official Firestore PATCH path',
     );
-    expect(ledger.match(/The 1639 material claims/g)).toHaveLength(2);
+    expect(ledger.match(/The 1739 material claims/g)).toHaveLength(2);
     expect(ledger).toContain(
-      '**Proposed contract revision:** `2026-08-12.4`',
+      '**Proposed contract revision:** `2026-08-12.5`',
     );
-    expect(ledger).toContain(
-      '**Status:** Pending one delegated review under issue #167',
-    );
+    expect(ledger).toContain('**Status:** Owner-reviewed');
     expect(ledger).toContain('Current first-party public-asset research');
   });
 
@@ -662,7 +667,9 @@ describe('remote API contract', () => {
       'firestoreGetEvent',
       'firestoreGetGuest',
       'getContacts',
+      'getGuests',
       'addGuest',
+      'addInvitedGuestsAsHost',
       'markEventInterest',
       'createEvent',
       'cancelEvent',
@@ -727,7 +734,9 @@ describe('remote API contract', () => {
       'firestoreGetEvent',
       'firestoreGetGuest',
       'getContacts',
+      'getGuests',
       'addGuest',
+      'addInvitedGuestsAsHost',
       'markEventInterest',
       'createEvent',
       'cancelEvent',
@@ -747,7 +756,9 @@ describe('remote API contract', () => {
       ['firestoreGetEvent', evidence.sources.readGuestFirestore20260811],
       ['firestoreGetGuest', evidence.sources.readGuestFirestore20260811],
       ['getContacts', evidence.sources.readContacts20260811],
+      ['getGuests', `${guestAssetResearchPath}#getguests-response-and-guest-fields`],
       ['addGuest', evidence.sources.publicAddGuestCompletion20260812],
+      ['addInvitedGuestsAsHost', evidence.sources.firebaseCallableProtocol],
       ['markEventInterest', evidence.sources.publicInterestCompletion20260812],
       ['createEvent', evidence.sources.publicCreateEventCompletion20260812],
       ['cancelEvent', evidence.sources.publicCancelEvent20260812],
@@ -759,9 +770,12 @@ describe('remote API contract', () => {
       expect(operation.responses.default).not.toHaveProperty('content');
       const operationClaim = evidence.operationClaims[operation.operationId];
       if (observedResponseOps.has(operation.operationId)) {
-        const expectedClassification = operation.operationId === 'firestorePatchEvent'
+        const expectedClassification = [
+          'firestorePatchEvent',
+          'addInvitedGuestsAsHost',
+        ].includes(operation.operationId)
           ? 'official-protocol-specification'
-          : ['addGuest', 'markEventInterest', 'createEvent', 'cancelEvent']
+          : ['addGuest', 'getGuests', 'markEventInterest', 'createEvent', 'cancelEvent']
               .includes(operation.operationId)
             ? 'current-first-party-public-asset-research'
             : 'dated-live-observation';
@@ -1569,9 +1583,9 @@ describe('remote API contract', () => {
     const product = fs.readFileSync(productContractPath, 'utf8');
     for (const expected of [
       '**Status:** Approved product contract',
-      '**Product contract revision:** `2026-08-12.4`',
-      '**Remote API contract revision:** `2026-08-12.4`',
-      '**Currently shipped Go revisions:** product and remote `2026-08-12.4`',
+      '**Product contract revision:** `2026-08-12.5`',
+      '**Remote API contract revision:** `2026-08-12.5`',
+      '**Currently shipped Go revisions:** product and remote `2026-08-12.5`',
       '`PUBLISHED` → `active`',
       '`CANCELED` → `cancelled`',
       '`UNSAVED` exists in the current first-party client vocabulary',
@@ -1616,8 +1630,8 @@ describe('remote API contract', () => {
     );
 
     const appSource = fs.readFileSync('internal/app/app.go', 'utf8');
-    expect(appSource).toContain('ProductContractRevision = "2026-08-12.4"');
-    expect(appSource).toContain('RemoteContractRevision  = "2026-08-12.4"');
+    expect(appSource).toContain('ProductContractRevision = "2026-08-12.5"');
+    expect(appSource).toContain('RemoteContractRevision  = "2026-08-12.5"');
   });
 
   it('defines evidence-backed RSVP planning and submitted-only completion', () => {
@@ -2148,14 +2162,14 @@ describe('remote API contract', () => {
       /"remoteContractRevision": "([^"]+)"/g,
     )].map((match) => match[1]);
 
-    expect(shippedRevision).toBe('2026-08-12.4');
-    expect(documentedRevision).toBe('2026-08-12.4');
-    expect(documentedProductRevision).toBe('2026-08-12.4');
+    expect(shippedRevision).toBe('2026-08-12.5');
+    expect(documentedRevision).toBe('2026-08-12.5');
+    expect(documentedProductRevision).toBe('2026-08-12.5');
     expect(new Set(envelopeRevisions)).toEqual(new Set([documentedRevision]));
     expect(spec.info.version).toBe(documentedRevision);
     expect(evidence.status).toBe('owner-reviewed');
     expect(spec.info.version).toBe(shippedRevision);
-    expect(appSource).toContain('ProductContractRevision = "2026-08-12.4"');
+    expect(appSource).toContain('ProductContractRevision = "2026-08-12.5"');
     expect(productContract)
       .not.toContain('currently leaves every operation response status and body unknown');
     expect(contactResearch)


### PR DESCRIPTION
## Summary

Implements the evidence-backed Go guest slice for #168.

- adds host-only `guests list` with bounded reviewed cursor traversal and privacy-safe local pagination
- distinguishes attendee denial from an empty host guest list
- adds consequential `guests invite --contact` with exact confirmed, single-use mutation plans
- resolves the private contact identity during planning, rebinds contact/event facts during apply, and dispatches the stored reviewed identity
- validates the current `getGuests` and `addInvitedGuestsAsHost` requests and submitted-only completion
- advances the reviewed contract revision to `2026-08-12.5`

No live invitation or credential capture was used.

## Validation

- `go test -race ./...`
- `go vet ./...`
- `go build ./...`
- `go mod verify`
- `npm test -- tests/remote-api-contract.test.js`
- `npm run typecheck`
- privacy guard and diff check

Closes #168.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added commands to view an event’s guest list with pagination.
  - Added host guest invitations using email addresses, phone contacts, or user IDs.
  - Added preview and confirmation workflows with privacy-safe request details.
  - Added validation for permissions, event ownership, ambiguous contacts, and stale plans.

- **Documentation**
  - Updated API contracts and research to document guest retrieval and invitation behavior.
  - Added request, response, pagination, and completion schemas for guest operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->