### PR TITLE
feat(go): implement cohost lifecycle and links (#169)

### DIFF
--- a/docs/CLI-PRODUCT-CONTRACT.md
+++ b/docs/CLI-PRODUCT-CONTRACT.md
@@ -2,13 +2,13 @@
 
 **Status:** Approved product contract
 
-**Product contract revision:** `2026-08-12.5`
+**Product contract revision:** `2026-08-12.6`
 
-**Remote API contract revision:** `2026-08-12.5`
+**Remote API contract revision:** `2026-08-12.6`
 
 **Owner-reviewed baseline:** product and remote `2026-08-12.3`
 
-**Currently shipped Go revisions:** product and remote `2026-08-12.5`
+**Currently shipped Go revisions:** product and remote `2026-08-12.6`
 
 This document defines the public behavior of the greenfield Go `partiful` CLI.
 It is the authority for commands, inputs, JSON outputs, failures, and mutation
@@ -83,8 +83,8 @@ Every successful command returns:
   "meta": {
     "command": "events.get",
     "cliVersion": "1.0.0",
-    "productContractRevision": "2026-08-12.5",
-    "remoteContractRevision": "2026-08-12.5",
+    "productContractRevision": "2026-08-12.6",
+    "remoteContractRevision": "2026-08-12.6",
     "warnings": []
   }
 }
@@ -107,8 +107,8 @@ Every failed command returns:
   "meta": {
     "command": "guests.list",
     "cliVersion": "1.0.0",
-    "productContractRevision": "2026-08-12.5",
-    "remoteContractRevision": "2026-08-12.5"
+    "productContractRevision": "2026-08-12.6",
+    "remoteContractRevision": "2026-08-12.6"
   }
 }
 ```
@@ -155,8 +155,8 @@ Collection commands return:
   "meta": {
     "command": "events.list",
     "cliVersion": "1.0.0",
-    "productContractRevision": "2026-08-12.5",
-    "remoteContractRevision": "2026-08-12.5",
+    "productContractRevision": "2026-08-12.6",
+    "remoteContractRevision": "2026-08-12.6",
     "warnings": [],
     "page": {
       "limit": 25,
@@ -228,8 +228,8 @@ remote mutation:
   "meta": {
     "command": "events.update",
     "cliVersion": "1.0.0",
-    "productContractRevision": "2026-08-12.5",
-    "remoteContractRevision": "2026-08-12.5",
+    "productContractRevision": "2026-08-12.6",
+    "remoteContractRevision": "2026-08-12.6",
     "warnings": []
   }
 }
@@ -988,7 +988,7 @@ reviewed callable and client completion condition. It does not prove
 persisted RSVP state, delivery, notification, or another business side
 effect.
 
-This `2026-08-12.5` contract is the approved event-write product contract and
+This `2026-08-12.6` contract is the approved event-write product contract and
 the current shipped Go contract revision.
 
 ### Contacts
@@ -1033,9 +1033,41 @@ partiful cohosts link revoke <event-id>
 
 All are host-only consequential actions. Contact commands use the same
 privacy-safe match rules and resolved-identity plan binding as guest
-invitations.
-The machine-readable schema paths for the subresource commands are
-`cohosts.link.create` and `cohosts.link.revoke`.
+invitations. The machine-readable schema paths for the subresource commands
+are `cohosts.link.create` and `cohosts.link.revoke`.
+
+Each no-apply invocation returns a five-minute single-use consequential plan.
+Execution must repeat the exact same input with `--apply --confirm <token>`.
+Apply re-reads the bound event, contact, request-state, or link-state facts
+once, compares them to the stored plan, consumes the token immediately before
+one dispatch attempt, and never retries.
+
+The contact commands use the same privacy-safe resolution rules as guest
+invitations:
+
+- a unique exact display-name match wins;
+- otherwise a unique partial display-name match wins;
+- no safe match returns `resource.not_found`; and
+- multiple safe matches return `match.ambiguous`.
+
+The resolved private contact identity is bound into the private plan record.
+Apply does not resolve by name again and does not emit a user ID.
+
+The observable preconditions are:
+
+- `invite`: the event `ownerIds` must contain the current account and the
+  selected contact must have no current request or a current `DECLINED`
+  request;
+- `revoke-invite`: the selected contact must have current request status
+  `PENDING` or `DECLINED`;
+- `remove`: the selected contact must have current request status
+  `ACCEPTED`;
+- `link create`: the current `cohostSecret` document must be absent; and
+- `link revoke`: the current `cohostSecret` document must be present.
+
+A changed role, changed contact binding, changed cohost request state, changed
+link state, changed account, expired token, or replayed token returns
+`safety.plan_stale` before a mutation request.
 
 The three contact actions return:
 
@@ -1049,7 +1081,8 @@ The three contact actions return:
 }
 ```
 
-`status` is `invited`, `revoked`, or `removed`.
+`status` is exactly `invited`, `revoked`, or `removed`, according to the
+command.
 
 Link creation returns:
 
@@ -1057,14 +1090,26 @@ Link creation returns:
 {
   "eventId": "evt_example",
   "link": {
-    "url": "https://partiful.com/example-cohost-link",
+    "url": "https://partiful.com/e/evt_example?accept-cohost=token",
     "state": "active"
   }
 }
 ```
 
-Link revocation returns the same shape with `url: null` and `state:
-"revoked"`.
+Only reviewed `generateEventCohostLink` success may emit the URL. The CLI
+does not echo a pre-existing active URL from a read-only precondition check.
+
+Link revocation returns:
+
+```json
+{
+  "eventId": "evt_example",
+  "link": {
+    "url": null,
+    "state": "revoked"
+  }
+}
+```
 
 ### Blasts
 

--- a/docs/REMOTE-API-CONTRACT.md
+++ b/docs/REMOTE-API-CONTRACT.md
@@ -1,12 +1,12 @@
 # Remote API contract
 
-`spec/partiful.openapi.json` is owner-reviewed revision `2026-08-12.5` of the
+`spec/partiful.openapi.json` is owner-reviewed revision `2026-08-12.6` of the
 remote transport snapshot. Its owner-reviewed baseline is `2026-08-12.3`,
 which is based on owner-reviewed revision `2026-08-12.2`. It describes only
 network operations and wire shapes. It does not prescribe commands, output,
 credentials, mutation safeguards, or implementation architecture.
 
-The Go CLI ships remote contract revision `2026-08-12.5`.
+The Go CLI ships remote contract revision `2026-08-12.6`.
 
 ## Authority and change process
 
@@ -295,6 +295,54 @@ completion, not persisted invite state or delivery. Non-empty
 `phoneContactsToInvite` and `emailsToInvite` member shapes, failure bodies,
 permission responses, attendee-denial behavior, and business-success state
 remain unknown and fail closed.
+
+## Cohost lifecycle proposal
+
+Revision `2026-08-12.6` adds unauthenticated current-client evidence from
+`docs/research/2026-08-12-cohost-lifecycle-public-assets.md`. The source is
+the current public login page, build manifest, shared `_app` chunk, shared
+cohost chunk, and shared event chunk. No credential and no live cohost or
+access-link mutation was used.
+
+The current client exposes host-only cohost controls. It routes the five
+reviewed lifecycle writes through:
+
+- `createCohostRequest` with `params.eventId` and `params.targetUserId`;
+- `deleteCohostRequest` with `params.eventId` and `params.targetUserId`;
+- `removeCohost` with `params.eventId` and `params.targetUserId`;
+- `generateEventCohostLink` with `params.eventId`; and
+- `revokeEventCohostLink` with `params.eventId`.
+
+These call sites use the same shared callable wrapper already reviewed for the
+current public client. The wrapper supplies `params` and can also add
+`deviceInfo`, `amplitudeDeviceId`, `amplitudeSessionId`,
+`adminAccessRequested`, and `userId` when available. The current cohost
+callers inspect only the returned business result, not those metadata fields.
+
+The current completion predicates are narrow:
+
+- `createCohostRequest` reads `response.data` and does not inspect the value
+  further;
+- `deleteCohostRequest`, `removeCohost`, and `revokeEventCohostLink` inspect
+  no business field; and
+- `generateEventCohostLink` reads `response.data.path`.
+
+Accordingly, the four non-link-returning operations use only generic callable
+HTTP `200` protocol completion. `generateEventCohostLink` additionally
+requires a decoded business-result object with nested `data.path` string. No
+operation here proves persisted cohost state, invitation delivery, access
+grant, revocation side effect, authorization failure, or any non-`200`
+status.
+
+The same public assets also establish the current cohost read paths used for
+safe planning:
+
+- Firestore collection `events/{eventId}/cohostRequests`;
+- Firestore document `events/{eventId}/private/cohostSecret`; and
+- closed cohost-request statuses `PENDING`, `ACCEPTED`, and `DECLINED`.
+
+The current client treats the secret document as optional and uses the
+server-returned link `path`; it does not synthesize an `accept-cohost` token.
 
 ## Historical provenance
 

--- a/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
+++ b/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
@@ -1,6 +1,6 @@
 # Partiful remote API contract evidence ledger
 
-**Proposed contract revision:** `2026-08-12.5`
+**Proposed contract revision:** `2026-08-12.6`
 **Owner-reviewed baseline:** `2026-08-12.3`
 **Status:** Owner-reviewed
 **Contract:** `spec/partiful.openapi.json`
@@ -44,15 +44,19 @@ retains an unknown response. The Firestore event read has an observed typed
 ### Current public-asset operations
 
 `addGuest`, `markEventInterest`, `createEvent`, `cancelEvent`, `getGuests`,
-and `addInvitedGuestsAsHost` have current first-party public-asset request
-and/or completion mappings. Their endpoint business meanings, errors, and all
-non-`200` statuses remain unknown unless separately observed.
+`addInvitedGuestsAsHost`, `createCohostRequest`, `deleteCohostRequest`,
+`removeCohost`, `generateEventCohostLink`, and `revokeEventCohostLink` have
+current first-party public-asset request and/or completion mappings. Their
+endpoint business meanings, errors, and all non-`200` statuses remain unknown
+unless separately observed.
 
-Five callable operations have protocol-specified HTTP `200` completion
+Ten callable operations have protocol-specified HTTP `200` completion
 responses. `addGuest`, `markEventInterest`, `createEvent`, `cancelEvent`, and
 `addInvitedGuestsAsHost` use the official Firebase callable
 status/result envelope plus current first-party client completion behavior.
-None is a live business-success observation.
+`createCohostRequest`, `deleteCohostRequest`, `removeCohost`,
+`generateEventCohostLink`, and `revokeEventCohostLink` now do the same. None
+is a live business-success observation.
 
 ### Official-protocol operations
 
@@ -65,11 +69,8 @@ success is inferred.
 
 ### TypeScript-derived operations
 
-The other 7 operations remain TypeScript-derived inferences:
+The other 2 operations remain TypeScript-derived inferences:
 
-- callable: `createCohostRequest`, `deleteCohostRequest`,
-  `removeCohost`, `generateEventCohostLink`, and
-  `revokeEventCohostLink`;
 - Firestore: `firestoreListDocuments`;
 - Firebase auxiliary: `uploadEventPhoto`.
 
@@ -78,12 +79,12 @@ the JSON ledger, including operation, parameter, content-type, security,
 schema, constraint, and response claims. Unless a claim is specifically
 observed, callable result payloads, status codes, error bodies, permission
 rules, and limits are **explicit unknown**. Eleven operations with an observed
-HTTP `200` status, five operations with protocol-specified callable
+HTTP `200` status, ten operations with protocol-specified callable
 completion, and one official Firestore PATCH completion have typed response
 bodies. The schema-free send-code `200` and OpenAPI `default` responses do not
 claim a body.
 
-The 1740 material claims are audited by
+The 1782 material claims are audited by
 `tests/remote-api-contract.test.js`. Each ledger citation resolves either to a
 JSON Pointer in the committed non-authoritative historical artifact or to a
 heading in the committed stable source index. This keeps the audit independent
@@ -140,6 +141,39 @@ completion. They do not supply endpoint business success. Complete
 post-write Event state, Partiful authorization, inaccessible-event behavior,
 unobserved statuses and errors, cancellation or notification delivery, and
 retry safety remain unknown.
+
+## Cohost lifecycle public-asset evidence
+
+The August 12 cohost note records current public build
+`Sf-HOOx63XpPtr5pPkTvg`, deployment
+`dpl_D7TPPj16g1fU46JSHSyrsRURxrK9`, exact URLs, module IDs, and hashes. The
+research used no credential and made no cohost or access-link mutation. It
+establishes current host-only cohost controls, the exact five callable
+request shapes, the current request-state and secret-document read paths, and
+the current completion checks.
+
+The shared callable wrapper supplies `params` and can attach
+`amplitudeDeviceId`, `amplitudeSessionId`, and `userId`. The cohost callers
+send:
+
+- `createCohostRequest({params:{eventId,targetUserId}})`
+- `deleteCohostRequest({params:{eventId,targetUserId}})`
+- `removeCohost({params:{eventId,targetUserId}})`
+- `generateEventCohostLink({params:{eventId}})`
+- `revokeEventCohostLink({params:{eventId}})`
+
+Current read-path helpers select Firestore collection
+`events/{eventId}/cohostRequests` and document
+`events/{eventId}/private/cohostSecret`. The closed cohost-request status enum
+is `PENDING`, `ACCEPTED`, and `DECLINED`. The link query token key is
+`accept-cohost`.
+
+The current client inspects no endpoint business field for
+`deleteCohostRequest`, `removeCohost`, or `revokeEventCohostLink`. It reads
+`response.data` for `createCohostRequest`, and reads `response.data.path` for
+`generateEventCohostLink`. These are client completion checks only. They do
+not prove stored cohost state, invitation delivery, access grant, revocation,
+or any endpoint error mapping.
 
 ## Authentication evidence
 
@@ -371,7 +405,7 @@ by the Go implementation's Firebase requests:
 Origin is unmodelled and remains unknown because the reviewed evidence
 establishes no Origin request fact.
 
-The 1740 material claims are audited by `tests/remote-api-contract.test.js`.
+The 1782 material claims are audited by `tests/remote-api-contract.test.js`.
 
 ## Resolved conflict
 
@@ -385,6 +419,6 @@ nested `message` object with `text`, `to`, `showOnEventPage`, and optional
 
 Future safe observations must update both ledgers, preserve privacy-safe
 evidence, and receive owner review before changing the revision. The remaining
-8 TypeScript-derived operations have no observed response status or shape.
+2 TypeScript-derived operations have no observed response status or shape.
 The read-specific and event-write business-state unknowns above remain
 explicit and must not become inferred implementation behavior.

--- a/docs/research/2026-08-12-cohost-lifecycle-public-assets.md
+++ b/docs/research/2026-08-12-cohost-lifecycle-public-assets.md
@@ -1,0 +1,139 @@
+# Cohost lifecycle mappings in current public web assets
+
+## Scope and provenance
+
+This note records privacy-safe research from current first-party Partiful web
+assets and the official Firebase callable protocol. The assets were fetched
+without authentication on 2026-08-12. No credential, account-scoped request,
+real event ID, real user ID, cohost mutation, or access-link mutation was
+used.
+
+The public [login page](https://partiful.com/login) exposed Next build
+`Sf-HOOx63XpPtr5pPkTvg` and deployment query
+`dpl_D7TPPj16g1fU46JSHSyrsRURxrK9`.
+
+Exact public sources:
+
+| Asset | SHA-256 | Relevant modules |
+| --- | --- | --- |
+| <https://partiful.com/_next/static/Sf-HOOx63XpPtr5pPkTvg/_buildManifest.js?dpl=dpl_D7TPPj16g1fU46JSHSyrsRURxrK9> | `2de1d4a26e8d4e9e2370ef970cafab2cd1cd6f5c8402fd54a5ea6f150488cbf6` | route/chunk map |
+| <https://partiful.com/_next/static/chunks/pages/_app-b0dc833855a84321.js?dpl=dpl_D7TPPj16g1fU46JSHSyrsRURxrK9> | `812edcea27949b86471cfc5f970cb5b3b961e27a6eea80e7cf6d99aad6623f41` | `95722`, `99181`, `47186`, `35104`, `61713`, `17959`, `13680`, `70820`, `26813` |
+| <https://partiful.com/_next/static/chunks/6652-bc845eb80e835b16.js?dpl=dpl_D7TPPj16g1fU46JSHSyrsRURxrK9> | `d6b57ad394646129f4702bb7d74aea214d7c43750c3a9898367fb9d4541a71b4` | `73188`, `81977` |
+| <https://partiful.com/_next/static/chunks/1585-abd7081ec2f9f79f.js?dpl=dpl_D7TPPj16g1fU46JSHSyrsRURxrK9> | `437bf13262a46ca96ffb19f625c3ee2a5aaa1996ef9e97ae5b92731341d94487` | `31076` |
+| <https://firebase.google.com/docs/functions/callable-reference> | n/a | generic callable `200` and `result` envelope |
+
+The manifest, `_app`, shared cohost chunk, and event-shared chunk all reported
+`Last-Modified: Wed, 12 Aug 2026 17:42:55 GMT`.
+
+These assets establish current client request construction, current read-path
+selection, and current completion checks. They do not establish business
+success, authorization failures, non-`200` statuses, or unseen response
+variants.
+
+## Callable transport
+
+Shared module `95722` is the current Firebase callable wrapper. It calls the
+named function with one object that contains `params`, and it can also attach
+`deviceInfo`, `amplitudeDeviceId`, `amplitudeSessionId`,
+`adminAccessRequested`, and `userId` when those values are available. It
+removes `undefined` direct `params` properties before dispatch and returns the
+decoded callable business result.
+
+The official Firebase callable protocol is the authority only for generic
+successful HTTP `200` completion and the top-level `result` envelope. It does
+not establish a Partiful business side effect.
+
+## Host-only gating and state reads
+
+Shared module `73188` wires cohost mutation and link controls. For a current
+host it exposes:
+
+- `createCohostRequest`
+- `deleteCohostRequest`
+- `removeCohost`
+- `generateEventCohostLink`
+- `revokeEventCohostLink`
+
+For a non-host it exposes only `claimEventCohostLink`.
+
+Host gating depends on shared module `70820` hook `M_()`, which checks current
+owner membership against the loaded event. This agrees with the existing event
+ownership research that treats `ownerIds` membership as host access.
+
+Shared module `99181` builds the current Firestore cohost paths:
+
+```text
+events/{eventId}/cohostRequests
+events/{eventId}/private/cohostSecret
+```
+
+Module `35104` subscribes to the request collection. Module `61713` subscribes
+to the secret document. Shared module `47186` defines collection `cohostRequests`
+and private-document key `cohostSecret`.
+
+## Cohost request document shape
+
+Shared decoder module `17959` maps each cohost-request document to current
+client state by:
+
+- decoding the Firestore document;
+- taking `eventId` from the parent collection path;
+- reading `target.id` as `targetUserId`; and
+- reading `status` from the document body.
+
+Shared module `13680` defines the closed cohost-request status enum:
+
+```text
+PENDING
+ACCEPTED
+DECLINED
+```
+
+The current client does not expose another request status here.
+
+## Link document shape and token path
+
+Shared subscription module `61713` treats the secret document as optional and
+returns `undefined` when it does not exist. The cohost provider stores that
+decoded object as `cohostSecret`.
+
+Current link creation consumes a server-returned `path`. The current event
+shared module `31076` defines the invite query key constant
+`"accept-cohost"`. The client does not synthesize a token path locally.
+
+This note therefore supports only the current optional secret-document state
+and the current server-owned `path` field. It does not claim any other secret
+field as required.
+
+## Operation requests and completions
+
+Shared module `73188` makes these exact callable requests:
+
+```text
+createCohostRequest({ params: { eventId, targetUserId } })
+deleteCohostRequest({ params: { eventId, targetUserId } })
+removeCohost({ params: { eventId, targetUserId } })
+generateEventCohostLink({ params: { eventId } })
+revokeEventCohostLink({ params: { eventId } })
+```
+
+The current completion use is:
+
+- `createCohostRequest`: reads `response.data` and does not inspect its
+  content further;
+- `deleteCohostRequest`: inspects no business field;
+- `removeCohost`: inspects no business field;
+- `generateEventCohostLink`: reads `response.data.path`; and
+- `revokeEventCohostLink`: inspects no business field.
+
+Current reviewed completion consequences are therefore:
+
+- the four non-link-returning operations need only a generic callable protocol
+  completion at the current client boundary; and
+- `generateEventCohostLink` additionally requires a decoded business-result
+  object with nested `data.path` string.
+
+No current public asset proves persisted cohost state, invitation delivery,
+link delivery, access grant, revocation side effect, or any error mapping.
+Every received non-`200` status, endpoint error, and unseen response shape
+remains explicit unknown.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -14,8 +14,8 @@ import (
 
 const (
 	Version                 = "1.0.0"
-	ProductContractRevision = "2026-08-12.5"
-	RemoteContractRevision  = "2026-08-12.5"
+	ProductContractRevision = "2026-08-12.6"
+	RemoteContractRevision  = "2026-08-12.6"
 )
 
 type Request struct {
@@ -64,6 +64,11 @@ const (
 	eventsCancelCommand
 	rsvpGetCommand
 	rsvpSetCommand
+	cohostsInviteCommand
+	cohostsRevokeInviteCommand
+	cohostsRemoveCommand
+	cohostsLinkCreateCommand
+	cohostsLinkRevokeCommand
 )
 
 type commandDefinition struct {
@@ -490,6 +495,157 @@ var commandCatalog = []commandDefinition{
 			"internal.failure",
 		},
 		safety: standardMutationSafety(),
+	},
+	{
+		path:       "cohosts.invite",
+		invocation: []string{"cohosts", "invite"},
+		kind:       cohostsInviteCommand,
+		positionals: []positionalDefinition{{
+			Name:        "event-id",
+			Required:    true,
+			Description: "Event identifier.",
+		}},
+		flags: []flagDefinition{
+			{Name: "--contact", Description: "Resolvable contact display name.", TakesValue: true, Required: true},
+			{Name: "--apply", Description: "Apply a reviewed consequential plan."},
+			{Name: "--confirm", Description: "Exact consequential confirmation token.", TakesValue: true},
+		},
+		inputSchema:   cohostContactInputSchema(),
+		successSchema: cohostInviteSuccessSchema(),
+		failureTypes: []string{
+			"auth.required",
+			"auth.expired",
+			"permission.denied",
+			"resource.not_found",
+			"match.ambiguous",
+			"state.conflict",
+			"safety.confirmation_required",
+			"safety.plan_stale",
+			"remote.unavailable",
+			"contract.protocol_changed",
+			"internal.failure",
+		},
+		safety: consequentialActionSafety(),
+	},
+	{
+		path:       "cohosts.revoke-invite",
+		invocation: []string{"cohosts", "revoke-invite"},
+		kind:       cohostsRevokeInviteCommand,
+		positionals: []positionalDefinition{{
+			Name:        "event-id",
+			Required:    true,
+			Description: "Event identifier.",
+		}},
+		flags: []flagDefinition{
+			{Name: "--contact", Description: "Resolvable contact display name.", TakesValue: true, Required: true},
+			{Name: "--apply", Description: "Apply a reviewed consequential plan."},
+			{Name: "--confirm", Description: "Exact consequential confirmation token.", TakesValue: true},
+		},
+		inputSchema:   cohostContactInputSchema(),
+		successSchema: cohostRevokeInviteSuccessSchema(),
+		failureTypes: []string{
+			"auth.required",
+			"auth.expired",
+			"permission.denied",
+			"resource.not_found",
+			"match.ambiguous",
+			"state.conflict",
+			"safety.confirmation_required",
+			"safety.plan_stale",
+			"remote.unavailable",
+			"contract.protocol_changed",
+			"internal.failure",
+		},
+		safety: consequentialActionSafety(),
+	},
+	{
+		path:       "cohosts.remove",
+		invocation: []string{"cohosts", "remove"},
+		kind:       cohostsRemoveCommand,
+		positionals: []positionalDefinition{{
+			Name:        "event-id",
+			Required:    true,
+			Description: "Event identifier.",
+		}},
+		flags: []flagDefinition{
+			{Name: "--contact", Description: "Resolvable contact display name.", TakesValue: true, Required: true},
+			{Name: "--apply", Description: "Apply a reviewed consequential plan."},
+			{Name: "--confirm", Description: "Exact consequential confirmation token.", TakesValue: true},
+		},
+		inputSchema:   cohostContactInputSchema(),
+		successSchema: cohostRemoveSuccessSchema(),
+		failureTypes: []string{
+			"auth.required",
+			"auth.expired",
+			"permission.denied",
+			"resource.not_found",
+			"match.ambiguous",
+			"state.conflict",
+			"safety.confirmation_required",
+			"safety.plan_stale",
+			"remote.unavailable",
+			"contract.protocol_changed",
+			"internal.failure",
+		},
+		safety: consequentialActionSafety(),
+	},
+	{
+		path:       "cohosts.link.create",
+		invocation: []string{"cohosts", "link", "create"},
+		kind:       cohostsLinkCreateCommand,
+		positionals: []positionalDefinition{{
+			Name:        "event-id",
+			Required:    true,
+			Description: "Event identifier.",
+		}},
+		flags: []flagDefinition{
+			{Name: "--apply", Description: "Apply a reviewed consequential plan."},
+			{Name: "--confirm", Description: "Exact consequential confirmation token.", TakesValue: true},
+		},
+		inputSchema:   emptyInputSchema(),
+		successSchema: cohostLinkCreateSuccessSchema(),
+		failureTypes: []string{
+			"auth.required",
+			"auth.expired",
+			"permission.denied",
+			"resource.not_found",
+			"state.conflict",
+			"safety.confirmation_required",
+			"safety.plan_stale",
+			"remote.unavailable",
+			"contract.protocol_changed",
+			"internal.failure",
+		},
+		safety: consequentialActionSafety(),
+	},
+	{
+		path:       "cohosts.link.revoke",
+		invocation: []string{"cohosts", "link", "revoke"},
+		kind:       cohostsLinkRevokeCommand,
+		positionals: []positionalDefinition{{
+			Name:        "event-id",
+			Required:    true,
+			Description: "Event identifier.",
+		}},
+		flags: []flagDefinition{
+			{Name: "--apply", Description: "Apply a reviewed consequential plan."},
+			{Name: "--confirm", Description: "Exact consequential confirmation token.", TakesValue: true},
+		},
+		inputSchema:   emptyInputSchema(),
+		successSchema: cohostLinkRevokeSuccessSchema(),
+		failureTypes: []string{
+			"auth.required",
+			"auth.expired",
+			"permission.denied",
+			"resource.not_found",
+			"state.conflict",
+			"safety.confirmation_required",
+			"safety.plan_stale",
+			"remote.unavailable",
+			"contract.protocol_changed",
+			"internal.failure",
+		},
+		safety: consequentialActionSafety(),
 	},
 }
 
@@ -1341,6 +1497,16 @@ func Execute(ctx context.Context, request Request, dependencies Dependencies) Re
 				return executeRSVPGet(ctx, definition, argv, dependencies, pretty)
 			case rsvpSetCommand:
 				return executeRSVPSet(ctx, request, definition, argv, dependencies, pretty)
+			case cohostsInviteCommand:
+				return executeCohostInvite(ctx, definition, argv, dependencies, pretty)
+			case cohostsRevokeInviteCommand:
+				return executeCohostRevokeInvite(ctx, definition, argv, dependencies, pretty)
+			case cohostsRemoveCommand:
+				return executeCohostRemove(ctx, definition, argv, dependencies, pretty)
+			case cohostsLinkCreateCommand:
+				return executeCohostLinkCreate(ctx, definition, argv, dependencies, pretty)
+			case cohostsLinkRevokeCommand:
+				return executeCohostLinkRevoke(ctx, definition, argv, dependencies, pretty)
 			}
 		}
 	}
@@ -1379,7 +1545,12 @@ func (definition commandDefinition) matches(argv []string) bool {
 		definition.kind == eventsUpdateCommand ||
 		definition.kind == eventsCancelCommand ||
 		definition.kind == rsvpGetCommand ||
-		definition.kind == rsvpSetCommand) &&
+		definition.kind == rsvpSetCommand ||
+		definition.kind == cohostsInviteCommand ||
+		definition.kind == cohostsRevokeInviteCommand ||
+		definition.kind == cohostsRemoveCommand ||
+		definition.kind == cohostsLinkCreateCommand ||
+		definition.kind == cohostsLinkRevokeCommand) &&
 		len(argv) >= len(definition.invocation) {
 		return slices.Equal(argv[:len(definition.invocation)], definition.invocation)
 	}

--- a/internal/app/cohost_input.go
+++ b/internal/app/cohost_input.go
@@ -1,0 +1,213 @@
+package app
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+type cohostContactInput struct {
+	Contact string `json:"contact"`
+}
+
+type cohostActionOptions struct {
+	EventID      string
+	Input        cohostContactInput
+	Apply        bool
+	ConfirmToken string
+}
+
+type cohostLinkOptions struct {
+	EventID      string
+	Apply        bool
+	ConfirmToken string
+}
+
+func (input cohostContactInput) document() json.RawMessage {
+	document, _ := json.Marshal(input)
+	return document
+}
+
+func parseCohostActionOptions(
+	definition commandDefinition,
+	argv []string,
+) (cohostActionOptions, *errorBody) {
+	eventID, inputError := parseEventID(definition, argv[:len(definition.invocation)+1])
+	if inputError != nil {
+		return cohostActionOptions{}, inputError
+	}
+	scalars, parseError := parseCohostFlags(definition, argv, len(definition.invocation)+1)
+	if parseError != nil {
+		return cohostActionOptions{}, parseError
+	}
+	options := cohostActionOptions{EventID: eventID}
+	_, options.Apply = scalars["--apply"]
+	options.ConfirmToken = scalars["--confirm"]
+	if options.Apply && options.ConfirmToken == "" {
+		return cohostActionOptions{}, confirmationRequiredErrorBody()
+	}
+	if !options.Apply && options.ConfirmToken != "" {
+		return cohostActionOptions{}, eventWriteInputFailure("APPLY_REQUIRED", "--confirm requires --apply.")
+	}
+	contact := strings.TrimSpace(scalars["--contact"])
+	if contact == "" {
+		return cohostActionOptions{}, eventWriteInputFailure("CONTACT_REQUIRED", "--contact is required.")
+	}
+	options.Input = cohostContactInput{Contact: contact}
+	return options, nil
+}
+
+func parseCohostLinkOptions(
+	definition commandDefinition,
+	argv []string,
+) (cohostLinkOptions, *errorBody) {
+	eventID, inputError := parseEventID(definition, argv[:len(definition.invocation)+1])
+	if inputError != nil {
+		return cohostLinkOptions{}, inputError
+	}
+	scalars, parseError := parseCohostFlags(definition, argv, len(definition.invocation)+1)
+	if parseError != nil {
+		return cohostLinkOptions{}, parseError
+	}
+	options := cohostLinkOptions{EventID: eventID}
+	_, options.Apply = scalars["--apply"]
+	options.ConfirmToken = scalars["--confirm"]
+	if options.Apply && options.ConfirmToken == "" {
+		return cohostLinkOptions{}, confirmationRequiredErrorBody()
+	}
+	if !options.Apply && options.ConfirmToken != "" {
+		return cohostLinkOptions{}, eventWriteInputFailure("APPLY_REQUIRED", "--confirm requires --apply.")
+	}
+	return options, nil
+}
+
+func parseCohostFlags(
+	definition commandDefinition,
+	argv []string,
+	start int,
+) (map[string]string, *errorBody) {
+	allowed := make(map[string]flagDefinition, len(definition.flags))
+	for _, flag := range definition.flags {
+		allowed[flag.Name] = flag
+	}
+	scalars := make(map[string]string)
+	for index := start; index < len(argv); index++ {
+		name := argv[index]
+		flag, ok := allowed[name]
+		if !ok {
+			return nil, eventWriteInputFailure("FLAG_UNKNOWN", "The command contains an unknown flag.")
+		}
+		if _, repeated := scalars[name]; repeated {
+			return nil, eventWriteInputFailureWithDetail("FLAG_REPEATED", "A scalar flag cannot be repeated.", "flag", name)
+		}
+		if !flag.TakesValue {
+			scalars[name] = "true"
+			continue
+		}
+		if index+1 >= len(argv) {
+			return nil, eventWriteInputFailureWithDetail("FLAG_VALUE_REQUIRED", "A flag value is required.", "flag", name)
+		}
+		index++
+		scalars[name] = argv[index]
+	}
+	return scalars, nil
+}
+
+func cohostContactInputSchema() jsonSchema {
+	one := 1
+	return objectSchema(
+		[]string{"contact"},
+		map[string]jsonSchema{
+			"contact": {Type: "string", MinLength: &one},
+		},
+	)
+}
+
+func cohostInviteSuccessSchema() jsonSchema {
+	return cohostContactActionSuccessSchema("createCohostRequest", "invited")
+}
+
+func cohostRevokeInviteSuccessSchema() jsonSchema {
+	return cohostContactActionSuccessSchema("deleteCohostRequest", "revoked")
+}
+
+func cohostRemoveSuccessSchema() jsonSchema {
+	return cohostContactActionSuccessSchema("removeCohost", "removed")
+}
+
+func cohostContactActionSuccessSchema(operation, status string) jsonSchema {
+	one := 1
+	threeHundred := 300
+	plan := objectSchema(
+		[]string{"operation", "eventId", "contact", "request", "effects", "preconditions", "expiresInSeconds", "planToken"},
+		map[string]jsonSchema{
+			"operation": {Type: "string", Enum: []string{operation}},
+			"eventId":   {Type: "string", MinLength: &one},
+			"contact": objectSchema(
+				[]string{"displayName"},
+				map[string]jsonSchema{"displayName": {Type: "string", MinLength: &one}},
+			),
+			"request":          {Type: "object"},
+			"effects":          {Type: "array", Items: pointerSchema(jsonSchema{Type: "string"})},
+			"preconditions":    {Type: "object"},
+			"expiresInSeconds": {Type: "integer", Minimum: &threeHundred, Maximum: &threeHundred},
+			"planToken":        {Type: "string", MinLength: &one},
+		},
+	)
+	success := objectSchema(
+		[]string{"eventId", "cohost"},
+		map[string]jsonSchema{
+			"eventId": {Type: "string", MinLength: &one},
+			"cohost": objectSchema(
+				[]string{"displayName", "status"},
+				map[string]jsonSchema{
+					"displayName": {Type: "string", MinLength: &one},
+					"status":      {Type: "string", Enum: []string{status}},
+				},
+			),
+		},
+	)
+	return jsonSchema{Type: "object", OneOf: []jsonSchema{plan, success}}
+}
+
+func cohostLinkCreateSuccessSchema() jsonSchema {
+	return cohostLinkActionSuccessSchema("generateEventCohostLink", "active", true)
+}
+
+func cohostLinkRevokeSuccessSchema() jsonSchema {
+	return cohostLinkActionSuccessSchema("revokeEventCohostLink", "revoked", false)
+}
+
+func cohostLinkActionSuccessSchema(operation, state string, includeURL bool) jsonSchema {
+	one := 1
+	threeHundred := 300
+	plan := objectSchema(
+		[]string{"operation", "eventId", "request", "effects", "preconditions", "expiresInSeconds", "planToken"},
+		map[string]jsonSchema{
+			"operation":        {Type: "string", Enum: []string{operation}},
+			"eventId":          {Type: "string", MinLength: &one},
+			"request":          {Type: "object"},
+			"effects":          {Type: "array", Items: pointerSchema(jsonSchema{Type: "string"})},
+			"preconditions":    {Type: "object"},
+			"expiresInSeconds": {Type: "integer", Minimum: &threeHundred, Maximum: &threeHundred},
+			"planToken":        {Type: "string", MinLength: &one},
+		},
+	)
+	linkURLType := []string{"null"}
+	if includeURL {
+		linkURLType = []string{"string"}
+	}
+	success := objectSchema(
+		[]string{"eventId", "link"},
+		map[string]jsonSchema{
+			"eventId": {Type: "string", MinLength: &one},
+			"link": objectSchema(
+				[]string{"url", "state"},
+				map[string]jsonSchema{
+					"url":   {Type: linkURLType, Format: "uri"},
+					"state": {Type: "string", Enum: []string{state}},
+				},
+			),
+		},
+	)
+	return jsonSchema{Type: "object", OneOf: []jsonSchema{plan, success}}
+}

--- a/internal/app/cohosts.go
+++ b/internal/app/cohosts.go
@@ -222,7 +222,10 @@ func executeCohostContactAction(
 			return cohostProtocolChangedFailure(definition.path, operation, pretty)
 		}
 	}
-	if !event.OwnerIDsPresent || !containsString(event.OwnerIDs, session.UserID) {
+	if !event.OwnerIDsPresent {
+		return cohostProtocolChangedFailure(definition.path, operation, pretty)
+	}
+	if !containsString(event.OwnerIDs, session.UserID) {
 		if options.Apply {
 			return eventPlanStaleFailure(definition.path, pretty)
 		}
@@ -470,7 +473,10 @@ func executeCohostLinkAction(
 			return cohostProtocolChangedFailure(definition.path, operation, pretty)
 		}
 	}
-	if !event.OwnerIDsPresent || !containsString(event.OwnerIDs, session.UserID) {
+	if !event.OwnerIDsPresent {
+		return cohostProtocolChangedFailure(definition.path, operation, pretty)
+	}
+	if !containsString(event.OwnerIDs, session.UserID) {
 		if options.Apply {
 			return eventPlanStaleFailure(definition.path, pretty)
 		}

--- a/internal/app/cohosts.go
+++ b/internal/app/cohosts.go
@@ -1,0 +1,710 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/KalebCole/partiful-cli/internal/mutation"
+	"github.com/KalebCole/partiful-cli/internal/remote"
+)
+
+type cohostPlan struct {
+	Operation        string            `json:"operation"`
+	EventID          string            `json:"eventId"`
+	Contact          *cohostPlanTarget `json:"contact,omitempty"`
+	Request          any               `json:"request"`
+	Effects          []string          `json:"effects"`
+	Preconditions    map[string]string `json:"preconditions"`
+	ExpiresInSeconds int               `json:"expiresInSeconds"`
+	PlanToken        string            `json:"planToken"`
+}
+
+type cohostPlanTarget struct {
+	DisplayName string `json:"displayName"`
+}
+
+type cohostPlanRequest struct {
+	EventID string `json:"eventId"`
+	Contact string `json:"contact,omitempty"`
+}
+
+type cohostContactResult struct {
+	EventID string           `json:"eventId"`
+	Cohost  cohostResultUser `json:"cohost"`
+}
+
+type cohostResultUser struct {
+	DisplayName string `json:"displayName"`
+	Status      string `json:"status"`
+}
+
+type cohostLinkResult struct {
+	EventID string           `json:"eventId"`
+	Link    cohostResultLink `json:"link"`
+}
+
+type cohostResultLink struct {
+	URL   *string `json:"url"`
+	State string  `json:"state"`
+}
+
+type cohostPrivateContactPreconditions struct {
+	OwnerIDs eventFieldSnapshot   `json:"ownerIds"`
+	Contact  cohostPrivateContact `json:"contact"`
+	Target   cohostTargetState    `json:"target"`
+}
+
+type cohostPrivateContact struct {
+	UserID      string `json:"userId"`
+	DisplayName string `json:"displayName"`
+}
+
+type cohostPrivateLinkPreconditions struct {
+	OwnerIDs eventFieldSnapshot `json:"ownerIds"`
+	Link     cohostLinkState    `json:"link"`
+}
+
+type cohostTargetState struct {
+	Marker string `json:"marker"`
+	Status string `json:"status,omitempty"`
+}
+
+type cohostLinkState struct {
+	Marker string `json:"marker"`
+	Path   string `json:"path,omitempty"`
+}
+
+type resolvedCohostContact struct {
+	UserID           string
+	DisplayName      string
+	SharedEventCount int
+}
+
+func executeCohostInvite(
+	ctx context.Context,
+	definition commandDefinition,
+	argv []string,
+	dependencies Dependencies,
+	pretty bool,
+) Result {
+	return executeCohostContactAction(
+		ctx,
+		definition,
+		argv,
+		dependencies,
+		pretty,
+		"createCohostRequest",
+		"invited",
+		[]string{"Invites the contact to co-host the event."},
+		func(state cohostTargetState) bool {
+			return state.Marker == "absent" || state.Marker == "present" && state.Status == "DECLINED"
+		},
+		func(client remote.Client, ctx context.Context, accessToken, deviceID, userID string, params remote.CohostTargetParams) error {
+			return client.CreateCohostRequest(ctx, accessToken, deviceID, userID, params)
+		},
+		"The selected contact cannot be invited with the reviewed cohost lifecycle.",
+	)
+}
+
+func executeCohostRevokeInvite(
+	ctx context.Context,
+	definition commandDefinition,
+	argv []string,
+	dependencies Dependencies,
+	pretty bool,
+) Result {
+	return executeCohostContactAction(
+		ctx,
+		definition,
+		argv,
+		dependencies,
+		pretty,
+		"deleteCohostRequest",
+		"revoked",
+		[]string{"Revokes the contact's co-host invitation."},
+		func(state cohostTargetState) bool {
+			return state.Marker == "present" && (state.Status == "PENDING" || state.Status == "DECLINED")
+		},
+		func(client remote.Client, ctx context.Context, accessToken, deviceID, userID string, params remote.CohostTargetParams) error {
+			return client.DeleteCohostRequest(ctx, accessToken, deviceID, userID, params)
+		},
+		"The selected contact does not have a revocable co-host invitation.",
+	)
+}
+
+func executeCohostRemove(
+	ctx context.Context,
+	definition commandDefinition,
+	argv []string,
+	dependencies Dependencies,
+	pretty bool,
+) Result {
+	return executeCohostContactAction(
+		ctx,
+		definition,
+		argv,
+		dependencies,
+		pretty,
+		"removeCohost",
+		"removed",
+		[]string{"Removes the contact as a co-host."},
+		func(state cohostTargetState) bool {
+			return state.Marker == "present" && state.Status == "ACCEPTED"
+		},
+		func(client remote.Client, ctx context.Context, accessToken, deviceID, userID string, params remote.CohostTargetParams) error {
+			return client.RemoveCohost(ctx, accessToken, deviceID, userID, params)
+		},
+		"The selected contact is not an accepted co-host.",
+	)
+}
+
+func executeCohostContactAction(
+	ctx context.Context,
+	definition commandDefinition,
+	argv []string,
+	dependencies Dependencies,
+	pretty bool,
+	operation string,
+	successStatus string,
+	effects []string,
+	allowed func(cohostTargetState) bool,
+	dispatch func(remote.Client, context.Context, string, string, string, remote.CohostTargetParams) error,
+	preconditionMessage string,
+) Result {
+	options, inputError := parseCohostActionOptions(definition, argv)
+	if inputError != nil {
+		return failure(definition.path, exitCodeForType(inputError.Type), *inputError, pretty)
+	}
+	session, sessionFailure := acquireProtectedSession(ctx, definition.path, dependencies, pretty)
+	if sessionFailure != nil {
+		return *sessionFailure
+	}
+	if session.AccountFingerprint == "" || session.UserID == "" {
+		return internalFailure(definition.path, pretty)
+	}
+	clock := time.Now
+	if dependencies.Now != nil {
+		clock = dependencies.Now
+	}
+	authority := mutation.Authority{Files: dependencies.Files, Path: eventMutationPath(dependencies), Now: clock, Random: dependencies.MutationRandom}
+	inputDocument := options.Input.document()
+	var inspected mutation.Record
+	if options.Apply {
+		var err error
+		inspected, err = authority.Inspect(options.ConfirmToken, definition.path, operation, session.AccountFingerprint, inputDocument)
+		if err != nil {
+			if errors.Is(err, mutation.ErrStale) {
+				return eventPlanStaleFailure(definition.path, pretty)
+			}
+			return internalFailure(definition.path, pretty)
+		}
+	}
+	deviceID, err := randomDeviceID(dependencies.AuthRandom)
+	if err != nil {
+		return internalFailure(definition.path, pretty)
+	}
+	client := remote.Client{HTTP: dependencies.HTTP}
+	event, err := client.GetEventInfo(ctx, session.AccessToken, deviceID, options.EventID)
+	if err != nil {
+		switch {
+		case errors.Is(err, remote.ErrEventNotFound):
+			if options.Apply {
+				return eventPlanStaleFailure(definition.path, pretty)
+			}
+			return eventNotFoundFailure(definition.path, pretty)
+		case errors.Is(err, remote.ErrUnavailable):
+			return eventRemoteUnavailableFailure(definition.path, "The cohost action could not read current event data.", "partiful: cohost action unavailable\n", pretty)
+		default:
+			return cohostProtocolChangedFailure(definition.path, operation, pretty)
+		}
+	}
+	if !event.OwnerIDsPresent || !containsString(event.OwnerIDs, session.UserID) {
+		if options.Apply {
+			return eventPlanStaleFailure(definition.path, pretty)
+		}
+		return hostPermissionFailure(definition.path, pretty)
+	}
+	contacts, err := client.GetContacts(ctx, session.AccessToken, deviceID)
+	if err != nil {
+		switch {
+		case errors.Is(err, remote.ErrUnavailable):
+			return eventRemoteUnavailableFailure(definition.path, "The cohost action could not read current contact data.", "partiful: cohost action unavailable\n", pretty)
+		case errors.Is(err, remote.ErrUnauthenticated):
+			return authenticationExpiredFailure(
+				definition.path,
+				"REMOTE_SESSION_UNAUTHENTICATED",
+				"Stored authentication is no longer accepted. Log in again.",
+				pretty,
+			)
+		default:
+			return contactsProtocolChangedFailure(definition.path, pretty)
+		}
+	}
+	requests, err := client.GetCohostRequests(ctx, session.AccessToken, options.EventID)
+	if err != nil {
+		if errors.Is(err, remote.ErrUnavailable) {
+			return eventRemoteUnavailableFailure(definition.path, "The cohost action could not read current cohost state.", "partiful: cohost action unavailable\n", pretty)
+		}
+		return cohostProtocolChangedFailure(definition.path, operation, pretty)
+	}
+
+	var contact resolvedCohostContact
+	if options.Apply {
+		expected, decodeErr := decodeCohostTargetRequest(inspected.Binding.Request)
+		if decodeErr != nil {
+			return internalFailure(definition.path, pretty)
+		}
+		found, ok := findCohostContactByID(expected.TargetUserID, contacts.Contacts)
+		if !ok {
+			return eventPlanStaleFailure(definition.path, pretty)
+		}
+		contact = found
+	} else {
+		resolved, resolveFailure := resolveCohostContact(options.Input.Contact, contacts.Contacts)
+		if resolveFailure != nil {
+			return failure(definition.path, resolveFailure.exitCode, resolveFailure.body, pretty)
+		}
+		contact = resolved
+	}
+
+	targetState, stateErr := currentCohostTargetState(requests, contact.UserID)
+	if stateErr != nil {
+		return cohostProtocolChangedFailure(definition.path, operation, pretty)
+	}
+	preconditions := cohostPrivateContactPreconditions{
+		OwnerIDs: rawEventField(event, "ownerIds"),
+		Contact: cohostPrivateContact{
+			UserID:      contact.UserID,
+			DisplayName: contact.DisplayName,
+		},
+		Target: targetState,
+	}
+	requestDocument, _ := json.Marshal(remote.CohostTargetParams{
+		EventID:      options.EventID,
+		TargetUserID: contact.UserID,
+	})
+	preconditionDocument, _ := json.Marshal(preconditions)
+	if options.Apply && !bytes.Equal(inspected.Binding.Preconditions, preconditionDocument) {
+		return eventPlanStaleFailure(definition.path, pretty)
+	}
+	if !allowed(targetState) {
+		return cohostStateFailure(definition.path, preconditionMessage, pretty)
+	}
+	binding := mutation.Binding{
+		Command:            definition.path,
+		Operation:          operation,
+		AccountFingerprint: session.AccountFingerprint,
+		Input:              inputDocument,
+		Request:            requestDocument,
+		Preconditions:      preconditionDocument,
+	}
+	if options.Apply {
+		if !bytes.Equal(inspected.Binding.Request, requestDocument) || !bytes.Equal(inspected.Binding.Preconditions, preconditionDocument) {
+			return eventPlanStaleFailure(definition.path, pretty)
+		}
+		if err := authority.Consume(options.ConfirmToken, binding); err != nil {
+			if errors.Is(err, mutation.ErrStale) {
+				return eventPlanStaleFailure(definition.path, pretty)
+			}
+			return internalFailure(definition.path, pretty)
+		}
+		if err := dispatch(client, ctx, session.AccessToken, deviceID, session.UserID, remote.CohostTargetParams{
+			EventID:      options.EventID,
+			TargetUserID: contact.UserID,
+		}); err != nil {
+			if errors.Is(err, remote.ErrUnavailable) {
+				return eventSubmissionUnavailableFailure(definition.path, "Cohost submission could not be confirmed. Create a new plan before another attempt.", pretty)
+			}
+			return cohostProtocolChangedFailure(definition.path, operation, pretty)
+		}
+		return success(definition.path, cohostContactResult{
+			EventID: options.EventID,
+			Cohost: cohostResultUser{
+				DisplayName: contact.DisplayName,
+				Status:      successStatus,
+			},
+		}, pretty)
+	}
+	token, err := authority.Create(binding)
+	if err != nil {
+		return internalFailure(definition.path, pretty)
+	}
+	return success(definition.path, cohostPlan{
+		Operation: operation,
+		EventID:   options.EventID,
+		Contact:   &cohostPlanTarget{DisplayName: contact.DisplayName},
+		Request: cohostPlanRequest{
+			EventID: options.EventID,
+			Contact: contact.DisplayName,
+		},
+		Effects:          effects,
+		Preconditions:    map[string]string{"ownership": "bound", "contact": "bound", "cohostState": "bound"},
+		ExpiresInSeconds: 300,
+		PlanToken:        token,
+	}, pretty)
+}
+
+func executeCohostLinkCreate(
+	ctx context.Context,
+	definition commandDefinition,
+	argv []string,
+	dependencies Dependencies,
+	pretty bool,
+) Result {
+	return executeCohostLinkAction(
+		ctx,
+		definition,
+		argv,
+		dependencies,
+		pretty,
+		"generateEventCohostLink",
+		[]string{"Creates a co-host invite link."},
+		func(state cohostLinkState) bool { return state.Marker == "absent" },
+		func(client remote.Client, ctx context.Context, accessToken, deviceID, userID string, params remote.CohostLinkParams) (*string, error) {
+			path, err := client.GenerateEventCohostLink(ctx, accessToken, deviceID, userID, params)
+			if err != nil {
+				return nil, err
+			}
+			url, ok := cohostPathToURL(path)
+			if !ok {
+				return nil, remote.ErrProtocolChanged
+			}
+			return &url, nil
+		},
+		"The co-host invite link already exists.",
+		"active",
+		true,
+	)
+}
+
+func executeCohostLinkRevoke(
+	ctx context.Context,
+	definition commandDefinition,
+	argv []string,
+	dependencies Dependencies,
+	pretty bool,
+) Result {
+	return executeCohostLinkAction(
+		ctx,
+		definition,
+		argv,
+		dependencies,
+		pretty,
+		"revokeEventCohostLink",
+		[]string{"Revokes the current co-host invite link."},
+		func(state cohostLinkState) bool { return state.Marker == "present" },
+		func(client remote.Client, ctx context.Context, accessToken, deviceID, userID string, params remote.CohostLinkParams) (*string, error) {
+			if err := client.RevokeEventCohostLink(ctx, accessToken, deviceID, userID, params); err != nil {
+				return nil, err
+			}
+			return nil, nil
+		},
+		"The co-host invite link is already revoked.",
+		"revoked",
+		false,
+	)
+}
+
+func executeCohostLinkAction(
+	ctx context.Context,
+	definition commandDefinition,
+	argv []string,
+	dependencies Dependencies,
+	pretty bool,
+	operation string,
+	effects []string,
+	allowed func(cohostLinkState) bool,
+	dispatch func(remote.Client, context.Context, string, string, string, remote.CohostLinkParams) (*string, error),
+	preconditionMessage string,
+	successState string,
+	emitURL bool,
+) Result {
+	options, inputError := parseCohostLinkOptions(definition, argv)
+	if inputError != nil {
+		return failure(definition.path, exitCodeForType(inputError.Type), *inputError, pretty)
+	}
+	session, sessionFailure := acquireProtectedSession(ctx, definition.path, dependencies, pretty)
+	if sessionFailure != nil {
+		return *sessionFailure
+	}
+	if session.AccountFingerprint == "" || session.UserID == "" {
+		return internalFailure(definition.path, pretty)
+	}
+	clock := time.Now
+	if dependencies.Now != nil {
+		clock = dependencies.Now
+	}
+	authority := mutation.Authority{Files: dependencies.Files, Path: eventMutationPath(dependencies), Now: clock, Random: dependencies.MutationRandom}
+	inputDocument := json.RawMessage(`{}`)
+	var inspected mutation.Record
+	if options.Apply {
+		var err error
+		inspected, err = authority.Inspect(options.ConfirmToken, definition.path, operation, session.AccountFingerprint, inputDocument)
+		if err != nil {
+			if errors.Is(err, mutation.ErrStale) {
+				return eventPlanStaleFailure(definition.path, pretty)
+			}
+			return internalFailure(definition.path, pretty)
+		}
+	}
+	deviceID, err := randomDeviceID(dependencies.AuthRandom)
+	if err != nil {
+		return internalFailure(definition.path, pretty)
+	}
+	client := remote.Client{HTTP: dependencies.HTTP}
+	event, err := client.GetEventInfo(ctx, session.AccessToken, deviceID, options.EventID)
+	if err != nil {
+		switch {
+		case errors.Is(err, remote.ErrEventNotFound):
+			if options.Apply {
+				return eventPlanStaleFailure(definition.path, pretty)
+			}
+			return eventNotFoundFailure(definition.path, pretty)
+		case errors.Is(err, remote.ErrUnavailable):
+			return eventRemoteUnavailableFailure(definition.path, "The cohost link action could not read current event data.", "partiful: cohost action unavailable\n", pretty)
+		default:
+			return cohostProtocolChangedFailure(definition.path, operation, pretty)
+		}
+	}
+	if !event.OwnerIDsPresent || !containsString(event.OwnerIDs, session.UserID) {
+		if options.Apply {
+			return eventPlanStaleFailure(definition.path, pretty)
+		}
+		return hostPermissionFailure(definition.path, pretty)
+	}
+	link, err := client.GetCohostLink(ctx, session.AccessToken, options.EventID)
+	if err != nil {
+		if errors.Is(err, remote.ErrUnavailable) {
+			return eventRemoteUnavailableFailure(definition.path, "The cohost link action could not read current link state.", "partiful: cohost action unavailable\n", pretty)
+		}
+		return cohostProtocolChangedFailure(definition.path, operation, pretty)
+	}
+	linkState := snapshotCohostLinkState(link)
+	preconditions := cohostPrivateLinkPreconditions{
+		OwnerIDs: rawEventField(event, "ownerIds"),
+		Link:     linkState,
+	}
+	requestDocument, _ := json.Marshal(remote.CohostLinkParams{EventID: options.EventID})
+	preconditionDocument, _ := json.Marshal(preconditions)
+	if options.Apply && !bytes.Equal(inspected.Binding.Preconditions, preconditionDocument) {
+		return eventPlanStaleFailure(definition.path, pretty)
+	}
+	if !allowed(linkState) {
+		return cohostStateFailure(definition.path, preconditionMessage, pretty)
+	}
+	binding := mutation.Binding{
+		Command:            definition.path,
+		Operation:          operation,
+		AccountFingerprint: session.AccountFingerprint,
+		Input:              inputDocument,
+		Request:            requestDocument,
+		Preconditions:      preconditionDocument,
+	}
+	if options.Apply {
+		if !bytes.Equal(inspected.Binding.Request, requestDocument) || !bytes.Equal(inspected.Binding.Preconditions, preconditionDocument) {
+			return eventPlanStaleFailure(definition.path, pretty)
+		}
+		if err := authority.Consume(options.ConfirmToken, binding); err != nil {
+			if errors.Is(err, mutation.ErrStale) {
+				return eventPlanStaleFailure(definition.path, pretty)
+			}
+			return internalFailure(definition.path, pretty)
+		}
+		linkURL, err := dispatch(client, ctx, session.AccessToken, deviceID, session.UserID, remote.CohostLinkParams{EventID: options.EventID})
+		if err != nil {
+			if errors.Is(err, remote.ErrUnavailable) {
+				return eventSubmissionUnavailableFailure(definition.path, "Cohost submission could not be confirmed. Create a new plan before another attempt.", pretty)
+			}
+			return cohostProtocolChangedFailure(definition.path, operation, pretty)
+		}
+		if !emitURL {
+			linkURL = nil
+		}
+		return success(definition.path, cohostLinkResult{
+			EventID: options.EventID,
+			Link: cohostResultLink{
+				URL:   linkURL,
+				State: successState,
+			},
+		}, pretty)
+	}
+	token, err := authority.Create(binding)
+	if err != nil {
+		return internalFailure(definition.path, pretty)
+	}
+	return success(definition.path, cohostPlan{
+		Operation:        operation,
+		EventID:          options.EventID,
+		Request:          cohostPlanRequest{EventID: options.EventID},
+		Effects:          effects,
+		Preconditions:    map[string]string{"ownership": "bound", "link": "bound"},
+		ExpiresInSeconds: 300,
+		PlanToken:        token,
+	}, pretty)
+}
+
+func resolveCohostContact(query string, contacts []remote.Contact) (resolvedCohostContact, *cursorValidationFailure) {
+	lowered := strings.ToLower(strings.TrimSpace(query))
+	if lowered == "" {
+		return resolvedCohostContact{}, &cursorValidationFailure{
+			exitCode: 2,
+			body: errorBody{
+				Type:      "input.invalid",
+				Code:      "CONTACT_REQUIRED",
+				Message:   "--contact is required.",
+				Retryable: false,
+				Details:   map[string]any{},
+			},
+		}
+	}
+	unique := uniqueContacts(contacts)
+	exact := make([]remote.Contact, 0, 1)
+	for _, contact := range unique {
+		if strings.ToLower(strings.TrimSpace(contact.Name)) == lowered {
+			exact = append(exact, contact)
+		}
+	}
+	candidates := exact
+	if len(candidates) == 0 {
+		for _, contact := range unique {
+			if containsFold(contact.Name, lowered) {
+				candidates = append(candidates, contact)
+			}
+		}
+	}
+	if len(candidates) == 0 {
+		return resolvedCohostContact{}, &cursorValidationFailure{
+			exitCode: 5,
+			body: errorBody{
+				Type:      "resource.not_found",
+				Code:      "CONTACT_NOT_FOUND",
+				Message:   "The contact was not found.",
+				Retryable: false,
+				Details:   map[string]any{},
+			},
+		}
+	}
+	if len(candidates) > 1 {
+		safe := make([]map[string]any, 0, len(candidates))
+		for _, candidate := range candidates {
+			safe = append(safe, map[string]any{
+				"displayName":      candidate.Name,
+				"sharedEventCount": candidate.SharedEventCount,
+			})
+		}
+		return resolvedCohostContact{}, &cursorValidationFailure{
+			exitCode: 2,
+			body: errorBody{
+				Type:      "match.ambiguous",
+				Code:      "CONTACT_AMBIGUOUS",
+				Message:   "More than one contact matches that name.",
+				Retryable: false,
+				Details:   map[string]any{"candidates": safe},
+			},
+		}
+	}
+	return resolvedCohostContact{
+		UserID:           candidates[0].ID,
+		DisplayName:      candidates[0].Name,
+		SharedEventCount: candidates[0].SharedEventCount,
+	}, nil
+}
+
+func findCohostContactByID(userID string, contacts []remote.Contact) (resolvedCohostContact, bool) {
+	for _, contact := range uniqueContacts(contacts) {
+		if contact.ID == userID {
+			return resolvedCohostContact{
+				UserID:           contact.ID,
+				DisplayName:      contact.Name,
+				SharedEventCount: contact.SharedEventCount,
+			}, true
+		}
+	}
+	return resolvedCohostContact{}, false
+}
+
+func uniqueContacts(contacts []remote.Contact) []remote.Contact {
+	seen := make(map[string]struct{}, len(contacts))
+	unique := make([]remote.Contact, 0, len(contacts))
+	for _, contact := range contacts {
+		if contact.ID == "" || contact.Name == "" {
+			continue
+		}
+		if _, ok := seen[contact.ID]; ok {
+			continue
+		}
+		seen[contact.ID] = struct{}{}
+		unique = append(unique, contact)
+	}
+	return unique
+}
+
+func currentCohostTargetState(requests []remote.CohostRequest, userID string) (cohostTargetState, error) {
+	state := cohostTargetState{Marker: "absent"}
+	for _, request := range requests {
+		if request.TargetUserID != userID {
+			continue
+		}
+		if state.Marker != "absent" {
+			return cohostTargetState{}, errors.New("duplicate cohost request")
+		}
+		state = cohostTargetState{Marker: "present", Status: request.Status}
+	}
+	return state, nil
+}
+
+func snapshotCohostLinkState(link remote.CohostLink) cohostLinkState {
+	if !link.Present {
+		return cohostLinkState{Marker: "absent"}
+	}
+	return cohostLinkState{Marker: "present", Path: link.Path}
+}
+
+func decodeCohostTargetRequest(raw json.RawMessage) (remote.CohostTargetParams, error) {
+	var request remote.CohostTargetParams
+	return request, json.Unmarshal(raw, &request)
+}
+
+func containsString(values []string, needle string) bool {
+	for _, value := range values {
+		if value == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func cohostStateFailure(command, message string, pretty bool) Result {
+	result := failure(command, 6, errorBody{
+		Type:      "state.conflict",
+		Code:      "COHOST_PRECONDITION_FAILED",
+		Message:   message,
+		Retryable: false,
+		Details:   map[string]any{},
+	}, pretty)
+	result.Stderr = "partiful: cohost precondition failed\n"
+	return result
+}
+
+func cohostProtocolChangedFailure(command, operation string, pretty bool) Result {
+	result := failure(command, 9, errorBody{
+		Type:      "contract.protocol_changed",
+		Code:      "COHOST_PROTOCOL_CHANGED",
+		Message:   "The cohost action no longer matches the reviewed remote contract.",
+		Retryable: false,
+		Details:   map[string]any{"operation": operation},
+	}, pretty)
+	result.Stderr = "partiful: cohost protocol changed\n"
+	return result
+}
+
+func cohostPathToURL(path string) (string, bool) {
+	if !strings.HasPrefix(path, "/e/") || !strings.Contains(path, "accept-cohost=") {
+		return "", false
+	}
+	return "https://partiful.com" + path, true
+}

--- a/internal/app/cohosts_execute_test.go
+++ b/internal/app/cohosts_execute_test.go
@@ -1,0 +1,556 @@
+package app_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KalebCole/partiful-cli/internal/app"
+)
+
+func contactPageResponse(items []map[string]any, nextCursor *string) string {
+	page := map[string]any{
+		"result": map[string]any{
+			"data":   items,
+			"paging": map[string]any{},
+		},
+	}
+	if nextCursor != nil {
+		page["result"].(map[string]any)["paging"] = map[string]any{"nextCursor": *nextCursor}
+	}
+	body, _ := json.Marshal(page)
+	return string(body)
+}
+
+func cohostRequestDocument(targetUserID, status string) string {
+	return `{"name":"projects/getpartiful/databases/(default)/documents/events/event-example/cohostRequests/req-1","fields":{"target":{"referenceValue":"projects/getpartiful/databases/(default)/documents/users/` + targetUserID + `"},"status":{"stringValue":"` + status + `"}}}`
+}
+
+func cohostLinkDocument(path string) string {
+	return `{"name":"projects/getpartiful/databases/(default)/documents/events/event-example/private/cohostSecret","fields":{"path":{"stringValue":"` + path + `"}}}`
+}
+
+func firestoreNotFound() string {
+	return `{"error":{"status":"NOT_FOUND"}}`
+}
+
+func assertContactsPageRequest(t *testing.T, request *http.Request, cursor *string) {
+	t.Helper()
+	if request.Method != http.MethodPost || request.URL.String() != "https://api.partiful.com/getContacts" {
+		t.Fatalf("request = %s %s, want getContacts", request.Method, request.URL)
+	}
+	want := `{"data":{"params":{},"amplitudeDeviceId":"MDEyMzQ1Njc4OWFiY2RlZg","paging":{"maxResults":1000,"cursor":null}}}`
+	if cursor != nil {
+		want = `{"data":{"params":{},"amplitudeDeviceId":"MDEyMzQ1Njc4OWFiY2RlZg","paging":{"maxResults":1000,"cursor":"` + *cursor + `"}}}`
+	}
+	assertEventCallableRequest(t, request, "getContacts", want)
+}
+
+func TestExecuteCohostInvitePlansAndAppliesConfirmedAction(t *testing.T) {
+	files := &memoryFilesystem{files: map[string][]byte{
+		eventWriteCredentialsPath: []byte(eventWriteCredentials),
+	}}
+	dependencies := eventWriteDependencies(files)
+	dependencies.MutationRandom = strings.NewReader(strings.Repeat("h", 32))
+	cursor := "cursor-1"
+	call := 0
+	dependencies.HTTP = scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+		call++
+		switch call {
+		case 1, 5:
+			assertEventCallableRequest(
+				t,
+				request,
+				"getEventInfo",
+				`{"data":{"params":{"eventId":"event-example"},"amplitudeDeviceId":"MDEyMzQ1Njc4OWFiY2RlZg"}}`,
+			)
+			event := compatibleUpdateEvent()
+			event["ownerIds"] = []string{"private-account"}
+			return jsonResponse(http.StatusOK, eventResponse(t, event)), nil
+		case 2, 6:
+			assertContactsPageRequest(t, request, nil)
+			return jsonResponse(http.StatusOK, contactPageResponse([]map[string]any{{
+				"id":               "private-contact-id",
+				"name":             "Example Contact",
+				"sharedEventCount": 3,
+			}}, &cursor)), nil
+		case 3, 7:
+			assertContactsPageRequest(t, request, &cursor)
+			return jsonResponse(http.StatusOK, contactPageResponse([]map[string]any{}, nil)), nil
+		case 4, 8:
+			if request.Method != http.MethodGet || request.URL.String() != "https://firestore.googleapis.com/v1/projects/getpartiful/databases/(default)/documents/events/event-example/cohostRequests?pageSize=100" {
+				t.Fatalf("request = %s %s, want cohost request list", request.Method, request.URL)
+			}
+			return jsonResponse(http.StatusOK, `{}`), nil
+		case 9:
+			assertEventCallableRequest(
+				t,
+				request,
+				"createCohostRequest",
+				`{"data":{"params":{"eventId":"event-example","targetUserId":"private-contact-id"},"amplitudeDeviceId":"MDEyMzQ1Njc4OWFiY2RlZg","userId":"private-account"}}`,
+			)
+			return jsonResponse(http.StatusOK, `{"result":{"data":{}}}`), nil
+		default:
+			t.Fatalf("unexpected request %d: %s", call, request.URL)
+			return nil, nil
+		}
+	}}
+
+	argv := []string{"cohosts", "invite", "event-example", "--contact", "  Example Contact  "}
+	plan := app.Execute(context.Background(), app.Request{Argv: argv}, dependencies)
+	if plan.ExitCode != 0 || plan.Stderr != "" {
+		t.Fatalf("plan = %#v, want cohost invite plan", plan)
+	}
+	if !strings.Contains(plan.Stdout, `"operation":"createCohostRequest"`) ||
+		!strings.Contains(plan.Stdout, `"displayName":"Example Contact"`) ||
+		!strings.Contains(plan.Stdout, `"cohostState":"bound"`) {
+		t.Fatalf("plan stdout = %s, want redacted cohost invite plan", plan.Stdout)
+	}
+	token := rsvpPlanToken(t, plan)
+	applied := app.Execute(context.Background(), app.Request{
+		Argv: append(append([]string{}, argv...), "--apply", "--confirm", token),
+	}, dependencies)
+	if applied.ExitCode != 0 ||
+		!strings.Contains(applied.Stdout, `"status":"invited"`) ||
+		applied.Stderr != "" {
+		t.Fatalf("applied = %#v, want invite success", applied)
+	}
+	for _, privateValue := range []string{"private-contact-id", "private-account", "private-access-token"} {
+		if strings.Contains(plan.Stdout+applied.Stdout+plan.Stderr+applied.Stderr, privateValue) {
+			t.Fatalf("output exposed private value %q", privateValue)
+		}
+	}
+	reused := app.Execute(context.Background(), app.Request{
+		Argv: append(append([]string{}, argv...), "--apply", "--confirm", token),
+	}, dependencies)
+	if reused.ExitCode != 7 || !strings.Contains(reused.Stdout, `"type":"safety.plan_stale"`) {
+		t.Fatalf("reused = %#v, want stale consumed plan", reused)
+	}
+}
+
+func TestExecuteCohostRevokeInviteAndRemoveApplyExactReviewedOperations(t *testing.T) {
+	tests := []struct {
+		name           string
+		argv           []string
+		status         string
+		operation      string
+		successStatus  string
+		mutationBody   string
+		mutationResult string
+	}{
+		{
+			name:          "revoke invite",
+			argv:          []string{"cohosts", "revoke-invite", "event-example", "--contact", "Example Contact"},
+			status:        "DECLINED",
+			operation:     "deleteCohostRequest",
+			successStatus: "revoked",
+			mutationBody:  `{"data":{"params":{"eventId":"event-example","targetUserId":"private-contact-id"},"amplitudeDeviceId":"MDEyMzQ1Njc4OWFiY2RlZg","userId":"private-account"}}`,
+			mutationResult: `{"result":null}`,
+		},
+		{
+			name:          "remove cohost",
+			argv:          []string{"cohosts", "remove", "event-example", "--contact", "Example Contact"},
+			status:        "ACCEPTED",
+			operation:     "removeCohost",
+			successStatus: "removed",
+			mutationBody:  `{"data":{"params":{"eventId":"event-example","targetUserId":"private-contact-id"},"amplitudeDeviceId":"MDEyMzQ1Njc4OWFiY2RlZg","userId":"private-account"}}`,
+			mutationResult: `{"data":true}`,
+		},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			files := &memoryFilesystem{files: map[string][]byte{
+				eventWriteCredentialsPath: []byte(eventWriteCredentials),
+			}}
+			dependencies := eventWriteDependencies(files)
+			dependencies.MutationRandom = strings.NewReader(strings.Repeat("r", 32))
+			cursor := "cursor-1"
+			call := 0
+			dependencies.HTTP = scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+				call++
+				switch call {
+				case 1, 5:
+					assertEventCallableRequest(
+						t,
+						request,
+						"getEventInfo",
+						`{"data":{"params":{"eventId":"event-example"},"amplitudeDeviceId":"MDEyMzQ1Njc4OWFiY2RlZg"}}`,
+					)
+					event := compatibleUpdateEvent()
+					event["ownerIds"] = []string{"private-account"}
+					return jsonResponse(http.StatusOK, eventResponse(t, event)), nil
+				case 2, 6:
+					assertContactsPageRequest(t, request, nil)
+					return jsonResponse(http.StatusOK, contactPageResponse([]map[string]any{{
+						"id":               "private-contact-id",
+						"name":             "Example Contact",
+						"sharedEventCount": 3,
+					}}, &cursor)), nil
+				case 3, 7:
+					assertContactsPageRequest(t, request, &cursor)
+					return jsonResponse(http.StatusOK, contactPageResponse([]map[string]any{}, nil)), nil
+				case 4, 8:
+					if request.Method != http.MethodGet || request.URL.String() != "https://firestore.googleapis.com/v1/projects/getpartiful/databases/(default)/documents/events/event-example/cohostRequests?pageSize=100" {
+						t.Fatalf("request = %s %s, want cohost request list", request.Method, request.URL)
+					}
+					return jsonResponse(http.StatusOK, `{"documents":[`+cohostRequestDocument("private-contact-id", testCase.status)+`]}`), nil
+				case 9:
+					assertEventCallableRequest(t, request, testCase.operation, testCase.mutationBody)
+					return jsonResponse(http.StatusOK, testCase.mutationResult), nil
+				default:
+					t.Fatalf("unexpected request %d: %s", call, request.URL)
+					return nil, nil
+				}
+			}}
+
+			plan := app.Execute(context.Background(), app.Request{Argv: testCase.argv}, dependencies)
+			if plan.ExitCode != 0 || !strings.Contains(plan.Stdout, `"operation":"`+testCase.operation+`"`) {
+				t.Fatalf("plan = %#v, want %s plan", plan, testCase.operation)
+			}
+			token := rsvpPlanToken(t, plan)
+			applied := app.Execute(context.Background(), app.Request{
+				Argv: append(append([]string{}, testCase.argv...), "--apply", "--confirm", token),
+			}, dependencies)
+			if applied.ExitCode != 0 || !strings.Contains(applied.Stdout, `"status":"`+testCase.successStatus+`"`) {
+				t.Fatalf("applied = %#v, want %s success", applied, testCase.successStatus)
+			}
+		})
+	}
+}
+
+func TestExecuteCohostLinkCreateAndRevokeReturnDocumentedState(t *testing.T) {
+	tests := []struct {
+		name             string
+		argv             []string
+		linkResponse     string
+		linkPresent      bool
+		operation        string
+		successContains  string
+		mutationBody     string
+		mutationResponse string
+	}{
+		{
+			name:             "create link",
+			argv:             []string{"cohosts", "link", "create", "event-example"},
+			linkPresent:      false,
+			linkResponse:     firestoreNotFound(),
+			operation:        "generateEventCohostLink",
+			successContains:  `"link":{"url":"https://partiful.com/e/event-example?accept-cohost=secret-token","state":"active"}`,
+			mutationBody:     `{"data":{"params":{"eventId":"event-example"},"amplitudeDeviceId":"MDEyMzQ1Njc4OWFiY2RlZg","userId":"private-account"}}`,
+			mutationResponse: `{"result":{"data":{"path":"/e/event-example?accept-cohost=secret-token"}}}`,
+		},
+		{
+			name:             "revoke link",
+			argv:             []string{"cohosts", "link", "revoke", "event-example"},
+			linkPresent:      true,
+			linkResponse:     cohostLinkDocument(`/e/event-example?accept-cohost=existing-token`),
+			operation:        "revokeEventCohostLink",
+			successContains:  `"link":{"url":null,"state":"revoked"}`,
+			mutationBody:     `{"data":{"params":{"eventId":"event-example"},"amplitudeDeviceId":"MDEyMzQ1Njc4OWFiY2RlZg","userId":"private-account"}}`,
+			mutationResponse: `{"result":null}`,
+		},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			files := &memoryFilesystem{files: map[string][]byte{
+				eventWriteCredentialsPath: []byte(eventWriteCredentials),
+			}}
+			dependencies := eventWriteDependencies(files)
+			dependencies.MutationRandom = strings.NewReader(strings.Repeat("l", 32))
+			call := 0
+			dependencies.HTTP = scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+				call++
+				switch call {
+				case 1, 3:
+					assertEventCallableRequest(
+						t,
+						request,
+						"getEventInfo",
+						`{"data":{"params":{"eventId":"event-example"},"amplitudeDeviceId":"MDEyMzQ1Njc4OWFiY2RlZg"}}`,
+					)
+					event := compatibleUpdateEvent()
+					event["ownerIds"] = []string{"private-account"}
+					return jsonResponse(http.StatusOK, eventResponse(t, event)), nil
+				case 2, 4:
+					if request.Method != http.MethodGet || request.URL.String() != "https://firestore.googleapis.com/v1/projects/getpartiful/databases/(default)/documents/events/event-example/private/cohostSecret" {
+						t.Fatalf("request = %s %s, want cohost secret read", request.Method, request.URL)
+					}
+					if testCase.linkPresent {
+						return jsonResponse(http.StatusOK, testCase.linkResponse), nil
+					}
+					return jsonResponse(http.StatusNotFound, testCase.linkResponse), nil
+				case 5:
+					assertEventCallableRequest(t, request, testCase.operation, testCase.mutationBody)
+					return jsonResponse(http.StatusOK, testCase.mutationResponse), nil
+				default:
+					t.Fatalf("unexpected request %d: %s", call, request.URL)
+					return nil, nil
+				}
+			}}
+
+			plan := app.Execute(context.Background(), app.Request{Argv: testCase.argv}, dependencies)
+			if plan.ExitCode != 0 || !strings.Contains(plan.Stdout, `"operation":"`+testCase.operation+`"`) {
+				t.Fatalf("plan = %#v, want %s plan", plan, testCase.operation)
+			}
+			token := rsvpPlanToken(t, plan)
+			applied := app.Execute(context.Background(), app.Request{
+				Argv: append(append([]string{}, testCase.argv...), "--apply", "--confirm", token),
+			}, dependencies)
+			if applied.ExitCode != 0 || !strings.Contains(applied.Stdout, testCase.successContains) {
+				t.Fatalf("applied = %#v, want %s", applied, testCase.successContains)
+			}
+		})
+	}
+}
+
+func TestExecuteCohostLinkCreateFailsClosedWithoutLeakingExistingURL(t *testing.T) {
+	files := &memoryFilesystem{files: map[string][]byte{
+		eventWriteCredentialsPath: []byte(eventWriteCredentials),
+	}}
+	dependencies := eventWriteDependencies(files)
+	dependencies.HTTP = scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+		switch request.URL.String() {
+		case "https://api.partiful.com/getEventInfo":
+			event := compatibleUpdateEvent()
+			event["ownerIds"] = []string{"private-account"}
+			return jsonResponse(http.StatusOK, eventResponse(t, event)), nil
+		case "https://firestore.googleapis.com/v1/projects/getpartiful/databases/(default)/documents/events/event-example/private/cohostSecret":
+			return jsonResponse(http.StatusOK, cohostLinkDocument(`/e/event-example?accept-cohost=private-secret-token`)), nil
+		default:
+			t.Fatalf("unexpected request %s", request.URL)
+			return nil, nil
+		}
+	}}
+
+	result := app.Execute(context.Background(), app.Request{
+		Argv: []string{"cohosts", "link", "create", "event-example"},
+	}, dependencies)
+	if result.ExitCode != 6 || !strings.Contains(result.Stdout, `"type":"state.conflict"`) {
+		t.Fatalf("result = %#v, want link precondition failure", result)
+	}
+	if strings.Contains(result.Stdout+result.Stderr, "private-secret-token") {
+		t.Fatal("existing cohost link leaked in failure output")
+	}
+}
+
+func TestExecuteCohostPlansStaleOnChangedRoleContactLinkAccountAndExpiry(t *testing.T) {
+	t.Run("changed role", func(t *testing.T) {
+		files := &memoryFilesystem{files: map[string][]byte{
+			eventWriteCredentialsPath: []byte(eventWriteCredentials),
+		}}
+		dependencies := eventWriteDependencies(files)
+		dependencies.MutationRandom = strings.NewReader(strings.Repeat("s", 32))
+		cursor := "cursor-1"
+		call := 0
+		dependencies.HTTP = scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+			call++
+			switch call {
+			case 1:
+				event := compatibleUpdateEvent()
+				event["ownerIds"] = []string{"private-account"}
+				return jsonResponse(http.StatusOK, eventResponse(t, event)), nil
+			case 2:
+				return jsonResponse(http.StatusOK, contactPageResponse([]map[string]any{{
+					"id":               "private-contact-id",
+					"name":             "Example Contact",
+					"sharedEventCount": 3,
+				}}, &cursor)), nil
+			case 3:
+				return jsonResponse(http.StatusOK, contactPageResponse([]map[string]any{}, nil)), nil
+			case 4:
+				return jsonResponse(http.StatusOK, `{}`), nil
+			case 5:
+				event := compatibleUpdateEvent()
+				event["ownerIds"] = []string{"different-host"}
+				return jsonResponse(http.StatusOK, eventResponse(t, event)), nil
+			case 6:
+				return jsonResponse(http.StatusOK, contactPageResponse([]map[string]any{{
+					"id":               "private-contact-id",
+					"name":             "Example Contact",
+					"sharedEventCount": 3,
+				}}, &cursor)), nil
+			case 7:
+				return jsonResponse(http.StatusOK, contactPageResponse([]map[string]any{}, nil)), nil
+			case 8:
+				return jsonResponse(http.StatusOK, `{}`), nil
+			default:
+				t.Fatalf("unexpected request %d", call)
+				return nil, nil
+			}
+		}}
+		argv := []string{"cohosts", "invite", "event-example", "--contact", "Example Contact"}
+		plan := app.Execute(context.Background(), app.Request{Argv: argv}, dependencies)
+		token := rsvpPlanToken(t, plan)
+		applied := app.Execute(context.Background(), app.Request{Argv: append(append([]string{}, argv...), "--apply", "--confirm", token)}, dependencies)
+		if applied.ExitCode != 7 || !strings.Contains(applied.Stdout, `"type":"safety.plan_stale"`) {
+			t.Fatalf("applied = %#v, want stale plan on role change", applied)
+		}
+	})
+
+	t.Run("changed contact", func(t *testing.T) {
+		files := &memoryFilesystem{files: map[string][]byte{
+			eventWriteCredentialsPath: []byte(eventWriteCredentials),
+		}}
+		dependencies := eventWriteDependencies(files)
+		dependencies.MutationRandom = strings.NewReader(strings.Repeat("c", 32))
+		cursor := "cursor-1"
+		call := 0
+		dependencies.HTTP = scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+			call++
+			switch call {
+			case 1, 5:
+				event := compatibleUpdateEvent()
+				event["ownerIds"] = []string{"private-account"}
+				return jsonResponse(http.StatusOK, eventResponse(t, event)), nil
+			case 2:
+				return jsonResponse(http.StatusOK, contactPageResponse([]map[string]any{{
+					"id":               "private-contact-id",
+					"name":             "Example Contact",
+					"sharedEventCount": 3,
+				}}, &cursor)), nil
+			case 3:
+				return jsonResponse(http.StatusOK, contactPageResponse([]map[string]any{}, nil)), nil
+			case 4, 8:
+				return jsonResponse(http.StatusOK, `{}`), nil
+			case 6:
+				return jsonResponse(http.StatusOK, contactPageResponse([]map[string]any{{
+					"id":               "other-contact-id",
+					"name":             "Example Contact",
+					"sharedEventCount": 3,
+				}}, &cursor)), nil
+			case 7:
+				return jsonResponse(http.StatusOK, contactPageResponse([]map[string]any{}, nil)), nil
+			default:
+				t.Fatalf("unexpected request %d", call)
+				return nil, nil
+			}
+		}}
+		argv := []string{"cohosts", "invite", "event-example", "--contact", "Example Contact"}
+		plan := app.Execute(context.Background(), app.Request{Argv: argv}, dependencies)
+		token := rsvpPlanToken(t, plan)
+		applied := app.Execute(context.Background(), app.Request{Argv: append(append([]string{}, argv...), "--apply", "--confirm", token)}, dependencies)
+		if applied.ExitCode != 7 || !strings.Contains(applied.Stdout, `"type":"safety.plan_stale"`) {
+			t.Fatalf("applied = %#v, want stale plan on contact change", applied)
+		}
+	})
+
+	t.Run("changed link state", func(t *testing.T) {
+		files := &memoryFilesystem{files: map[string][]byte{
+			eventWriteCredentialsPath: []byte(eventWriteCredentials),
+		}}
+		dependencies := eventWriteDependencies(files)
+		dependencies.MutationRandom = strings.NewReader(strings.Repeat("k", 32))
+		call := 0
+		dependencies.HTTP = scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+			call++
+			switch call {
+			case 1, 3:
+				event := compatibleUpdateEvent()
+				event["ownerIds"] = []string{"private-account"}
+				return jsonResponse(http.StatusOK, eventResponse(t, event)), nil
+			case 2:
+				return jsonResponse(http.StatusNotFound, firestoreNotFound()), nil
+			case 4:
+				return jsonResponse(http.StatusOK, cohostLinkDocument(`/e/event-example?accept-cohost=unexpected`)), nil
+			default:
+				t.Fatalf("unexpected request %d", call)
+				return nil, nil
+			}
+		}}
+		argv := []string{"cohosts", "link", "create", "event-example"}
+		plan := app.Execute(context.Background(), app.Request{Argv: argv}, dependencies)
+		token := rsvpPlanToken(t, plan)
+		applied := app.Execute(context.Background(), app.Request{Argv: append(append([]string{}, argv...), "--apply", "--confirm", token)}, dependencies)
+		if applied.ExitCode != 7 || !strings.Contains(applied.Stdout, `"type":"safety.plan_stale"`) {
+			t.Fatalf("applied = %#v, want stale plan on link change", applied)
+		}
+	})
+
+	t.Run("changed account", func(t *testing.T) {
+		files := &memoryFilesystem{files: map[string][]byte{
+			eventWriteCredentialsPath: []byte(eventWriteCredentials),
+		}}
+		dependencies := eventWriteDependencies(files)
+		dependencies.MutationRandom = strings.NewReader(strings.Repeat("a", 32))
+		cursor := "cursor-1"
+		call := 0
+		dependencies.HTTP = scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+			call++
+			switch call {
+			case 1:
+				event := compatibleUpdateEvent()
+				event["ownerIds"] = []string{"private-account"}
+				return jsonResponse(http.StatusOK, eventResponse(t, event)), nil
+			case 2:
+				return jsonResponse(http.StatusOK, contactPageResponse([]map[string]any{{
+					"id":               "private-contact-id",
+					"name":             "Example Contact",
+					"sharedEventCount": 3,
+				}}, &cursor)), nil
+			case 3:
+				return jsonResponse(http.StatusOK, contactPageResponse([]map[string]any{}, nil)), nil
+			case 4:
+				return jsonResponse(http.StatusOK, `{}`), nil
+			default:
+				t.Fatalf("unexpected request %d", call)
+				return nil, nil
+			}
+		}}
+		argv := []string{"cohosts", "invite", "event-example", "--contact", "Example Contact"}
+		plan := app.Execute(context.Background(), app.Request{Argv: argv}, dependencies)
+		files.files[eventWriteCredentialsPath] = []byte(`{"accessToken":"private-access-token","userId":"other-account","expiresAt":"2026-08-12T02:00:00Z"}`)
+		token := rsvpPlanToken(t, plan)
+		applied := app.Execute(context.Background(), app.Request{Argv: append(append([]string{}, argv...), "--apply", "--confirm", token)}, dependencies)
+		if applied.ExitCode != 7 || !strings.Contains(applied.Stdout, `"type":"safety.plan_stale"`) {
+			t.Fatalf("applied = %#v, want stale plan on account change", applied)
+		}
+		if call != 4 {
+			t.Fatalf("HTTP calls = %d, want no apply reads after account mismatch", call)
+		}
+	})
+
+	t.Run("expired plan", func(t *testing.T) {
+		files := &memoryFilesystem{files: map[string][]byte{
+			eventWriteCredentialsPath: []byte(eventWriteCredentials),
+		}}
+		dependencies := eventWriteDependencies(files)
+		dependencies.MutationRandom = strings.NewReader(strings.Repeat("e", 32))
+		cursor := "cursor-1"
+		call := 0
+		dependencies.HTTP = scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+			call++
+			switch call {
+			case 1:
+				event := compatibleUpdateEvent()
+				event["ownerIds"] = []string{"private-account"}
+				return jsonResponse(http.StatusOK, eventResponse(t, event)), nil
+			case 2:
+				return jsonResponse(http.StatusOK, contactPageResponse([]map[string]any{{
+					"id":               "private-contact-id",
+					"name":             "Example Contact",
+					"sharedEventCount": 3,
+				}}, &cursor)), nil
+			case 3:
+				return jsonResponse(http.StatusOK, contactPageResponse([]map[string]any{}, nil)), nil
+			case 4:
+				return jsonResponse(http.StatusOK, `{}`), nil
+			default:
+				t.Fatalf("unexpected request %d", call)
+				return nil, nil
+			}
+		}}
+		argv := []string{"cohosts", "invite", "event-example", "--contact", "Example Contact"}
+		plan := app.Execute(context.Background(), app.Request{Argv: argv}, dependencies)
+		dependencies.Now = func() time.Time {
+			return time.Date(2026, time.August, 12, 0, 6, 0, 0, time.UTC)
+		}
+		token := rsvpPlanToken(t, plan)
+		applied := app.Execute(context.Background(), app.Request{Argv: append(append([]string{}, argv...), "--apply", "--confirm", token)}, dependencies)
+		if applied.ExitCode != 7 || !strings.Contains(applied.Stdout, `"type":"safety.plan_stale"`) {
+			t.Fatalf("applied = %#v, want stale expired plan", applied)
+		}
+	})
+}

--- a/internal/app/cohosts_execute_test.go
+++ b/internal/app/cohosts_execute_test.go
@@ -3,6 +3,7 @@ package app_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strings"
 	"testing"
@@ -142,21 +143,21 @@ func TestExecuteCohostRevokeInviteAndRemoveApplyExactReviewedOperations(t *testi
 		mutationResult string
 	}{
 		{
-			name:          "revoke invite",
-			argv:          []string{"cohosts", "revoke-invite", "event-example", "--contact", "Example Contact"},
-			status:        "DECLINED",
-			operation:     "deleteCohostRequest",
-			successStatus: "revoked",
-			mutationBody:  `{"data":{"params":{"eventId":"event-example","targetUserId":"private-contact-id"},"amplitudeDeviceId":"MDEyMzQ1Njc4OWFiY2RlZg","userId":"private-account"}}`,
+			name:           "revoke invite",
+			argv:           []string{"cohosts", "revoke-invite", "event-example", "--contact", "Example Contact"},
+			status:         "DECLINED",
+			operation:      "deleteCohostRequest",
+			successStatus:  "revoked",
+			mutationBody:   `{"data":{"params":{"eventId":"event-example","targetUserId":"private-contact-id"},"amplitudeDeviceId":"MDEyMzQ1Njc4OWFiY2RlZg","userId":"private-account"}}`,
 			mutationResult: `{"result":null}`,
 		},
 		{
-			name:          "remove cohost",
-			argv:          []string{"cohosts", "remove", "event-example", "--contact", "Example Contact"},
-			status:        "ACCEPTED",
-			operation:     "removeCohost",
-			successStatus: "removed",
-			mutationBody:  `{"data":{"params":{"eventId":"event-example","targetUserId":"private-contact-id"},"amplitudeDeviceId":"MDEyMzQ1Njc4OWFiY2RlZg","userId":"private-account"}}`,
+			name:           "remove cohost",
+			argv:           []string{"cohosts", "remove", "event-example", "--contact", "Example Contact"},
+			status:         "ACCEPTED",
+			operation:      "removeCohost",
+			successStatus:  "removed",
+			mutationBody:   `{"data":{"params":{"eventId":"event-example","targetUserId":"private-contact-id"},"amplitudeDeviceId":"MDEyMzQ1Njc4OWFiY2RlZg","userId":"private-account"}}`,
 			mutationResult: `{"data":true}`,
 		},
 	}
@@ -333,6 +334,79 @@ func TestExecuteCohostLinkCreateFailsClosedWithoutLeakingExistingURL(t *testing.
 	}
 	if strings.Contains(result.Stdout+result.Stderr, "private-secret-token") {
 		t.Fatal("existing cohost link leaked in failure output")
+	}
+}
+
+func TestExecuteCohostInviteAcceptsNullCompletion(t *testing.T) {
+	files := &memoryFilesystem{files: map[string][]byte{
+		eventWriteCredentialsPath: []byte(eventWriteCredentials),
+	}}
+	dependencies := eventWriteDependencies(files)
+	dependencies.MutationRandom = strings.NewReader(strings.Repeat("i", 32))
+	cursor := "cursor-1"
+	call := 0
+	dependencies.HTTP = scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+		call++
+		switch call {
+		case 1, 5:
+			event := compatibleUpdateEvent()
+			event["ownerIds"] = []string{"private-account"}
+			return jsonResponse(http.StatusOK, eventResponse(t, event)), nil
+		case 2, 6:
+			return jsonResponse(http.StatusOK, contactPageResponse([]map[string]any{{
+				"id": "private-contact-id", "name": "Alex Example", "sharedEventCount": 2,
+			}}, &cursor)), nil
+		case 3, 7:
+			return jsonResponse(http.StatusOK, contactPageResponse([]map[string]any{}, nil)), nil
+		case 4, 8:
+			return jsonResponse(http.StatusOK, `{}`), nil
+		case 9:
+			return jsonResponse(http.StatusOK, `{"result":null}`), nil
+		default:
+			return nil, errors.New("unexpected request")
+		}
+	}}
+	argv := []string{"cohosts", "invite", "event-example", "--contact", "Alex Example"}
+
+	plan := app.Execute(context.Background(), app.Request{Argv: argv}, dependencies)
+	if plan.ExitCode != 0 {
+		t.Fatalf("plan = %#v", plan)
+	}
+	token := rsvpPlanToken(t, plan)
+	applied := app.Execute(context.Background(), app.Request{
+		Argv: append(append([]string{}, argv...), "--apply", "--confirm", token),
+	}, dependencies)
+	if applied.ExitCode != 0 || !strings.Contains(applied.Stdout, `"status":"invited"`) {
+		t.Fatalf("applied = %#v, want submitted invite", applied)
+	}
+}
+
+func TestExecuteCohostActionsFailClosedWhenOwnerIDsAreMissing(t *testing.T) {
+	tests := []struct {
+		name string
+		argv []string
+	}{
+		{name: "contact action", argv: []string{"cohosts", "invite", "event-example", "--contact", "Alex Example"}},
+		{name: "link action", argv: []string{"cohosts", "link", "create", "event-example"}},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			files := &memoryFilesystem{files: map[string][]byte{
+				eventWriteCredentialsPath: []byte(eventWriteCredentials),
+			}}
+			dependencies := eventWriteDependencies(files)
+			dependencies.HTTP = scriptedHTTP{do: func(*http.Request) (*http.Response, error) {
+				event := compatibleUpdateEvent()
+				delete(event, "ownerIds")
+				return jsonResponse(http.StatusOK, eventResponse(t, event)), nil
+			}}
+
+			result := app.Execute(context.Background(), app.Request{Argv: testCase.argv}, dependencies)
+			if result.ExitCode != 9 ||
+				!strings.Contains(result.Stdout, `"type":"contract.protocol_changed"`) {
+				t.Fatalf("result = %#v, want missing owner protocol failure", result)
+			}
+		})
 	}
 }
 

--- a/internal/app/execute_test.go
+++ b/internal/app/execute_test.go
@@ -112,7 +112,7 @@ func TestExecuteEventsListProjectsReviewedUpcomingEventWithoutPrompting(t *testi
 		}},
 	})
 
-	const want = `{"ok":true,"data":{"items":[{"eventId":"event-example","title":"Example event","start":"2026-09-12T19:00:00-07:00","end":null,"timezone":"America/Los_Angeles","state":"active","userRole":"host","myRsvp":"going"}]},"meta":{"command":"events.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
+	const want = `{"ok":true,"data":{"items":[{"eventId":"event-example","title":"Example event","start":"2026-09-12T19:00:00-07:00","end":null,"timezone":"America/Los_Angeles","state":"active","userRole":"host","myRsvp":"going"}]},"meta":{"command":"events.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
 	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want reviewed upcoming event projection", result)
 	}
@@ -184,7 +184,7 @@ func TestExecuteEventsListRefreshesAndUsesTokenIdentityWithoutPrompting(t *testi
 		}},
 	})
 
-	const want = `{"ok":true,"data":{"items":[{"eventId":"event-example","title":null,"start":null,"end":null,"timezone":null,"state":null,"userRole":"host","myRsvp":null}]},"meta":{"command":"events.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
+	const want = `{"ok":true,"data":{"items":[{"eventId":"event-example","title":null,"start":null,"end":null,"timezone":null,"state":null,"userRole":"host","myRsvp":null}]},"meta":{"command":"events.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
 	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want refreshed identity projection", result)
 	}
@@ -747,7 +747,7 @@ func TestExecuteEventsGetProjectsReviewedDetailAndNullUnavailableFields(t *testi
 		}},
 	})
 
-	const want = `{"ok":true,"data":{"eventId":"event-example","title":"Example event","start":"2026-09-12T19:00:00-07:00","end":"2026-09-12T22:00:00-07:00","timezone":"America/Los_Angeles","state":"cancelled","userRole":null,"myRsvp":null,"description":null,"location":null,"address":null,"visibility":null,"guestLimit":null,"poster":null,"links":null},"meta":{"command":"events.get","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"eventId":"event-example","title":"Example event","start":"2026-09-12T19:00:00-07:00","end":"2026-09-12T22:00:00-07:00","timezone":"America/Los_Angeles","state":"cancelled","userRole":null,"myRsvp":null,"description":null,"location":null,"address":null,"visibility":null,"guestLimit":null,"poster":null,"links":null},"meta":{"command":"events.get","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want reviewed nullable event detail", result)
 	}
@@ -1115,7 +1115,7 @@ func TestExecutePostersListReturnsFirstLocalPage(t *testing.T) {
 		}},
 	}))
 
-	const want = `{"ok":true,"data":{"items":[{"posterId":"first","name":"First","url":"https://example.invalid/first.png","contentType":"image/png","width":1200,"height":630,"tags":["party"],"categories":["fun"]},{"posterId":"duplicate","name":"Duplicate","url":"https://example.invalid/duplicate.gif","contentType":"image/gif","width":null,"height":null,"tags":["dance"],"categories":[]},{"posterId":"duplicate","name":"Duplicate Again","url":"https://example.invalid/duplicate-2.gif","contentType":"image/gif","width":640,"height":480,"tags":[],"categories":["night"]}]},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
+	const want = `{"ok":true,"data":{"items":[{"posterId":"first","name":"First","url":"https://example.invalid/first.png","contentType":"image/png","width":1200,"height":630,"tags":["party"],"categories":["fun"]},{"posterId":"duplicate","name":"Duplicate","url":"https://example.invalid/duplicate.gif","contentType":"image/gif","width":null,"height":null,"tags":["dance"],"categories":[]},{"posterId":"duplicate","name":"Duplicate Again","url":"https://example.invalid/duplicate-2.gif","contentType":"image/gif","width":640,"height":480,"tags":[],"categories":["night"]}]},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -1521,7 +1521,7 @@ func TestExecutePostersListRejectsCursorWhenPayloadChanges(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, dependencies)
 
-	const want = `{"ok":false,"error":{"type":"state.conflict","code":"CURSOR_SNAPSHOT_CHANGED","message":"The poster catalog changed after this cursor was issued.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"state.conflict","code":"CURSOR_SNAPSHOT_CHANGED","message":"The poster catalog changed after this cursor was issued.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
 	if result.ExitCode != 6 {
 		t.Fatalf("exit code = %d, want 6", result.ExitCode)
 	}
@@ -1666,7 +1666,7 @@ func TestExecutePostersListRejectsUnexpectedSuccessContentType(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
 	const wantStderr = "partiful: poster catalog protocol changed\n"
 	if result.ExitCode != 9 {
 		t.Fatalf("exit code = %d, want 9", result.ExitCode)
@@ -1692,7 +1692,7 @@ func TestExecutePostersListRejectsMalformedCursorBeforeRemoteFailure(t *testing.
 		}},
 	}))
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_INVALID","message":"The cursor is malformed.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_INVALID","message":"The cursor is malformed.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -1747,7 +1747,7 @@ func TestExecutePostersSearchRejectsCursorWithDifferentNormalizedFilter(t *testi
 		Stdin: strings.NewReader(""),
 	}, dependencies)
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_FILTER_MISMATCH","message":"The cursor does not match this command and filters.","retryable":false,"details":{}},"meta":{"command":"posters.search","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_FILTER_MISMATCH","message":"The cursor does not match this command and filters.","retryable":false,"details":{}},"meta":{"command":"posters.search","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -1770,7 +1770,7 @@ func TestExecutePostersListMapsNetworkFailureToRemoteUnavailable(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"remote.unavailable","code":"POSTER_CATALOG_UNAVAILABLE","message":"The poster catalog is unavailable.","retryable":true,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"remote.unavailable","code":"POSTER_CATALOG_UNAVAILABLE","message":"The poster catalog is unavailable.","retryable":true,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
 	const wantStderr = "partiful: poster catalog unavailable\n"
 	if result.ExitCode != 8 {
 		t.Fatalf("exit code = %d, want 8", result.ExitCode)
@@ -1800,7 +1800,7 @@ func TestExecutePostersListFailsClosedOnReceivedNon200(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
 	const wantStderr = "partiful: poster catalog protocol changed\n"
 	if result.ExitCode != 9 {
 		t.Fatalf("exit code = %d, want 9", result.ExitCode)
@@ -1878,7 +1878,7 @@ func TestExecutePostersListFailsClosedOnMalformed200Body(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
 	if result.ExitCode != 9 {
 		t.Fatalf("exit code = %d, want 9", result.ExitCode)
 	}
@@ -1943,7 +1943,7 @@ func TestExecutePostersListRequiresMaxItemsWithAll(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"MAX_ITEMS_REQUIRED","message":"--all requires --max-items.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"MAX_ITEMS_REQUIRED","message":"--all requires --max-items.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -1965,7 +1965,7 @@ func TestExecutePostersListRejectsLimitWithAll(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"LIMIT_WITH_ALL","message":"--limit cannot be combined with --all.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"LIMIT_WITH_ALL","message":"--limit cannot be combined with --all.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -1983,7 +1983,7 @@ func TestExecutePostersListRejectsLimitAboveMaximum(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"LIMIT_INVALID","message":"Limit must be an integer from 1 to 100.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"LIMIT_INVALID","message":"Limit must be an integer from 1 to 100.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -1998,7 +1998,7 @@ func TestExecutePostersListRejectsEmptyCursor(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_INVALID","message":"The cursor is malformed.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_INVALID","message":"The cursor is malformed.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -2016,7 +2016,7 @@ func TestExecutePostersSearchRequiresNonEmptyQuery(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"QUERY_REQUIRED","message":"Search query must not be empty.","retryable":false,"details":{}},"meta":{"command":"posters.search","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"QUERY_REQUIRED","message":"Search query must not be empty.","retryable":false,"details":{}},"meta":{"command":"posters.search","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -2031,7 +2031,7 @@ func TestExecuteVersion(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":true,"data":{"version":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"},"meta":{"command":"version","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"version":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"},"meta":{"command":"version","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -2049,7 +2049,7 @@ func TestExecuteEventsListRequiresWhen(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"WHEN_INVALID","message":"--when must be upcoming or past.","retryable":false,"details":{}},"meta":{"command":"events.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"WHEN_INVALID","message":"--when must be upcoming or past.","retryable":false,"details":{}},"meta":{"command":"events.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -2071,14 +2071,14 @@ func TestExecutePrettyPrintsOneCompleteEnvelope(t *testing.T) {
   "ok": true,
   "data": {
     "version": "1.0.0",
-    "productContractRevision": "2026-08-12.5",
-    "remoteContractRevision": "2026-08-12.5"
+    "productContractRevision": "2026-08-12.6",
+    "remoteContractRevision": "2026-08-12.6"
   },
   "meta": {
     "command": "version",
     "cliVersion": "1.0.0",
-    "productContractRevision": "2026-08-12.5",
-    "remoteContractRevision": "2026-08-12.5",
+    "productContractRevision": "2026-08-12.6",
+    "remoteContractRevision": "2026-08-12.6",
     "warnings": []
   }
 }
@@ -2100,7 +2100,7 @@ func TestExecuteAcceptsNonInteractiveGlobalFlag(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":true,"data":{"version":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"},"meta":{"command":"version","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"version":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"},"meta":{"command":"version","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -2132,8 +2132,8 @@ func TestExecuteRejectsRepeatedScalarFlag(t *testing.T) {
   "meta": {
     "command": "version",
     "cliVersion": "1.0.0",
-    "productContractRevision": "2026-08-12.5",
-    "remoteContractRevision": "2026-08-12.5"
+    "productContractRevision": "2026-08-12.6",
+    "remoteContractRevision": "2026-08-12.6"
   }
 }
 `
@@ -2154,7 +2154,7 @@ func TestExecuteSchemaListsOnlyCompletedCatalog(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":true,"data":{"commands":["auth.login","auth.logout","auth.status","contacts.list","doctor","events.cancel","events.create","events.get","events.list","events.update","guests.invite","guests.list","posters.list","posters.search","rsvp.get","rsvp.set","schema","version"]},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"commands":["auth.login","auth.logout","auth.status","cohosts.invite","cohosts.link.create","cohosts.link.revoke","cohosts.remove","cohosts.revoke-invite","contacts.list","doctor","events.cancel","events.create","events.get","events.list","events.update","guests.invite","guests.list","posters.list","posters.search","rsvp.get","rsvp.set","schema","version"]},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -2172,7 +2172,7 @@ func TestExecuteSchemaProjectsExecutableDefinition(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":true,"data":{"command":"auth.status","positionals":[],"flags":[],"inputSchema":{"type":"object","additionalProperties":false},"successSchema":{"type":"object","additionalProperties":false,"required":["authenticated","tokenState","expiresAt"],"properties":{"authenticated":{"type":"boolean"},"expiresAt":{"type":["string","null"],"format":"date-time"},"tokenState":{"type":"string","enum":["healthy","expiring","expired","missing"]}}},"failureTypes":["usage.invalid","input.invalid","auth.expired","remote.unavailable","contract.protocol_changed","internal.failure"],"safety":{"kind":"local-mutation","planRequired":false,"confirmationRequired":false}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"command":"auth.status","positionals":[],"flags":[],"inputSchema":{"type":"object","additionalProperties":false},"successSchema":{"type":"object","additionalProperties":false,"required":["authenticated","tokenState","expiresAt"],"properties":{"authenticated":{"type":"boolean"},"expiresAt":{"type":["string","null"],"format":"date-time"},"tokenState":{"type":"string","enum":["healthy","expiring","expired","missing"]}}},"failureTypes":["usage.invalid","input.invalid","auth.expired","remote.unavailable","contract.protocol_changed","internal.failure"],"safety":{"kind":"local-mutation","planRequired":false,"confirmationRequired":false}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -2230,7 +2230,7 @@ func TestExecuteRejectsUnknownSchemaPathWithoutEchoingInput(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_SCHEMA_NOT_FOUND","message":"No completed command has that schema path.","retryable":false,"details":{}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_SCHEMA_NOT_FOUND","message":"No completed command has that schema path.","retryable":false,"details":{}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -2261,7 +2261,7 @@ func TestExecuteAuthStatusWhenCredentialsAreMissing(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"missing","expiresAt":null},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"missing","expiresAt":null},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -2279,7 +2279,7 @@ func TestExecuteAuthLoginRequiresPrivateTerminal(t *testing.T) {
 		Stdin: strings.NewReader("private-stdin-value"),
 	}, app.Dependencies{})
 
-	const wantStdout = `{"ok":false,"error":{"type":"auth.human_required","code":"PRIVATE_TERMINAL_REQUIRED","message":"Authentication login requires a private terminal.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"auth.human_required","code":"PRIVATE_TERMINAL_REQUIRED","message":"Authentication login requires a private terminal.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
 	const wantStderr = "partiful: private terminal required\n"
 	if result.ExitCode != 3 {
 		t.Fatalf("exit code = %d, want 3", result.ExitCode)
@@ -2338,7 +2338,7 @@ func TestExecuteAuthLoginRejectsEmptyPrivateInputBeforeHTTP(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"input.invalid","code":"AUTH_INPUT_INVALID","message":"Authentication input is invalid.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"input.invalid","code":"AUTH_INPUT_INVALID","message":"Authentication input is invalid.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
 	if result.ExitCode != 2 || result.Stdout != wantStdout {
 		t.Fatalf("result = %#v, want invalid private input failure", result)
 	}
@@ -2480,7 +2480,7 @@ func TestExecuteAuthLoginPersistsReviewedSessionWithoutRevealingPrivateValues(t 
 		}},
 	})
 
-	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T01:10:00Z"},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T01:10:00Z"},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want redacted login success", result)
 	}
@@ -2553,7 +2553,7 @@ func TestExecuteAuthLoginMapsReviewedWrongCodeWithoutEchoingIt(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"input.invalid","code":"AUTH_CODE_REJECTED","message":"The verification code was rejected.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"input.invalid","code":"AUTH_CODE_REJECTED","message":"The verification code was rejected.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
 	const wantStderr = "partiful: authentication code rejected\n"
 	if result.ExitCode != 2 || result.Stdout != wantStdout || result.Stderr != wantStderr {
 		t.Fatalf("result = %#v, want reviewed wrong-code failure", result)
@@ -2694,7 +2694,7 @@ func TestExecuteAuthLoginMapsRejectedCustomTokenToExpired(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"INVALID_CUSTOM_TOKEN","message":"Authentication expired during login. Start login again.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"INVALID_CUSTOM_TOKEN","message":"Authentication expired during login. Start login again.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
 	const wantStderr = "partiful: authentication expired\n"
 	if result.ExitCode != 3 || result.Stdout != wantStdout || result.Stderr != wantStderr {
 		t.Fatalf("result = %#v, want reviewed custom-token failure", result)
@@ -2881,7 +2881,7 @@ func TestExecuteAuthLoginFailsClosedOnMalformedReviewedSuccess(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"AUTH_PROTOCOL_CHANGED","message":"Authentication no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"AUTH_PROTOCOL_CHANGED","message":"Authentication no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
 	const wantStderr = "partiful: authentication protocol changed\n"
 	if result.ExitCode != 9 || result.Stdout != wantStdout || result.Stderr != wantStderr {
 		t.Fatalf("result = %#v, want protocol drift failure", result)
@@ -2978,7 +2978,7 @@ func TestExecuteAuthLoginMapsNoResponseWithoutLeakingTransportError(t *testing.T
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"remote.unavailable","code":"AUTH_SERVICE_UNAVAILABLE","message":"The authentication service is unavailable.","retryable":true,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"remote.unavailable","code":"AUTH_SERVICE_UNAVAILABLE","message":"The authentication service is unavailable.","retryable":true,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
 	const wantStderr = "partiful: authentication service unavailable\n"
 	if result.ExitCode != 8 || result.Stdout != wantStdout || result.Stderr != wantStderr {
 		t.Fatalf("result = %#v, want auth unavailable failure", result)
@@ -3032,7 +3032,7 @@ func TestExecuteAuthLoginAtomicPersistenceFailurePreservesExistingCredentials(t 
 		Argv: []string{"auth", "login"},
 	}, dependencies)
 
-	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIAL_STORE_UNAVAILABLE","message":"Local credential storage is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIAL_STORE_UNAVAILABLE","message":"Local credential storage is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
 	if result.ExitCode != 10 || result.Stdout != wantStdout {
 		t.Fatalf("result = %#v, want atomic persistence failure", result)
 	}
@@ -3144,7 +3144,7 @@ func TestExecuteContactsListTraversesReviewedPagesAndReturnsOnlyPublicFields(t *
 		}},
 	})
 
-	const want = `{"ok":true,"data":{"items":[{"displayName":"Alice Example","sharedEventCount":2}]},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
+	const want = `{"ok":true,"data":{"items":[{"displayName":"Alice Example","sharedEventCount":2}]},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
 	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want reviewed public contact collection", result)
 	}
@@ -3199,7 +3199,7 @@ func TestExecuteContactsListFiltersLocallyAfterFirstIdentityOccurrenceWins(t *te
 		}},
 	})
 
-	const want = `{"ok":true,"data":{"items":[{"displayName":"Alice First","sharedEventCount":1},{"displayName":"Second ALICE","sharedEventCount":3}]},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
+	const want = `{"ok":true,"data":{"items":[{"displayName":"Alice First","sharedEventCount":1},{"displayName":"Second ALICE","sharedEventCount":3}]},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
 	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want locally filtered first-occurrence contacts", result)
 	}
@@ -3509,7 +3509,7 @@ func TestExecuteContactsListAcceptsOpenReviewedResponseFields(t *testing.T) {
 		}},
 	})
 
-	const want = `{"ok":true,"data":{"items":[{"displayName":"Open Contact","sharedEventCount":4}]},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
+	const want = `{"ok":true,"data":{"items":[{"displayName":"Open Contact","sharedEventCount":4}]},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
 	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want reviewed open response traversal", result)
 	}
@@ -3622,7 +3622,7 @@ func TestExecuteContactsListAcceptsUnknownUnauthenticatedErrorFields(t *testing.
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"REMOTE_SESSION_UNAUTHENTICATED","message":"Stored authentication is no longer accepted. Log in again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"REMOTE_SESSION_UNAUTHENTICATED","message":"Stored authentication is no longer accepted. Log in again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
 	if result.ExitCode != 3 || result.Stdout != wantStdout {
 		t.Fatalf("result = %#v, want reviewed unauthenticated mapping", result)
 	}
@@ -3655,7 +3655,7 @@ func TestExecuteContactsListMapsReviewedUnauthenticatedResponseToExpired(t *test
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"REMOTE_SESSION_UNAUTHENTICATED","message":"Stored authentication is no longer accepted. Log in again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"REMOTE_SESSION_UNAUTHENTICATED","message":"Stored authentication is no longer accepted. Log in again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
 	if result.ExitCode != 3 || result.Stdout != wantStdout {
 		t.Fatalf("result = %#v, want reviewed unauthenticated mapping", result)
 	}
@@ -3791,7 +3791,7 @@ func TestExecuteContactsListRejectsCursorWhenContactCatalogChanges(t *testing.T)
 		Stdin: strings.NewReader(""),
 	}, dependencies)
 
-	const want = `{"ok":false,"error":{"type":"state.conflict","code":"CURSOR_SNAPSHOT_CHANGED","message":"The contact catalog changed after this cursor was issued.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"state.conflict","code":"CURSOR_SNAPSHOT_CHANGED","message":"The contact catalog changed after this cursor was issued.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
 	if result.ExitCode != 6 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want contact snapshot conflict", result)
 	}
@@ -3937,7 +3937,7 @@ func TestExecuteContactsListMapsRejectedRefreshWithoutAttemptingRead(t *testing.
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"INVALID_REFRESH_TOKEN","message":"Stored authentication has expired. Log in again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"INVALID_REFRESH_TOKEN","message":"Stored authentication has expired. Log in again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
 	if result.ExitCode != 3 || result.Stdout != wantStdout {
 		t.Fatalf("result = %#v, want rejected refresh failure", result)
 	}
@@ -3998,7 +3998,7 @@ func TestExecuteContactsListReportsUnavailableConfigurationBeforeProtectedRead(t
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CONFIG_DIRECTORY_UNAVAILABLE","message":"Local configuration directory is unavailable.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CONFIG_DIRECTORY_UNAVAILABLE","message":"Local configuration directory is unavailable.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
 	if result.ExitCode != 10 || result.Stdout != wantStdout {
 		t.Fatalf("result = %#v, want unavailable configuration failure", result)
 	}
@@ -4027,7 +4027,7 @@ func TestExecuteContactsListRequiresAuthenticationWithoutRemoteCall(t *testing.T
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"auth.required","code":"AUTHENTICATION_REQUIRED","message":"Authentication is required. Log in and try again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"auth.required","code":"AUTHENTICATION_REQUIRED","message":"Authentication is required. Log in and try again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
 	if result.ExitCode != 3 || result.Stdout != wantStdout {
 		t.Fatalf("result = %#v, want authentication requirement", result)
 	}
@@ -4178,7 +4178,7 @@ func TestExecuteAuthStatusRedactsHealthyCredentials(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T02:00:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T02:00:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -4212,7 +4212,7 @@ func TestExecuteAuthStatusReportsExpiringToken(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"expiring","expiresAt":"2026-08-11T00:04:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"expiring","expiresAt":"2026-08-11T00:04:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -4287,7 +4287,7 @@ func TestExecuteAuthStatusDeterministicallyRefreshesExpiringSession(t *testing.T
 	first := app.Execute(context.Background(), app.Request{
 		Argv: []string{"auth", "status"},
 	}, dependencies)
-	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T01:10:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T01:10:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[]}}` + "\n"
 	if first.ExitCode != 0 || first.Stdout != want || first.Stderr != "" {
 		t.Fatalf("first status = %#v, want refreshed healthy session", first)
 	}
@@ -4461,7 +4461,7 @@ func TestExecuteAuthStatusMapsReviewedInvalidRefreshTokenToExpired(t *testing.T)
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"INVALID_REFRESH_TOKEN","message":"Stored authentication has expired. Log in again.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"INVALID_REFRESH_TOKEN","message":"Stored authentication has expired. Log in again.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
 	const wantStderr = "partiful: authentication expired\n"
 	if result.ExitCode != 3 || result.Stdout != wantStdout || result.Stderr != wantStderr {
 		t.Fatalf("result = %#v, want reviewed invalid-refresh failure", result)
@@ -4580,7 +4580,7 @@ func TestExecuteAuthStatusReportsExpiredToken(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"expired","expiresAt":"2026-08-10T23:59:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"expired","expiresAt":"2026-08-10T23:59:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -4609,7 +4609,7 @@ func TestExecuteAuthStatusFailureDoesNotRevealCredentialContents(t *testing.T) {
 		},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIALS_INVALID","message":"Local credentials are invalid.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIALS_INVALID","message":"Local credentials are invalid.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
 	const wantStderr = "partiful: local operation failed\n"
 	if result.ExitCode != 10 {
 		t.Fatalf("exit code = %d, want 10", result.ExitCode)
@@ -4645,7 +4645,7 @@ func TestExecuteAuthLogoutAtomicallyRemovesCredentials(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, dependencies)
 
-	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"missing","expiresAt":null},"meta":{"command":"auth.logout","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"missing","expiresAt":null},"meta":{"command":"auth.logout","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -4724,7 +4724,7 @@ func TestExecuteAuthLogoutFailureLeavesCredentialsAvailableAndRedactsError(t *te
 		Stdin: strings.NewReader(""),
 	}, dependencies)
 
-	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIAL_STORE_UNAVAILABLE","message":"Local credential storage is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.logout","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIAL_STORE_UNAVAILABLE","message":"Local credential storage is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.logout","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
 	if result.ExitCode != 10 {
 		t.Fatalf("exit code = %d, want 10", result.ExitCode)
 	}
@@ -4761,7 +4761,7 @@ func TestExecuteDoctorReportsHealthyCredentialsWithoutPrivateData(t *testing.T) 
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":true,"checks":[{"name":"credentials","status":"pass","message":"Authentication credentials are available.","remediation":null}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":true,"checks":[{"name":"credentials","status":"pass","message":"Authentication credentials are available.","remediation":null}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -4794,7 +4794,7 @@ func TestExecuteDoctorReportsMissingCredentialsAsARedactedCheck(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials are missing.","remediation":"Establish authentication before using commands that require it."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials are missing.","remediation":"Establish authentication before using commands that require it."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -4823,7 +4823,7 @@ func TestExecuteDoctorWarnsWhenCredentialsExpireSoon(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":true,"checks":[{"name":"credentials","status":"warn","message":"Authentication credentials expire soon.","remediation":"Refresh authentication before the credentials expire."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":true,"checks":[{"name":"credentials","status":"warn","message":"Authentication credentials expire soon.","remediation":"Refresh authentication before the credentials expire."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -4852,7 +4852,7 @@ func TestExecuteDoctorFailsExpiredCredentialsCheck(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials have expired.","remediation":"Re-establish authentication."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials have expired.","remediation":"Re-establish authentication."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -4881,7 +4881,7 @@ func TestExecuteDoctorRedactsInvalidCredentialFile(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials are invalid.","remediation":"Remove the invalid credentials and re-establish authentication."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials are invalid.","remediation":"Remove the invalid credentials and re-establish authentication."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -4913,7 +4913,7 @@ func TestExecuteDoctorRedactsCredentialStorageFailure(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Credential storage is unavailable.","remediation":"Check local credential file permissions."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Credential storage is unavailable.","remediation":"Check local credential file permissions."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -5021,7 +5021,7 @@ func TestExecuteUsesDefinitionForFlagFailureCommandMetadata(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"FLAG_REPEATED","message":"A scalar flag cannot be repeated.","retryable":false,"details":{"flag":"--non-interactive"}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"FLAG_REPEATED","message":"A scalar flag cannot be repeated.","retryable":false,"details":{"flag":"--non-interactive"}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -5065,7 +5065,7 @@ func TestExecuteUsesKnownCommandMetadataForInvalidArity(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_NOT_FOUND","message":"Unknown command.","retryable":false,"details":{}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_NOT_FOUND","message":"Unknown command.","retryable":false,"details":{}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -5090,7 +5090,7 @@ func TestExecuteAuthStatusReportsConfigurationDirectoryFailure(t *testing.T) {
 		},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CONFIG_DIRECTORY_UNAVAILABLE","message":"Local configuration directory is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CONFIG_DIRECTORY_UNAVAILABLE","message":"Local configuration directory is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
 	if result.ExitCode != 10 {
 		t.Fatalf("exit code = %d, want 10", result.ExitCode)
 	}
@@ -5115,7 +5115,7 @@ func TestExecuteDoctorDiagnosesConfigurationDirectoryFailure(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Configuration directory is unavailable.","remediation":"Set a usable user configuration directory."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Configuration directory is unavailable.","remediation":"Set a usable user configuration directory."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}

--- a/internal/app/guests_execute_test.go
+++ b/internal/app/guests_execute_test.go
@@ -173,7 +173,7 @@ func TestExecuteGuestsListReturnsPermissionDeniedForAttendee(t *testing.T) {
 		}},
 	})
 
-	const want = `{"ok":false,"error":{"type":"permission.denied","code":"HOST_PERMISSION_REQUIRED","message":"This command requires host access to the event.","retryable":false,"details":{"requiredRole":"host"}},"meta":{"command":"guests.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"permission.denied","code":"HOST_PERMISSION_REQUIRED","message":"This command requires host access to the event.","retryable":false,"details":{"requiredRole":"host"}},"meta":{"command":"guests.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
 	if result.ExitCode != 4 || result.Stdout != want || result.Stderr != "partiful: host access required\n" {
 		t.Fatalf("result = %#v, want host permission denial", result)
 	}
@@ -225,7 +225,7 @@ func TestExecuteGuestsListReturnsEmptyCollectionForHost(t *testing.T) {
 		}},
 	})
 
-	const want = `{"ok":true,"data":{"items":[]},"meta":{"command":"guests.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
+	const want = `{"ok":true,"data":{"items":[]},"meta":{"command":"guests.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
 	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want empty host guest list", result)
 	}
@@ -276,7 +276,7 @@ func TestExecuteGuestsInviteBindsResolvedContactAndAppliesWithoutReResolvingName
 	applied := app.Execute(context.Background(), app.Request{
 		Argv: append(append([]string{}, argv...), "--apply", "--confirm", token),
 	}, dependencies)
-	const want = `{"ok":true,"data":{"eventId":"event-example","submitted":true},"meta":{"command":"guests.invite","cliVersion":"1.0.0","productContractRevision":"2026-08-12.5","remoteContractRevision":"2026-08-12.5","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"eventId":"event-example","submitted":true},"meta":{"command":"guests.invite","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[]}}` + "\n"
 	if applied.ExitCode != 0 || applied.Stdout != want || applied.Stderr != "" {
 		t.Fatalf("applied = %#v, want submitted-only guest invite result", applied)
 	}

--- a/internal/remote/cohosts.go
+++ b/internal/remote/cohosts.go
@@ -41,9 +41,9 @@ type callableCohostRequest[T any] struct {
 }
 
 type callableCohostRequestData[T any] struct {
-	Params            T   `json:"params"`
+	Params            T      `json:"params"`
 	AmplitudeDeviceID string `json:"amplitudeDeviceId"`
-	UserID            any `json:"userId"`
+	UserID            any    `json:"userId"`
 }
 
 type firestoreDocument struct {
@@ -58,7 +58,7 @@ func (client Client) CreateCohostRequest(
 	userID string,
 	params CohostTargetParams,
 ) error {
-	completion, err := callCohostMutation(
+	_, err := callCohostMutation(
 		client,
 		ctx,
 		accessToken,
@@ -67,13 +67,7 @@ func (client Client) CreateCohostRequest(
 		"createCohostRequest",
 		params,
 	)
-	if err != nil {
-		return err
-	}
-	if bytes.Equal(bytes.TrimSpace(completion), []byte("null")) {
-		return fmt.Errorf("%w: cohost invite completion", ErrProtocolChanged)
-	}
-	return nil
+	return err
 }
 
 func (client Client) DeleteCohostRequest(

--- a/internal/remote/cohosts.go
+++ b/internal/remote/cohosts.go
@@ -1,0 +1,518 @@
+package remote
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"unicode/utf8"
+)
+
+const (
+	maximumCohostResponseBytes = 1 << 20
+	maximumCohostRequestCount  = 100
+)
+
+type CohostTargetParams struct {
+	EventID      string `json:"eventId"`
+	TargetUserID string `json:"targetUserId"`
+}
+
+type CohostLinkParams struct {
+	EventID string `json:"eventId"`
+}
+
+type CohostRequest struct {
+	TargetUserID string
+	Status       string
+}
+
+type CohostLink struct {
+	Present bool
+	Path    string
+}
+
+type callableCohostRequest[T any] struct {
+	Data callableCohostRequestData[T] `json:"data"`
+}
+
+type callableCohostRequestData[T any] struct {
+	Params            T   `json:"params"`
+	AmplitudeDeviceID string `json:"amplitudeDeviceId"`
+	UserID            any `json:"userId"`
+}
+
+type firestoreDocument struct {
+	Name   string
+	Fields map[string]json.RawMessage
+}
+
+func (client Client) CreateCohostRequest(
+	ctx context.Context,
+	accessToken string,
+	amplitudeDeviceID string,
+	userID string,
+	params CohostTargetParams,
+) error {
+	completion, err := callCohostMutation(
+		client,
+		ctx,
+		accessToken,
+		amplitudeDeviceID,
+		userID,
+		"createCohostRequest",
+		params,
+	)
+	if err != nil {
+		return err
+	}
+	if bytes.Equal(bytes.TrimSpace(completion), []byte("null")) {
+		return fmt.Errorf("%w: cohost invite completion", ErrProtocolChanged)
+	}
+	return nil
+}
+
+func (client Client) DeleteCohostRequest(
+	ctx context.Context,
+	accessToken string,
+	amplitudeDeviceID string,
+	userID string,
+	params CohostTargetParams,
+) error {
+	_, err := callCohostMutation(
+		client,
+		ctx,
+		accessToken,
+		amplitudeDeviceID,
+		userID,
+		"deleteCohostRequest",
+		params,
+	)
+	return err
+}
+
+func (client Client) RemoveCohost(
+	ctx context.Context,
+	accessToken string,
+	amplitudeDeviceID string,
+	userID string,
+	params CohostTargetParams,
+) error {
+	_, err := callCohostMutation(
+		client,
+		ctx,
+		accessToken,
+		amplitudeDeviceID,
+		userID,
+		"removeCohost",
+		params,
+	)
+	return err
+}
+
+func (client Client) GenerateEventCohostLink(
+	ctx context.Context,
+	accessToken string,
+	amplitudeDeviceID string,
+	userID string,
+	params CohostLinkParams,
+) (string, error) {
+	completion, err := callCohostMutation(
+		client,
+		ctx,
+		accessToken,
+		amplitudeDeviceID,
+		userID,
+		"generateEventCohostLink",
+		params,
+	)
+	if err != nil {
+		return "", err
+	}
+	root, err := decodeEventObject(completion)
+	if err != nil {
+		return "", fmt.Errorf("%w: cohost link completion", ErrProtocolChanged)
+	}
+	data, err := eventObjectField(root, "data")
+	if err != nil {
+		return "", fmt.Errorf("%w: cohost link completion", ErrProtocolChanged)
+	}
+	path, present, err := eventStringField(data, "path", false)
+	if err != nil || !present || strings.TrimSpace(*path) == "" {
+		return "", fmt.Errorf("%w: cohost link completion", ErrProtocolChanged)
+	}
+	return *path, nil
+}
+
+func (client Client) RevokeEventCohostLink(
+	ctx context.Context,
+	accessToken string,
+	amplitudeDeviceID string,
+	userID string,
+	params CohostLinkParams,
+) error {
+	_, err := callCohostMutation(
+		client,
+		ctx,
+		accessToken,
+		amplitudeDeviceID,
+		userID,
+		"revokeEventCohostLink",
+		params,
+	)
+	return err
+}
+
+func (client Client) GetCohostRequests(
+	ctx context.Context,
+	accessToken string,
+	eventID string,
+) ([]CohostRequest, error) {
+	root, err := client.getFirestoreCollection(
+		ctx,
+		accessToken,
+		"events/"+eventID+"/cohostRequests",
+		maximumCohostRequestCount,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if token, ok := root["nextPageToken"]; ok && !bytes.Equal(bytes.TrimSpace(token), []byte(`""`)) {
+		return nil, fmt.Errorf("%w: cohost requests pagination", ErrProtocolChanged)
+	}
+	rawDocuments, ok := root["documents"]
+	if !ok {
+		return []CohostRequest{}, nil
+	}
+	if !isEventJSONKind(rawDocuments, '[') {
+		return nil, fmt.Errorf("%w: cohost requests documents", ErrProtocolChanged)
+	}
+	var documents []json.RawMessage
+	if err := json.Unmarshal(rawDocuments, &documents); err != nil {
+		return nil, fmt.Errorf("%w: cohost requests documents", ErrProtocolChanged)
+	}
+	if len(documents) > maximumCohostRequestCount {
+		return nil, fmt.Errorf("%w: cohost requests bound", ErrProtocolChanged)
+	}
+	requests := make([]CohostRequest, 0, len(documents))
+	for _, rawDocument := range documents {
+		document, err := decodeFirestoreDocument(rawDocument)
+		if err != nil {
+			return nil, err
+		}
+		targetUserID, err := firestoreReferenceUserID(document.Fields, "target")
+		if err != nil {
+			return nil, fmt.Errorf("%w: cohost request target", ErrProtocolChanged)
+		}
+		status, present, err := firestoreStringField(document.Fields, "status")
+		if err != nil || !present || !validCohostRequestStatus(*status) {
+			return nil, fmt.Errorf("%w: cohost request status", ErrProtocolChanged)
+		}
+		requests = append(requests, CohostRequest{
+			TargetUserID: targetUserID,
+			Status:       *status,
+		})
+	}
+	return requests, nil
+}
+
+func (client Client) GetCohostLink(
+	ctx context.Context,
+	accessToken string,
+	eventID string,
+) (CohostLink, error) {
+	document, found, err := client.getFirestoreDocument(
+		ctx,
+		accessToken,
+		"events/"+eventID+"/private/cohostSecret",
+	)
+	if err != nil {
+		return CohostLink{}, err
+	}
+	if !found {
+		return CohostLink{}, nil
+	}
+	path, present, err := firestoreStringField(document.Fields, "path")
+	if err != nil || !present || strings.TrimSpace(*path) == "" {
+		return CohostLink{}, fmt.Errorf("%w: cohost link path", ErrProtocolChanged)
+	}
+	return CohostLink{Present: true, Path: *path}, nil
+}
+
+func callCohostMutation[T any](
+	client Client,
+	ctx context.Context,
+	accessToken string,
+	amplitudeDeviceID string,
+	userID string,
+	operation string,
+	params T,
+) (json.RawMessage, error) {
+	if client.HTTP == nil {
+		return nil, fmt.Errorf("%w: cohost transport", ErrUnavailable)
+	}
+	var encodedUserID any
+	if userID != "" {
+		encodedUserID = userID
+	}
+	payload, _ := json.Marshal(callableCohostRequest[T]{
+		Data: callableCohostRequestData[T]{
+			Params:            params,
+			AmplitudeDeviceID: amplitudeDeviceID,
+			UserID:            encodedUserID,
+		},
+	})
+	request, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		partifulCallableHost+"/"+operation,
+		bytes.NewReader(payload),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("%w: cohost request", ErrUnavailable)
+	}
+	request.Header.Set("Authorization", "Bearer "+accessToken)
+	request.Header.Set("Content-Type", "application/json")
+	response, err := client.HTTP.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("%w: cohost request failed", ErrUnavailable)
+	}
+	if response == nil || response.Body == nil {
+		return nil, fmt.Errorf("%w: cohost response", ErrProtocolChanged)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%w: cohost status", ErrProtocolChanged)
+	}
+	if !eventJSONContentType(response.Header.Get("Content-Type")) {
+		return nil, fmt.Errorf("%w: cohost content type", ErrProtocolChanged)
+	}
+	body, err := io.ReadAll(io.LimitReader(response.Body, maximumCohostResponseBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("%w: cohost response read", ErrUnavailable)
+	}
+	if len(body) > maximumCohostResponseBytes || !utf8.Valid(body) {
+		return nil, fmt.Errorf("%w: cohost response body", ErrProtocolChanged)
+	}
+	root, err := decodeEventObject(body)
+	if err != nil {
+		return nil, fmt.Errorf("%w: cohost response body", ErrProtocolChanged)
+	}
+	if data, ok := root["data"]; ok {
+		return bytes.Clone(data), nil
+	}
+	if result, ok := root["result"]; ok {
+		return bytes.Clone(result), nil
+	}
+	return nil, fmt.Errorf("%w: cohost completion", ErrProtocolChanged)
+}
+
+func (client Client) getFirestoreCollection(
+	ctx context.Context,
+	accessToken string,
+	collectionPath string,
+	pageSize int,
+) (map[string]json.RawMessage, error) {
+	if client.HTTP == nil {
+		return nil, fmt.Errorf("%w: firestore transport", ErrUnavailable)
+	}
+	query := url.Values{}
+	if pageSize > 0 {
+		query.Set("pageSize", fmt.Sprintf("%d", pageSize))
+	}
+	request, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodGet,
+		firestoreDocumentsHost+"/v1/projects/getpartiful/databases/(default)/documents/"+escapeFirestorePath(collectionPath)+"?"+query.Encode(),
+		nil,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("%w: firestore request", ErrUnavailable)
+	}
+	request.Header.Set("Authorization", "Bearer "+accessToken)
+	response, err := client.HTTP.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("%w: firestore request failed", ErrUnavailable)
+	}
+	if response == nil || response.Body == nil {
+		return nil, fmt.Errorf("%w: firestore response", ErrProtocolChanged)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%w: firestore status", ErrProtocolChanged)
+	}
+	body, err := readFirestoreJSONBody(response)
+	if err != nil {
+		return nil, err
+	}
+	root, err := decodeEventObject(body)
+	if err != nil {
+		return nil, fmt.Errorf("%w: firestore list response", ErrProtocolChanged)
+	}
+	return root, nil
+}
+
+func (client Client) getFirestoreDocument(
+	ctx context.Context,
+	accessToken string,
+	documentPath string,
+) (firestoreDocument, bool, error) {
+	if client.HTTP == nil {
+		return firestoreDocument{}, false, fmt.Errorf("%w: firestore transport", ErrUnavailable)
+	}
+	request, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodGet,
+		firestoreDocumentsHost+"/v1/projects/getpartiful/databases/(default)/documents/"+escapeFirestorePath(documentPath),
+		nil,
+	)
+	if err != nil {
+		return firestoreDocument{}, false, fmt.Errorf("%w: firestore request", ErrUnavailable)
+	}
+	request.Header.Set("Authorization", "Bearer "+accessToken)
+	response, err := client.HTTP.Do(request)
+	if err != nil {
+		return firestoreDocument{}, false, fmt.Errorf("%w: firestore request failed", ErrUnavailable)
+	}
+	if response == nil || response.Body == nil {
+		return firestoreDocument{}, false, fmt.Errorf("%w: firestore response", ErrProtocolChanged)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode == http.StatusNotFound {
+		body, err := readFirestoreJSONBody(response)
+		if err != nil {
+			return firestoreDocument{}, false, err
+		}
+		if !validFirestoreNotFound(body) {
+			return firestoreDocument{}, false, fmt.Errorf("%w: firestore not found", ErrProtocolChanged)
+		}
+		return firestoreDocument{}, false, nil
+	}
+	if response.StatusCode != http.StatusOK {
+		return firestoreDocument{}, false, fmt.Errorf("%w: firestore status", ErrProtocolChanged)
+	}
+	body, err := readFirestoreJSONBody(response)
+	if err != nil {
+		return firestoreDocument{}, false, err
+	}
+	document, err := decodeFirestoreDocument(body)
+	if err != nil {
+		return firestoreDocument{}, false, err
+	}
+	return document, true, nil
+}
+
+func readFirestoreJSONBody(response *http.Response) ([]byte, error) {
+	if !eventJSONContentType(response.Header.Get("Content-Type")) {
+		return nil, fmt.Errorf("%w: firestore content type", ErrProtocolChanged)
+	}
+	body, err := io.ReadAll(io.LimitReader(response.Body, maximumEventWriteBodyBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("%w: firestore response read", ErrUnavailable)
+	}
+	if len(body) > maximumEventWriteBodyBytes || !utf8.Valid(body) {
+		return nil, fmt.Errorf("%w: firestore response body", ErrProtocolChanged)
+	}
+	return body, nil
+}
+
+func decodeFirestoreDocument(raw []byte) (firestoreDocument, error) {
+	root, err := decodeEventObject(raw)
+	if err != nil {
+		return firestoreDocument{}, fmt.Errorf("%w: firestore document", ErrProtocolChanged)
+	}
+	document := firestoreDocument{}
+	if name, present, err := eventStringField(root, "name", false); err != nil {
+		return firestoreDocument{}, fmt.Errorf("%w: firestore document name", ErrProtocolChanged)
+	} else if present {
+		document.Name = *name
+	}
+	if rawFields, ok := root["fields"]; ok {
+		fields, err := decodeEventObject(rawFields)
+		if err != nil {
+			return firestoreDocument{}, fmt.Errorf("%w: firestore document fields", ErrProtocolChanged)
+		}
+		for _, key := range []string{"createTime", "updateTime"} {
+			if value, ok := root[key]; ok {
+				var timestamp string
+				if json.Unmarshal(value, &timestamp) != nil {
+					return firestoreDocument{}, fmt.Errorf("%w: firestore document timestamp", ErrProtocolChanged)
+				}
+			}
+		}
+		for _, rawValue := range fields {
+			if err := validateFirestoreValue(rawValue); err != nil {
+				return firestoreDocument{}, fmt.Errorf("%w: firestore field", ErrProtocolChanged)
+			}
+		}
+		document.Fields = fields
+	} else {
+		document.Fields = map[string]json.RawMessage{}
+	}
+	return document, nil
+}
+
+func firestoreStringField(fields map[string]json.RawMessage, name string) (*string, bool, error) {
+	raw, ok := fields[name]
+	if !ok {
+		return nil, false, nil
+	}
+	object, err := decodeEventObject(raw)
+	if err != nil {
+		return nil, true, err
+	}
+	return eventStringField(object, "stringValue", false)
+}
+
+func firestoreReferenceUserID(fields map[string]json.RawMessage, name string) (string, error) {
+	raw, ok := fields[name]
+	if !ok {
+		return "", fmt.Errorf("reference is absent")
+	}
+	object, err := decodeEventObject(raw)
+	if err != nil {
+		return "", err
+	}
+	value, present, err := eventStringField(object, "referenceValue", false)
+	if err != nil || !present {
+		return "", fmt.Errorf("reference is invalid")
+	}
+	const prefix = "projects/getpartiful/databases/(default)/documents/users/"
+	if !strings.HasPrefix(*value, prefix) {
+		return "", fmt.Errorf("reference is invalid")
+	}
+	userID := strings.TrimPrefix(*value, prefix)
+	if strings.TrimSpace(userID) == "" || strings.Contains(userID, "/") {
+		return "", fmt.Errorf("reference is invalid")
+	}
+	return userID, nil
+}
+
+func validFirestoreNotFound(body []byte) bool {
+	root, err := decodeEventObject(body)
+	if err != nil {
+		return false
+	}
+	failure, err := eventObjectField(root, "error")
+	if err != nil {
+		return false
+	}
+	status, present, err := eventStringField(failure, "status", false)
+	return err == nil && present && *status == "NOT_FOUND"
+}
+
+func validCohostRequestStatus(value string) bool {
+	return value == "PENDING" || value == "ACCEPTED" || value == "DECLINED"
+}
+
+func escapeFirestorePath(path string) string {
+	parts := strings.Split(path, "/")
+	for index, part := range parts {
+		parts[index] = url.PathEscape(part)
+	}
+	return strings.Join(parts, "/")
+}

--- a/spec/partiful.api-evidence.json
+++ b/spec/partiful.api-evidence.json
@@ -1,5 +1,5 @@
 {
-  "contractRevision": "2026-08-12.5",
+  "contractRevision": "2026-08-12.6",
   "ownerReviewedBaseline": "2026-08-12.3",
   "contractPath": "spec/partiful.openapi.json",
   "allowedClassifications": [
@@ -62,7 +62,12 @@
     "publicEventPosterMapping20260812": "docs/research/2026-08-12-event-write-mapping-public-assets.md#built-in-poster-representation",
     "publicEventWritePreconditions20260812": "docs/research/2026-08-12-event-write-mapping-public-assets.md#update-preconditions",
     "officialFirestoreProtocol": "docs/research/2026-08-10-contract-evidence-sources.md#official-firestore-rest-protocol",
-    "publicGuestMapping20260812": "docs/research/2026-08-12-guest-mapping-public-assets.md#scope-and-provenance"
+    "publicGuestMapping20260812": "docs/research/2026-08-12-guest-mapping-public-assets.md#scope-and-provenance",
+    "publicCohostLifecycle20260812": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#scope-and-provenance",
+    "publicCohostCallableTransport20260812": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#callable-transport",
+    "publicCohostRequestDocs20260812": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#cohost-request-document-shape",
+    "publicCohostLinkState20260812": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#link-document-shape-and-token-path",
+    "publicCohostOperations20260812": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
   },
   "operations": {
     "createEvent": {
@@ -90,24 +95,24 @@
       "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#scope-and-provenance"
     },
     "createCohostRequest": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
     },
     "deleteCohostRequest": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
     },
     "removeCohost": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
     },
     "generateEventCohostLink": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
     },
     "revokeEventCohostLink": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post"
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
     },
     "getMyUpcomingEventsForHomePage": {
       "classification": "dated-live-observation",
@@ -228,44 +233,44 @@
       "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firebase-callable-protocol"
     },
     "createCohostRequest": {
-      "request": "typescript-derived-inference",
-      "requestCitation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post",
-      "response": "explicit-unknown",
-      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
-      "status": "explicit-unknown",
-      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+      "request": "current-first-party-public-asset-research",
+      "requestCitation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions",
+      "response": "current-first-party-public-asset-research",
+      "responseCitation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions",
+      "status": "official-protocol-specification",
+      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firebase-callable-protocol"
     },
     "deleteCohostRequest": {
-      "request": "typescript-derived-inference",
-      "requestCitation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post",
-      "response": "explicit-unknown",
-      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
-      "status": "explicit-unknown",
-      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+      "request": "current-first-party-public-asset-research",
+      "requestCitation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions",
+      "response": "current-first-party-public-asset-research",
+      "responseCitation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions",
+      "status": "official-protocol-specification",
+      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firebase-callable-protocol"
     },
     "removeCohost": {
-      "request": "typescript-derived-inference",
-      "requestCitation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post",
-      "response": "explicit-unknown",
-      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
-      "status": "explicit-unknown",
-      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+      "request": "current-first-party-public-asset-research",
+      "requestCitation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions",
+      "response": "current-first-party-public-asset-research",
+      "responseCitation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions",
+      "status": "official-protocol-specification",
+      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firebase-callable-protocol"
     },
     "generateEventCohostLink": {
-      "request": "typescript-derived-inference",
-      "requestCitation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post",
-      "response": "explicit-unknown",
-      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
-      "status": "explicit-unknown",
-      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+      "request": "current-first-party-public-asset-research",
+      "requestCitation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions",
+      "response": "current-first-party-public-asset-research",
+      "responseCitation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions",
+      "status": "official-protocol-specification",
+      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firebase-callable-protocol"
     },
     "revokeEventCohostLink": {
-      "request": "typescript-derived-inference",
-      "requestCitation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post",
-      "response": "explicit-unknown",
-      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
-      "status": "explicit-unknown",
-      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+      "request": "current-first-party-public-asset-research",
+      "requestCitation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions",
+      "response": "current-first-party-public-asset-research",
+      "responseCitation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions",
+      "status": "official-protocol-specification",
+      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firebase-callable-protocol"
     },
     "getMyUpcomingEventsForHomePage": {
       "request": "typescript-derived-inference",
@@ -1388,582 +1393,6 @@
     "#/paths/~1addInvitedGuestsAsHost/post/security/0/firebaseBearer": {
       "classification": "typescript-derived-inference",
       "citation": "spec/research/historical-27-operation-draft.json#/paths/~1addInvitedGuestsAsHost/post/security/0/firebaseBearer"
-    },
-    "#/paths/~1createCohostRequest/post/operationId": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/operationId"
-    },
-    "#/paths/~1createCohostRequest/post/requestBody/required": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/required"
-    },
-    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json"
-    },
-    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/type"
-    },
-    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/required/0": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/required/0"
-    },
-    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data"
-    },
-    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/type"
-    },
-    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/required/0": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/required/0"
-    },
-    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/required/1": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/required/1"
-    },
-    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params"
-    },
-    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/type"
-    },
-    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId"
-    },
-    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId/type"
-    },
-    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/targetUserId": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/targetUserId"
-    },
-    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/targetUserId/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/targetUserId/type"
-    },
-    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties"
-    },
-    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0"
-    },
-    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/1": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/1"
-    },
-    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId"
-    },
-    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type"
-    },
-    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId"
-    },
-    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type"
-    },
-    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format"
-    },
-    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/userId": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/userId"
-    },
-    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0"
-    },
-    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1"
-    },
-    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/additionalProperties": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/additionalProperties"
-    },
-    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/additionalProperties": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/additionalProperties"
-    },
-    "#/paths/~1createCohostRequest/post/responses/default": {
-      "classification": "explicit-unknown",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
-    },
-    "#/paths/~1createCohostRequest/post/security/0/firebaseBearer": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1createCohostRequest/post/security/0/firebaseBearer"
-    },
-    "#/paths/~1deleteCohostRequest/post/operationId": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/operationId"
-    },
-    "#/paths/~1deleteCohostRequest/post/requestBody/required": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/required"
-    },
-    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json"
-    },
-    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/type"
-    },
-    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/required/0": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/required/0"
-    },
-    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data"
-    },
-    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/type"
-    },
-    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/required/0": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/required/0"
-    },
-    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/required/1": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/required/1"
-    },
-    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params"
-    },
-    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/type"
-    },
-    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId"
-    },
-    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId/type"
-    },
-    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/targetUserId": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/targetUserId"
-    },
-    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/targetUserId/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/targetUserId/type"
-    },
-    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties"
-    },
-    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0"
-    },
-    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/1": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/1"
-    },
-    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId"
-    },
-    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type"
-    },
-    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId"
-    },
-    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type"
-    },
-    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format"
-    },
-    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/userId": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/userId"
-    },
-    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0"
-    },
-    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1"
-    },
-    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/additionalProperties": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/additionalProperties"
-    },
-    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/additionalProperties": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/additionalProperties"
-    },
-    "#/paths/~1deleteCohostRequest/post/responses/default": {
-      "classification": "explicit-unknown",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
-    },
-    "#/paths/~1deleteCohostRequest/post/security/0/firebaseBearer": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1deleteCohostRequest/post/security/0/firebaseBearer"
-    },
-    "#/paths/~1removeCohost/post/operationId": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/operationId"
-    },
-    "#/paths/~1removeCohost/post/requestBody/required": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/required"
-    },
-    "#/paths/~1removeCohost/post/requestBody/content/application~1json": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json"
-    },
-    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/type"
-    },
-    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/required/0": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/required/0"
-    },
-    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data"
-    },
-    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/type"
-    },
-    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/required/0": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/required/0"
-    },
-    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/required/1": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/required/1"
-    },
-    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/params": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/params"
-    },
-    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/params/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/params/type"
-    },
-    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId"
-    },
-    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId/type"
-    },
-    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/targetUserId": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/targetUserId"
-    },
-    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/targetUserId/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/targetUserId/type"
-    },
-    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties"
-    },
-    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0"
-    },
-    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/1": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/1"
-    },
-    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId"
-    },
-    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type"
-    },
-    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId"
-    },
-    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type"
-    },
-    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format"
-    },
-    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/userId": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/userId"
-    },
-    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0"
-    },
-    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1"
-    },
-    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/additionalProperties": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/additionalProperties"
-    },
-    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/additionalProperties": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/additionalProperties"
-    },
-    "#/paths/~1removeCohost/post/responses/default": {
-      "classification": "explicit-unknown",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
-    },
-    "#/paths/~1removeCohost/post/security/0/firebaseBearer": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1removeCohost/post/security/0/firebaseBearer"
-    },
-    "#/paths/~1generateEventCohostLink/post/operationId": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/operationId"
-    },
-    "#/paths/~1generateEventCohostLink/post/requestBody/required": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/required"
-    },
-    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json"
-    },
-    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/type"
-    },
-    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/required/0": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/required/0"
-    },
-    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data"
-    },
-    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/type"
-    },
-    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/required/0": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/required/0"
-    },
-    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/required/1": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/required/1"
-    },
-    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params"
-    },
-    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/type"
-    },
-    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId"
-    },
-    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId/type"
-    },
-    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties"
-    },
-    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0"
-    },
-    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId"
-    },
-    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type"
-    },
-    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId"
-    },
-    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type"
-    },
-    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format"
-    },
-    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/userId": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/userId"
-    },
-    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0"
-    },
-    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1"
-    },
-    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/additionalProperties": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/additionalProperties"
-    },
-    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/additionalProperties": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/additionalProperties"
-    },
-    "#/paths/~1generateEventCohostLink/post/responses/default": {
-      "classification": "explicit-unknown",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
-    },
-    "#/paths/~1generateEventCohostLink/post/security/0/firebaseBearer": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1generateEventCohostLink/post/security/0/firebaseBearer"
-    },
-    "#/paths/~1revokeEventCohostLink/post/operationId": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/operationId"
-    },
-    "#/paths/~1revokeEventCohostLink/post/requestBody/required": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/required"
-    },
-    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json"
-    },
-    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/type"
-    },
-    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/required/0": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/required/0"
-    },
-    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data"
-    },
-    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/type"
-    },
-    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/required/0": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/required/0"
-    },
-    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/required/1": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/required/1"
-    },
-    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params"
-    },
-    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/type"
-    },
-    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId"
-    },
-    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId/type"
-    },
-    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties"
-    },
-    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0"
-    },
-    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId"
-    },
-    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type"
-    },
-    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId"
-    },
-    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type"
-    },
-    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format"
-    },
-    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/userId": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/userId"
-    },
-    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0"
-    },
-    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1"
-    },
-    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/additionalProperties": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/additionalProperties"
-    },
-    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/additionalProperties": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/additionalProperties"
-    },
-    "#/paths/~1revokeEventCohostLink/post/responses/default": {
-      "classification": "explicit-unknown",
-      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
-    },
-    "#/paths/~1revokeEventCohostLink/post/security/0/firebaseBearer": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1revokeEventCohostLink/post/security/0/firebaseBearer"
     },
     "#/paths/~1getMyUpcomingEventsForHomePage/post/operationId": {
       "classification": "typescript-derived-inference",
@@ -7400,6 +6829,750 @@
     "#/paths/~1getGuests/post/security/0/firebaseBearer": {
       "classification": "current-first-party-public-asset-research",
       "citation": "docs/research/2026-08-12-guest-mapping-public-assets.md#current-callable-wrapper"
+    },
+    "#/paths/~1createCohostRequest/post/operationId": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/required": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/required/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/required/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/required/1": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/targetUserId": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/targetUserId/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/1": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/userId": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/properties/data/additionalProperties": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1createCohostRequest/post/requestBody/content/application~1json/schema/additionalProperties": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1createCohostRequest/post/responses/200": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1createCohostRequest/post/responses/200/content/application~1json": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1createCohostRequest/post/responses/200/content/application~1json/schema/$ref": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1createCohostRequest/post/responses/default": {
+      "classification": "explicit-unknown",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+    },
+    "#/paths/~1createCohostRequest/post/security/0/firebaseBearer": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1deleteCohostRequest/post/operationId": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/required": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/required/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/required/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/required/1": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/targetUserId": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/targetUserId/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/1": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/userId": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/properties/data/additionalProperties": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1deleteCohostRequest/post/requestBody/content/application~1json/schema/additionalProperties": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1deleteCohostRequest/post/responses/200": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1deleteCohostRequest/post/responses/200/content/application~1json": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1deleteCohostRequest/post/responses/200/content/application~1json/schema/$ref": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1deleteCohostRequest/post/responses/default": {
+      "classification": "explicit-unknown",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+    },
+    "#/paths/~1deleteCohostRequest/post/security/0/firebaseBearer": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1removeCohost/post/operationId": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1removeCohost/post/requestBody/required": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/required/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/required/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/required/1": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/params": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/params/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/targetUserId": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/targetUserId/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/1": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/userId": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/properties/data/additionalProperties": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1removeCohost/post/requestBody/content/application~1json/schema/additionalProperties": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1removeCohost/post/responses/200": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1removeCohost/post/responses/200/content/application~1json": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1removeCohost/post/responses/200/content/application~1json/schema/$ref": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1removeCohost/post/responses/default": {
+      "classification": "explicit-unknown",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+    },
+    "#/paths/~1removeCohost/post/security/0/firebaseBearer": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1generateEventCohostLink/post/operationId": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/required": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/required/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/required/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/required/1": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/userId": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/additionalProperties": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1generateEventCohostLink/post/requestBody/content/application~1json/schema/additionalProperties": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1generateEventCohostLink/post/responses/200": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1generateEventCohostLink/post/responses/200/content/application~1json": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1generateEventCohostLink/post/responses/200/content/application~1json/schema/$ref": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1generateEventCohostLink/post/responses/default": {
+      "classification": "explicit-unknown",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+    },
+    "#/paths/~1generateEventCohostLink/post/security/0/firebaseBearer": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1revokeEventCohostLink/post/operationId": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/required": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/required/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/required/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/required/1": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/properties/eventId/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/additionalProperties": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/params/required/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeDeviceId/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/amplitudeSessionId/format": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/userId": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/properties/userId/type/1": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/properties/data/additionalProperties": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1revokeEventCohostLink/post/requestBody/content/application~1json/schema/additionalProperties": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1revokeEventCohostLink/post/responses/200": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1revokeEventCohostLink/post/responses/200/content/application~1json": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1revokeEventCohostLink/post/responses/200/content/application~1json/schema/$ref": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1revokeEventCohostLink/post/responses/default": {
+      "classification": "explicit-unknown",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+    },
+    "#/paths/~1revokeEventCohostLink/post/security/0/firebaseBearer": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/components/schemas/CallableCompletionResponse/anyOf/0/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/components/schemas/CallableCompletionResponse/anyOf/0/required/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/components/schemas/CallableCompletionResponse/anyOf/0/properties/result": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/components/schemas/CallableCompletionResponse/anyOf/0/additionalProperties": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/components/schemas/CallableCompletionResponse/anyOf/1/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/components/schemas/CallableCompletionResponse/anyOf/1/required/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/components/schemas/CallableCompletionResponse/anyOf/1/properties/data": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/components/schemas/CallableCompletionResponse/anyOf/1/additionalProperties": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/components/schemas/GenerateEventCohostLinkResult/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/components/schemas/GenerateEventCohostLinkResult/required/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/components/schemas/GenerateEventCohostLinkResult/properties/data": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/components/schemas/GenerateEventCohostLinkResult/properties/data/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/components/schemas/GenerateEventCohostLinkResult/properties/data/required/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/components/schemas/GenerateEventCohostLinkResult/properties/data/properties/path": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/components/schemas/GenerateEventCohostLinkResult/properties/data/properties/path/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/components/schemas/GenerateEventCohostLinkResult/properties/data/additionalProperties": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/components/schemas/GenerateEventCohostLinkResult/additionalProperties": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/components/schemas/GenerateEventCohostLinkCompletionResponse/anyOf/0/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/components/schemas/GenerateEventCohostLinkCompletionResponse/anyOf/0/required/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/components/schemas/GenerateEventCohostLinkCompletionResponse/anyOf/0/properties/result": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/components/schemas/GenerateEventCohostLinkCompletionResponse/anyOf/0/properties/result/$ref": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/components/schemas/GenerateEventCohostLinkCompletionResponse/anyOf/0/additionalProperties": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/components/schemas/GenerateEventCohostLinkCompletionResponse/anyOf/1/type": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/components/schemas/GenerateEventCohostLinkCompletionResponse/anyOf/1/required/0": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/components/schemas/GenerateEventCohostLinkCompletionResponse/anyOf/1/properties/data": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/components/schemas/GenerateEventCohostLinkCompletionResponse/anyOf/1/properties/data/$ref": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/components/schemas/GenerateEventCohostLinkCompletionResponse/anyOf/1/additionalProperties": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
     }
   },
   "posterCatalogObservation": {
@@ -8014,5 +8187,58 @@
       "addInvitedGuestsAsHost"
     ]
   },
-  "materialClaimCount": 1740
+  "materialClaimCount": 1782,
+  "publicCohostAssetResearch": {
+    "classification": "current-first-party-public-asset-research",
+    "sourceCitation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#scope-and-provenance",
+    "observedAt": "2026-08-12T17:53:08Z",
+    "buildId": "Sf-HOOx63XpPtr5pPkTvg",
+    "deployment": "dpl_D7TPPj16g1fU46JSHSyrsRURxrK9",
+    "assets": {
+      "buildManifest": {
+        "url": "https://partiful.com/_next/static/Sf-HOOx63XpPtr5pPkTvg/_buildManifest.js?dpl=dpl_D7TPPj16g1fU46JSHSyrsRURxrK9",
+        "bytes": 11476,
+        "sha256": "2de1d4a26e8d4e9e2370ef970cafab2cd1cd6f5c8402fd54a5ea6f150488cbf6"
+      },
+      "sharedApp": {
+        "url": "https://partiful.com/_next/static/chunks/pages/_app-b0dc833855a84321.js?dpl=dpl_D7TPPj16g1fU46JSHSyrsRURxrK9",
+        "bytes": 2369333,
+        "sha256": "812edcea27949b86471cfc5f970cb5b3b961e27a6eea80e7cf6d99aad6623f41"
+      },
+      "cohostShared": {
+        "url": "https://partiful.com/_next/static/chunks/6652-bc845eb80e835b16.js?dpl=dpl_D7TPPj16g1fU46JSHSyrsRURxrK9",
+        "bytes": 42498,
+        "sha256": "d6b57ad394646129f4702bb7d74aea214d7c43750c3a9898367fb9d4541a71b4"
+      },
+      "eventShared": {
+        "url": "https://partiful.com/_next/static/chunks/1585-abd7081ec2f9f79f.js?dpl=dpl_D7TPPj16g1fU46JSHSyrsRURxrK9",
+        "bytes": 464421,
+        "sha256": "437bf13262a46ca96ffb19f625c3ee2a5aaa1996ef9e97ae5b92731341d94487"
+      }
+    },
+    "modules": {
+      "callableTransport": 95722,
+      "firestorePaths": 99181,
+      "firestoreCollections": 47186,
+      "cohostProvider": 73188,
+      "cohostRequestSubscription": 35104,
+      "cohostSecretSubscription": 61713,
+      "firestoreDecoder": 17959,
+      "cohostStatus": 13680,
+      "hostGate": 70820,
+      "authUser": 26813,
+      "linkTokenQuery": 31076
+    },
+    "hostOnly": true,
+    "requestStatuses": [
+      "PENDING",
+      "ACCEPTED",
+      "DECLINED"
+    ],
+    "requestCollection": "events/{eventId}/cohostRequests",
+    "secretDocument": "events/{eventId}/private/cohostSecret",
+    "linkQueryKey": "accept-cohost",
+    "liveMutations": false,
+    "credentialsUsed": false
+  }
 }

--- a/spec/partiful.openapi.json
+++ b/spec/partiful.openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Partiful remote API contract",
-    "version": "2026-08-12.5",
+    "version": "2026-08-12.6",
     "description": "Owner-reviewed remote-only transport snapshot. Evidence classifications and uncertainty are recorded in spec/partiful.api-evidence.json."
   },
   "servers": [
@@ -757,8 +757,18 @@
           }
         },
         "responses": {
+          "200": {
+            "description": "Generic callable protocol completion. The current client reads response.data and does not inspect the returned value further.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallableCompletionResponse"
+                }
+              }
+            }
+          },
           "default": {
-            "description": "Response status and body are unknown."
+            "description": "Unobserved response status or body."
           }
         },
         "security": [
@@ -827,8 +837,18 @@
           }
         },
         "responses": {
+          "200": {
+            "description": "Generic callable protocol completion. The current client inspects no endpoint business field.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallableCompletionResponse"
+                }
+              }
+            }
+          },
           "default": {
-            "description": "Response status and body are unknown."
+            "description": "Unobserved response status or body."
           }
         },
         "security": [
@@ -897,8 +917,18 @@
           }
         },
         "responses": {
+          "200": {
+            "description": "Generic callable protocol completion. The current client inspects no endpoint business field.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallableCompletionResponse"
+                }
+              }
+            }
+          },
           "default": {
-            "description": "Response status and body are unknown."
+            "description": "Unobserved response status or body."
           }
         },
         "security": [
@@ -963,8 +993,18 @@
           }
         },
         "responses": {
+          "200": {
+            "description": "Generic callable protocol completion with current nested data.path string.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenerateEventCohostLinkCompletionResponse"
+                }
+              }
+            }
+          },
           "default": {
-            "description": "Response status and body are unknown."
+            "description": "Unobserved response status or body."
           }
         },
         "security": [
@@ -1029,8 +1069,18 @@
           }
         },
         "responses": {
+          "200": {
+            "description": "Generic callable protocol completion. The current client inspects no endpoint business field.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallableCompletionResponse"
+                }
+              }
+            }
+          },
           "default": {
-            "description": "Response status and body are unknown."
+            "description": "Unobserved response status or body."
           }
         },
         "security": [
@@ -3800,6 +3850,79 @@
             }
           }
         }
+      },
+      "CallableCompletionResponse": {
+        "anyOf": [
+          {
+            "type": "object",
+            "required": [
+              "result"
+            ],
+            "properties": {
+              "result": {}
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "data"
+            ],
+            "properties": {
+              "data": {}
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "GenerateEventCohostLinkResult": {
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "type": "object",
+            "required": [
+              "path"
+            ],
+            "properties": {
+              "path": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": true
+      },
+      "GenerateEventCohostLinkCompletionResponse": {
+        "anyOf": [
+          {
+            "type": "object",
+            "required": [
+              "result"
+            ],
+            "properties": {
+              "result": {
+                "$ref": "#/components/schemas/GenerateEventCohostLinkResult"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "data"
+            ],
+            "properties": {
+              "data": {
+                "$ref": "#/components/schemas/GenerateEventCohostLinkResult"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
       }
     }
   }

--- a/tests/remote-api-contract.test.js
+++ b/tests/remote-api-contract.test.js
@@ -483,7 +483,7 @@ function citationResolves(citation) {
 describe('remote API contract', () => {
   it('is a consistently versioned OpenAPI 3.1 document with unique operation IDs', () => {
     expect(spec.openapi).toBe('3.1.0');
-    expect(evidence.contractRevision).toBe('2026-08-12.5');
+    expect(evidence.contractRevision).toBe('2026-08-12.6');
     expect(evidence.ownerReviewedBaseline).toBe('2026-08-12.3');
     expect(spec.info.version).toBe(evidence.contractRevision);
     expect(evidence.status).toBe('owner-reviewed');
@@ -504,8 +504,8 @@ describe('remote API contract', () => {
       .toBe(`${guestAssetResearchPath}#scope-and-provenance`);
     expect(citationResolves(evidence.sources.publicGuestMapping20260812)).toBe(true);
     const appSource = fs.readFileSync('internal/app/app.go', 'utf8');
-    expect(appSource).toContain('ProductContractRevision = "2026-08-12.5"');
-    expect(appSource).toContain('RemoteContractRevision  = "2026-08-12.5"');
+    expect(appSource).toContain('ProductContractRevision = "2026-08-12.6"');
+    expect(appSource).toContain('RemoteContractRevision  = "2026-08-12.6"');
     const ids = operations().map(({ operation }) => operation.operationId);
     expect(ids).toHaveLength(28);
     expect(new Set(ids).size).toBe(ids.length);
@@ -547,6 +547,11 @@ describe('remote API contract', () => {
         'cancelEvent',
         'getGuests',
         'firestorePatchEvent',
+        'createCohostRequest',
+        'deleteCohostRequest',
+        'removeCohost',
+        'generateEventCohostLink',
+        'revokeEventCohostLink',
       ]);
       const expectedStatus = liveStatusOps.has(operation.operationId)
         ? 'dated-live-observation'
@@ -561,7 +566,7 @@ describe('remote API contract', () => {
       ...materialClaimPointers(spec.paths, '#/paths', 'paths'),
       ...materialClaimPointers(spec.components, '#/components', 'components'),
     ]);
-    expect(pointers).toHaveLength(1740);
+    expect(pointers).toHaveLength(1782);
     for (const pointer of pointers) {
       const claim = evidence.claims[pointer];
       expect(claim, pointer).toBeDefined();
@@ -604,8 +609,8 @@ describe('remote API contract', () => {
       .filter(({ operation }) => operation.responses['200']?.content)
       .map(({ operation }) => operation.operationId)
       .sort();
-    expect(with200).toHaveLength(19);
-    expect(withTyped200Body).toHaveLength(18);
+    expect(with200).toHaveLength(24);
+    expect(withTyped200Body).toHaveLength(23);
     expect(with200.filter((id) => !withTyped200Body.includes(id)))
       .toEqual(['sendAuthCodeTrusted']);
 
@@ -620,14 +625,14 @@ describe('remote API contract', () => {
       /Eleven of those\s+operations have a typed `200` response body\./,
     );
     expect(ledger).toContain(
-      'Five callable operations have protocol-specified HTTP `200` completion',
+      'Ten callable operations have protocol-specified HTTP `200` completion',
     );
     expect(ledger).toContain(
       '`firestorePatchEvent` uses the official Firestore PATCH path',
     );
-    expect(ledger.match(/The 1740 material claims/g)).toHaveLength(2);
+    expect(ledger.match(/The 1782 material claims/g)).toHaveLength(2);
     expect(ledger).toContain(
-      '**Proposed contract revision:** `2026-08-12.5`',
+      '**Proposed contract revision:** `2026-08-12.6`',
     );
     expect(ledger).toContain('**Status:** Owner-reviewed');
     expect(ledger).toContain('Current first-party public-asset research');
@@ -673,6 +678,11 @@ describe('remote API contract', () => {
       'markEventInterest',
       'createEvent',
       'cancelEvent',
+      'createCohostRequest',
+      'deleteCohostRequest',
+      'removeCohost',
+      'generateEventCohostLink',
+      'revokeEventCohostLink',
       'firestorePatchEvent',
     ]);
     const observedErrorOps = {
@@ -740,6 +750,11 @@ describe('remote API contract', () => {
       'markEventInterest',
       'createEvent',
       'cancelEvent',
+      'createCohostRequest',
+      'deleteCohostRequest',
+      'removeCohost',
+      'generateEventCohostLink',
+      'revokeEventCohostLink',
       'firestorePatchEvent',
     ]);
     const observedResponseSources = new Map([
@@ -762,6 +777,11 @@ describe('remote API contract', () => {
       ['markEventInterest', evidence.sources.publicInterestCompletion20260812],
       ['createEvent', evidence.sources.publicCreateEventCompletion20260812],
       ['cancelEvent', evidence.sources.publicCancelEvent20260812],
+      ['createCohostRequest', evidence.sources.publicCohostOperations20260812],
+      ['deleteCohostRequest', evidence.sources.publicCohostOperations20260812],
+      ['removeCohost', evidence.sources.publicCohostOperations20260812],
+      ['generateEventCohostLink', evidence.sources.publicCohostOperations20260812],
+      ['revokeEventCohostLink', evidence.sources.publicCohostOperations20260812],
       ['firestorePatchEvent', evidence.sources.officialFirestoreProtocol],
     ]);
     for (const { path, method, operation } of operations()) {
@@ -775,7 +795,7 @@ describe('remote API contract', () => {
           'addInvitedGuestsAsHost',
         ].includes(operation.operationId)
           ? 'official-protocol-specification'
-          : ['addGuest', 'getGuests', 'markEventInterest', 'createEvent', 'cancelEvent']
+          : ['addGuest', 'getGuests', 'markEventInterest', 'createEvent', 'cancelEvent', 'createCohostRequest', 'deleteCohostRequest', 'removeCohost', 'generateEventCohostLink', 'revokeEventCohostLink']
               .includes(operation.operationId)
             ? 'current-first-party-public-asset-research'
             : 'dated-live-observation';
@@ -1583,9 +1603,9 @@ describe('remote API contract', () => {
     const product = fs.readFileSync(productContractPath, 'utf8');
     for (const expected of [
       '**Status:** Approved product contract',
-      '**Product contract revision:** `2026-08-12.5`',
-      '**Remote API contract revision:** `2026-08-12.5`',
-      '**Currently shipped Go revisions:** product and remote `2026-08-12.5`',
+      '**Product contract revision:** `2026-08-12.6`',
+      '**Remote API contract revision:** `2026-08-12.6`',
+      '**Currently shipped Go revisions:** product and remote `2026-08-12.6`',
       '`PUBLISHED` → `active`',
       '`CANCELED` → `cancelled`',
       '`UNSAVED` exists in the current first-party client vocabulary',
@@ -1630,8 +1650,8 @@ describe('remote API contract', () => {
     );
 
     const appSource = fs.readFileSync('internal/app/app.go', 'utf8');
-    expect(appSource).toContain('ProductContractRevision = "2026-08-12.5"');
-    expect(appSource).toContain('RemoteContractRevision  = "2026-08-12.5"');
+    expect(appSource).toContain('ProductContractRevision = "2026-08-12.6"');
+    expect(appSource).toContain('RemoteContractRevision  = "2026-08-12.6"');
   });
 
   it('defines evidence-backed RSVP planning and submitted-only completion', () => {
@@ -2162,14 +2182,14 @@ describe('remote API contract', () => {
       /"remoteContractRevision": "([^"]+)"/g,
     )].map((match) => match[1]);
 
-    expect(shippedRevision).toBe('2026-08-12.5');
-    expect(documentedRevision).toBe('2026-08-12.5');
-    expect(documentedProductRevision).toBe('2026-08-12.5');
+    expect(shippedRevision).toBe('2026-08-12.6');
+    expect(documentedRevision).toBe('2026-08-12.6');
+    expect(documentedProductRevision).toBe('2026-08-12.6');
     expect(new Set(envelopeRevisions)).toEqual(new Set([documentedRevision]));
     expect(spec.info.version).toBe(documentedRevision);
     expect(evidence.status).toBe('owner-reviewed');
     expect(spec.info.version).toBe(shippedRevision);
-    expect(appSource).toContain('ProductContractRevision = "2026-08-12.5"');
+    expect(appSource).toContain('ProductContractRevision = "2026-08-12.6"');
     expect(productContract)
       .not.toContain('currently leaves every operation response status and body unknown');
     expect(contactResearch)


### PR DESCRIPTION
## Summary

Implements the evidence-backed Go cohost lifecycle for #169.

- adds confirmed host-only cohost invite, invite revoke, cohost removal, link creation, and link revocation
- binds exact event/contact/role/link preconditions in persistent five-minute single-use plans
- re-reads applicable facts before apply, consumes before one dispatch attempt, and never retries
- validates reviewed request and completion shapes for all five callables
- keeps private identities out of public plans and emits link URLs only for reviewed link creation success
- preserves merged guest revision `.5` and advances the reviewed contract to `2026-08-12.6`

No live cohost or link mutation was used.

## Validation

- `go test -race ./...`
- `go vet ./...`
- `go build ./...`
- `go mod verify`
- `npm test -- tests/remote-api-contract.test.js`
- `npm run typecheck`
- privacy guard and diff check

Closes #169.