### PR TITLE
feat(go): add private confirmed text blasts (#170)

### DIFF
--- a/docs/CLI-PRODUCT-CONTRACT.md
+++ b/docs/CLI-PRODUCT-CONTRACT.md
@@ -2,13 +2,13 @@
 
 **Status:** Approved product contract
 
-**Product contract revision:** `2026-08-12.6`
+**Product contract revision:** `2026-08-12.7`
 
-**Remote API contract revision:** `2026-08-12.6`
+**Remote API contract revision:** `2026-08-12.7`
 
-**Owner-reviewed baseline:** product and remote `2026-08-12.3`
+**Owner-reviewed baseline:** product and remote `2026-08-12.6`
 
-**Currently shipped Go revisions:** product and remote `2026-08-12.6`
+**Currently shipped Go revisions:** product and remote `2026-08-12.7`
 
 This document defines the public behavior of the greenfield Go `partiful` CLI.
 It is the authority for commands, inputs, JSON outputs, failures, and mutation
@@ -83,8 +83,10 @@ Every successful command returns:
   "meta": {
     "command": "events.get",
     "cliVersion": "1.0.0",
-    "productContractRevision": "2026-08-12.6",
-    "remoteContractRevision": "2026-08-12.6",
+    "productContractRevision": "2026-08-12.7",
+    "remoteContractRevision": "2026-08-12.7",
+    "productContractRevision": "2026-08-12.7",
+    "remoteContractRevision": "2026-08-12.7",
     "warnings": []
   }
 }
@@ -107,8 +109,10 @@ Every failed command returns:
   "meta": {
     "command": "guests.list",
     "cliVersion": "1.0.0",
-    "productContractRevision": "2026-08-12.6",
-    "remoteContractRevision": "2026-08-12.6"
+    "productContractRevision": "2026-08-12.7",
+    "remoteContractRevision": "2026-08-12.7"
+    "productContractRevision": "2026-08-12.7",
+    "remoteContractRevision": "2026-08-12.7"
   }
 }
 ```
@@ -155,8 +159,10 @@ Collection commands return:
   "meta": {
     "command": "events.list",
     "cliVersion": "1.0.0",
-    "productContractRevision": "2026-08-12.6",
-    "remoteContractRevision": "2026-08-12.6",
+    "productContractRevision": "2026-08-12.7",
+    "remoteContractRevision": "2026-08-12.7",
+    "productContractRevision": "2026-08-12.7",
+    "remoteContractRevision": "2026-08-12.7",
     "warnings": [],
     "page": {
       "limit": 25,
@@ -228,8 +234,10 @@ remote mutation:
   "meta": {
     "command": "events.update",
     "cliVersion": "1.0.0",
-    "productContractRevision": "2026-08-12.6",
-    "remoteContractRevision": "2026-08-12.6",
+    "productContractRevision": "2026-08-12.7",
+    "remoteContractRevision": "2026-08-12.7",
+    "productContractRevision": "2026-08-12.7",
+    "remoteContractRevision": "2026-08-12.7",
     "warnings": []
   }
 }
@@ -988,7 +996,8 @@ reviewed callable and client completion condition. It does not prove
 persisted RSVP state, delivery, notification, or another business side
 effect.
 
-This `2026-08-12.6` contract is the approved event-write product contract and
+This `2026-08-12.7` contract is the approved event-write product contract and
+This `2026-08-12.7` contract is the approved event-write product contract and
 the current shipped Go contract revision.
 
 ### Contacts
@@ -1125,7 +1134,53 @@ This host-only consequential action accepts:
 
 The message is not accepted as a command-line value because shell history is
 not a private input channel. `--message-file -` reads plain UTF-8 text from
-stdin. Images are not supported in v1.
+stdin. The public plan and the persisted mutation record never contain the
+message text. They contain only a private digest and length. The text never
+appears in stdout, stderr, diagnostics, the confirmation token, or persisted
+metadata available to another local user. Images are not supported in v1.
+
+Planning reads `getEventInfo` once, the reviewed Firestore guest collection
+once, and the reviewed Firestore host-message collection once. `ownerIds` must
+contain the current private account ID. The event must not be older than
+`endDate + 67 days`, or `startDate + 6 hours + 67 days` when `endDate` is
+absent. The current text-blast count must be at most `10`, and the derived
+recipient set must be non-empty.
+
+`all-guests` is not a sentinel or an expanded identity list. The reviewed
+request sends the exact current group array in `message.to`, in this order:
+
+1. `invited` when the invited count is positive and not excluded;
+2. `checkedIn` when at least one guest has non-null `checkIn`; and
+3. the current reviewed status set for the event mode.
+
+The status set is:
+
+- `APPROVED`, `PENDING_APPROVAL`, `WAITLISTED_FOR_APPROVAL`, `WITHDRAWN`, and
+  `REJECTED` when `guestAction` is `APPLY`;
+- `RESPONDED_TO_FIND_A_TIME` for an active find-a-time event; or
+- `GOING`, `MAYBE`, `DECLINED`, and conditional `WAITLIST` for an ordinary
+  RSVP event.
+
+The current first-party client excludes the `invited` group from its
+all-guests selection when more than `100` invited guests are present. Its one
+private owner-ID exception is not promoted here. The CLI therefore fails
+closed or conservatively excludes `invited` when it cannot verify an
+exemption.
+
+The public consequential plan states the exact event ID, audience,
+`showOnEventPage`, exact derived `message.to`, and only the message digest and
+length. Its private record binds the stable account fingerprint, the same
+normalized private-input summary, the exact reviewed request summary, and the
+current event, guest, and blast-count preconditions. Apply repeats the same
+message input with:
+
+```text
+--apply --confirm <token>
+```
+
+`--apply` without `--confirm` returns `safety.confirmation_required`. Apply
+reacquires the account, re-reads the same facts once, consumes the token
+immediately before one dispatch attempt, and never retries automatically.
 
 Applied success returns:
 

--- a/docs/REMOTE-API-CONTRACT.md
+++ b/docs/REMOTE-API-CONTRACT.md
@@ -1,12 +1,12 @@
 # Remote API contract
 
-`spec/partiful.openapi.json` is owner-reviewed revision `2026-08-12.6` of the
-remote transport snapshot. Its owner-reviewed baseline is `2026-08-12.3`,
-which is based on owner-reviewed revision `2026-08-12.2`. It describes only
+`spec/partiful.openapi.json` is owner-reviewed revision `2026-08-12.7` of the
+remote transport snapshot. Its owner-reviewed baseline is `2026-08-12.6`,
+which is based on owner-reviewed revision `2026-08-12.3`. It describes only
 network operations and wire shapes. It does not prescribe commands, output,
 credentials, mutation safeguards, or implementation architecture.
 
-The Go CLI ships remote contract revision `2026-08-12.6`.
+The Go CLI ships remote contract revision `2026-08-12.7`.
 
 ## Authority and change process
 
@@ -343,6 +343,52 @@ safe planning:
 
 The current client treats the secret document as optional and uses the
 server-returned link `path`; it does not synthesize an `accept-cohost` token.
+
+## Text-blast proposal
+
+Revision `2026-08-12.7` adds unauthenticated current-client research from
+`docs/research/2026-08-12-text-blast-mapping-public-assets.md`. No text blast,
+guest contact, credential, or private event data was used.
+
+The dated March 24 request observation remains the request authority for the
+nested `message` object. The new proposal retains that dated request mapping
+and promotes only reviewed current-client completion and precondition facts.
+
+The current helper awaits `createTextBlast(...).data`, the caller ignores the
+returned value, and no post-send read occurs. `createTextBlast` therefore gains
+only generic callable HTTP `200` completion under the official Firebase
+callable protocol plus the current client rule that the decoded completion
+value must be non-nullish. No reviewed nested business-success field,
+recipient report, or delivery result exists.
+
+The same current asset computes `all-guests` as the exact ordered `message.to`
+group array, not a sentinel, not an empty array, and not an expanded identity
+list. The ordered groups are `invited`, `checkedIn`, and the current status
+set for the event mode. `invited` represents the invited-status family
+`READY_TO_SEND`, `SENDING`, `SENT`, `SEND_ERROR`, and `DELIVERY_ERROR`.
+`checkedIn` represents guests with non-null `checkIn`. The event-mode status
+set is:
+
+- `APPROVED`, `PENDING_APPROVAL`, `WAITLISTED_FOR_APPROVAL`, `WITHDRAWN`, and
+  `REJECTED` when `guestAction` is `APPLY`;
+- `RESPONDED_TO_FIND_A_TIME` for the current find-a-time predicate; or
+- `GOING`, `MAYBE`, `DECLINED`, and conditional `WAITLIST` for ordinary RSVP.
+
+The current first-party asset excludes the invited group from its all-guests
+selection when the invited count exceeds `100`. Its one private owner-ID
+exception is not promoted. A privacy-safe implementation must therefore fail
+closed or conservatively exclude `invited` when it cannot verify an exemption.
+
+Current host tooling also reads the Firestore guest and host-message
+collections before enabling send. The public asset uses
+`events/{eventId}/guests` to derive guest `status` and `checkIn`, and
+`events/{eventId}/hostMessages` to count current text blasts by `type`
+missing/null/`TEXT_BLAST`. OpenAPI now records official Firestore
+list-documents HTTP `200` completion for
+`/v1/projects/getpartiful/databases/(default)/documents/{collectionPath}`.
+This remains broad transport grammar. It does not infer Partiful authorization,
+query completeness, or business meaning beyond the collection paths reviewed
+for this slice.
 
 ## Historical provenance
 

--- a/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
+++ b/docs/research/2026-08-10-partiful-api-contract-evidence-ledger.md
@@ -1,7 +1,7 @@
 # Partiful remote API contract evidence ledger
 
-**Proposed contract revision:** `2026-08-12.6`
-**Owner-reviewed baseline:** `2026-08-12.3`
+**Proposed contract revision:** `2026-08-12.7`
+**Owner-reviewed baseline:** `2026-08-12.6`
 **Status:** Owner-reviewed
 **Contract:** `spec/partiful.openapi.json`
 **Machine-readable ledger:** `spec/partiful.api-evidence.json`
@@ -37,41 +37,46 @@ Fourteen operations have at least one operation-level dated live observation:
 
 Twelve operations have an observed HTTP `200` status. Eleven of those
 operations have a typed `200` response body. `sendAuthCodeTrusted` has an
-observed `200` status, but its body remains unclaimed. The text-blast operation
-retains an unknown response. The Firestore event read has an observed typed
-`403` response, not an observed success.
+observed `200` status, but its body remains unclaimed. `createTextBlast` keeps
+its dated request observation, but its completion now follows current
+public-asset callable behavior rather than a live business-success observation.
+The Firestore event read has an observed typed `403` response, not an observed
+success.
 
 ### Current public-asset operations
 
 `addGuest`, `markEventInterest`, `createEvent`, `cancelEvent`, `getGuests`,
 `addInvitedGuestsAsHost`, `createCohostRequest`, `deleteCohostRequest`,
 `removeCohost`, `generateEventCohostLink`, and `revokeEventCohostLink` have
-current first-party public-asset request and/or completion mappings. Their
-endpoint business meanings, errors, and all non-`200` statuses remain unknown
-unless separately observed.
+current first-party public-asset request and/or completion mappings.
+The text-blast operation keeps its dated request classification but now also has a
+current first-party completion mapping. Their endpoint business meanings,
+errors, and all non-`200` statuses remain unknown unless separately observed.
 
-Ten callable operations have protocol-specified HTTP `200` completion
+Eleven callable operations have protocol-specified HTTP `200` completion
 responses. `addGuest`, `markEventInterest`, `createEvent`, `cancelEvent`, and
 `addInvitedGuestsAsHost` use the official Firebase callable
 status/result envelope plus current first-party client completion behavior.
-`createCohostRequest`, `deleteCohostRequest`, `removeCohost`,
-`generateEventCohostLink`, and `revokeEventCohostLink` now do the same. None
-is a live business-success observation.
+The text-blast operation plus `createCohostRequest`, `deleteCohostRequest`,
+`removeCohost`, `generateEventCohostLink`, and `revokeEventCohostLink` now
+do the same. None is a live business-success observation.
 
 ### Official-protocol operations
 
 `firestorePatchEvent` uses the official Firestore PATCH path, bearer
 authorization, update mask, current-document preconditions, typed Value
-grammar, and HTTP `200` Document completion. Current first-party assets supply
-the event-field mapping, but the remote operation remains broad. The closed
-field projection is product policy. No Partiful authorization or business
-success is inferred.
+grammar, and HTTP `200` Document completion. `firestoreListDocuments` uses the
+official Firestore list-documents path, bearer authorization, typed Document
+grammar, and HTTP `200` list completion. Current first-party assets supply the
+event-field mapping and the collection-path usage for the blast slice, but both
+remote operations remain broad. The closed field projection and collection
+meaning are product policy. No Partiful authorization or business success is
+inferred.
 
 ### TypeScript-derived operations
 
-The other 2 operations remain TypeScript-derived inferences:
+The other 1 operation remains TypeScript-derived inference:
 
-- Firestore: `firestoreListDocuments`;
 - Firebase auxiliary: `uploadEventPhoto`.
 
 Every operation's request and response claim is enumerated by JSON Pointer in
@@ -79,12 +84,12 @@ the JSON ledger, including operation, parameter, content-type, security,
 schema, constraint, and response claims. Unless a claim is specifically
 observed, callable result payloads, status codes, error bodies, permission
 rules, and limits are **explicit unknown**. Eleven operations with an observed
-HTTP `200` status, ten operations with protocol-specified callable
-completion, and one official Firestore PATCH completion have typed response
+HTTP `200` status, eleven operations with protocol-specified callable
+completion, and one official Firestore PATCH plus one Firestore list completion have typed response
 bodies. The schema-free send-code `200` and OpenAPI `default` responses do not
 claim a body.
 
-The 1782 material claims are audited by
+The 1788 material claims are audited by
 `tests/remote-api-contract.test.js`. Each ledger citation resolves either to a
 JSON Pointer in the committed non-authoritative historical artifact or to a
 heading in the committed stable source index. This keeps the audit independent
@@ -405,7 +410,29 @@ by the Go implementation's Firebase requests:
 Origin is unmodelled and remains unknown because the reviewed evidence
 establishes no Origin request fact.
 
-The 1782 material claims are audited by `tests/remote-api-contract.test.js`.
+The 1788 material claims are audited by `tests/remote-api-contract.test.js`.
+
+## Text-blast public-asset and protocol evidence
+
+The August 12 text-blast note records public build `Sf-HOOx63XpPtr5pPkTvg`,
+deployment `dpl_D7TPPj16g1fU46JSHSyrsRURxrK9`, exact asset URLs, module IDs, and
+hashes. The research used no credential and made no text blast. It establishes
+current client completion behavior, exact all-guests group construction, and
+reviewed host-only precondition reads for the blast slice.
+
+The dated March 24 request note remains the authority for the nested
+`createTextBlast.message` object. The August 12 note adds only current
+completion and precondition facts. The current helper awaits
+`createTextBlast(...).data`, the caller ignores the returned value, and there is
+no post-send read. The remote contract therefore recognizes only generic
+callable HTTP `200` completion plus a non-nullish decoded completion value.
+
+The same public assets show that all-guests sends the exact ordered group array
+in `message.to`. It is not a sentinel, not an empty array, and not an expanded
+identity list. Host tooling also reads the Firestore guest and host-message
+collections before enabling send. This is the reviewed provenance for the exact
+all-guests representation, the invited-count exclusion, the checked-in group,
+and the blast-count preconditions used by the Go product.
 
 ## Resolved conflict
 

--- a/docs/research/2026-08-12-text-blast-mapping-public-assets.md
+++ b/docs/research/2026-08-12-text-blast-mapping-public-assets.md
@@ -1,0 +1,149 @@
+# Text-blast mappings from current public web assets
+
+## Scope and provenance
+
+This note records only unauthenticated, first-party public Partiful assets and
+official Firebase and Firestore protocol documents. No account, credential,
+real event, guest list, text blast, phone number, or live mutation was used.
+In particular, this research did not call `createTextBlast` or any Firestore
+write.
+
+The public login page at <https://partiful.com/login> exposed Next build
+`Sf-HOOx63XpPtr5pPkTvg` with deployment query
+`dpl_D7TPPj16g1fU46JSHSyrsRURxrK9` on 2026-08-12.
+The exact manifest URL was
+<https://partiful.com/_next/static/Sf-HOOx63XpPtr5pPkTvg/_buildManifest.js?dpl=dpl_D7TPPj16g1fU46JSHSyrsRURxrK9>
+with SHA-256
+`2de1d4a26e8d4e9e2370ef970cafab2cd1cd6f5c8402fd54a5ea6f150488cbf6`.
+Relevant assets were:
+
+| Asset | SHA-256 | Relevant modules |
+|---|---|---|
+| <https://partiful.com/_next/static/chunks/2583.bd7537e8be64d6a1.js?dpl=dpl_D7TPPj16g1fU46JSHSyrsRURxrK9> | `b0905f97d8fd2998a957884539c923809f2838ba502398ed6ae7841c24eddfdd` | `12583`, `8012` |
+| <https://partiful.com/_next/static/chunks/502-a1c7122349c97d59.js?dpl=dpl_D7TPPj16g1fU46JSHSyrsRURxrK9> | `011b2bb1bc2050b6516a465854a39d3cb3c2cc774952db984100cff92d0bd9d1` | `5851` |
+| <https://partiful.com/_next/static/chunks/1585-abd7081ec2f9f79f.js?dpl=dpl_D7TPPj16g1fU46JSHSyrsRURxrK9> | `437bf13262a46ca96ffb19f625c3ee2a5aaa1996ef9e97ae5b92731341d94487` | `75076`, `69865` |
+| <https://partiful.com/_next/static/chunks/pages/_app-b0dc833855a84321.js?dpl=dpl_D7TPPj16g1fU46JSHSyrsRURxrK9> | `812edcea27949b86471cfc5f970cb5b3b961e27a6eea80e7cf6d99aad6623f41` | `17959`, `47186`, `48144`, `82262`, `99181` |
+| <https://firebase.google.com/docs/functions/callable-reference> | n/a | callable protocol |
+| <https://firebase.google.com/docs/firestore/reference/rest/v1/projects.databases.documents/list> | n/a | list-documents protocol |
+
+The current assets establish client request construction, precondition checks,
+and completion handling. They do not establish endpoint business success,
+delivery, authorization, or unseen error bodies.
+
+## `createTextBlast` helper and completion
+
+Dynamic chunk `2583` module `12583` defines:
+
+```js
+async function ea(e) {
+  try {
+    return (await wF("createTextBlast", { params: e })).data
+  } catch (e) {
+    console.error("Error creating text blast", e)
+    throw e
+  }
+}
+```
+
+The same module's send button awaits `ea(...)`, marks the modal done, and closes
+it. It does not inspect a business-success field, recipient report, or post-send
+read. A rejected promise sets the modal error state.
+
+The reviewed completion facts are therefore:
+
+- callable protocol success uses HTTP `200` with the official Firebase callable
+  result envelope;
+- the decoded callable value must be non-nullish, because the helper reads its
+  `.data` property before returning; and
+- no reviewed nested business field is required after that helper access.
+
+A recognized completion means only that the exact submitted request reached the
+current client success path. It does not prove stored state, SMS delivery,
+email delivery, push delivery, or any recipient result.
+
+## Reviewed current client request facts for this slice
+
+The same `12583` module builds the modal request with:
+
+```js
+{ eventId, message: { text, to, showOnEventPage, ... } }
+```
+
+and sets `showOnEventPage` from the current checkbox state. The current modal
+also appends `notificationChannels` and optional `images`, but issue #170 keeps
+the dated nested `createTextBlast.message` mapping as the transport baseline.
+This note promotes only the reviewed `all-guests` `to` representation and the
+current page-display flag.
+
+The `Select all` button does **not** send a sentinel, empty array, or expanded
+identity list. Module `12583` sets the audience to:
+
+```js
+V.map(e => e.group)
+```
+
+where `V` is the enabled, non-empty subset of the current group list. The
+request then sends that exact ordered array as `message.to`.
+
+## Group derivation for `all-guests`
+
+Module `5851` constructs the ordered group list as:
+
+1. `"invited"`
+2. `"checkedIn"`
+3. one of these status sets:
+   - `APPROVED`, `PENDING_APPROVAL`, `WAITLISTED_FOR_APPROVAL`, `WITHDRAWN`,
+     `REJECTED` when `guestAction === "APPLY"`;
+   - `RESPONDED_TO_FIND_A_TIME` when the current event satisfies the active
+     find-a-time predicate; or
+   - `GOING`, `MAYBE`, `DECLINED`, and conditional `WAITLIST` for ordinary RSVP
+     events.
+
+Chunk `_app` module `82262` defines the recipient predicate used for these
+counts. `"invited"` matches the five invited statuses
+`READY_TO_SEND`, `SENDING`, `SENT`, `SEND_ERROR`, and `DELIVERY_ERROR`.
+`"checkedIn"` matches any guest with non-null `checkIn`. Exact status groups
+match the same string value.
+
+For `all-guests`, only enabled groups with a positive count are included in the
+submitted array. Module `5851` also marks invited groups as excluded from
+`Select all` when the invited count exceeds `100`. The current bundle contains
+one private hard-coded owner exception for that exclusion. This note does not
+promote that private identifier. A privacy-safe implementation must therefore
+fail closed or conservatively exclude the invited group when it cannot verify an
+exemption.
+
+## Host-only precondition reads
+
+Current host tooling reads the event guest collection and host-message
+collection before enabling send:
+
+- `_app` module `99181` builds `events/{eventId}/guests` and
+  `events/{eventId}/hostMessages` Firestore collection references;
+- `_app` module `17959` keeps guest `status` and `checkIn` when it normalizes a
+  guest document, and keeps optional host-message `type` when it normalizes a
+  host-message document; and
+- chunk `2583` module `12583` passes the loaded guest list length and current
+  text-blast list length into module `5851`'s `canSendTextBlast` helper.
+
+That helper disables send for exactly three reviewed reasons:
+
+- `event_expired`
+- `max_text_blasts_per_event_reached`
+- `no_guests`
+
+The expiry helper uses `_app` modules `48144` and `26969`. It treats an event
+as old when `endDate + 67 days` is in the past, or when `startDate + 6 hours +
+67 days` is in the past for an event without `endDate`.
+
+Current host-message counting filters the collection to documents whose `type`
+is missing, null, or `TEXT_BLAST`. No recipient failure detail is consulted
+before submit.
+
+## Submitted-only boundary
+
+Because the reviewed current client does not inspect a business-success field or
+perform a post-send read, a safe CLI result can report only submitted intent.
+The correct public result is the exact submitted event ID, audience,
+`showOnEventPage`, `submitted: true`, and `recipientStatus:
+"not-reported"`.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -14,8 +14,8 @@ import (
 
 const (
 	Version                 = "1.0.0"
-	ProductContractRevision = "2026-08-12.6"
-	RemoteContractRevision  = "2026-08-12.6"
+	ProductContractRevision = "2026-08-12.7"
+	RemoteContractRevision  = "2026-08-12.7"
 )
 
 type Request struct {
@@ -62,6 +62,7 @@ const (
 	eventsCreateCommand
 	eventsUpdateCommand
 	eventsCancelCommand
+	blastsSendCommand
 	rsvpGetCommand
 	rsvpSetCommand
 	cohostsInviteCommand
@@ -426,6 +427,38 @@ var commandCatalog = []commandDefinition{
 		},
 		inputSchema:   eventCancelInputSchema(),
 		successSchema: eventCancelSuccessSchema(),
+		failureTypes: []string{
+			"auth.required",
+			"auth.expired",
+			"permission.denied",
+			"resource.not_found",
+			"state.conflict",
+			"safety.confirmation_required",
+			"safety.plan_stale",
+			"remote.unavailable",
+			"contract.protocol_changed",
+			"internal.failure",
+		},
+		safety: consequentialActionSafety(),
+	},
+	{
+		path:       "blasts.send",
+		invocation: []string{"blasts", "send"},
+		kind:       blastsSendCommand,
+		positionals: []positionalDefinition{{
+			Name:        "event-id",
+			Required:    true,
+			Description: "Event identifier.",
+		}},
+		flags: []flagDefinition{
+			{Name: "--audience", Description: "Only all-guests is supported.", TakesValue: true},
+			{Name: "--message-file", Description: "Read the private message from a file path or - for stdin.", TakesValue: true},
+			{Name: "--show-on-event-page", Description: "Show the blast in the event activity feed."},
+			{Name: "--apply", Description: "Apply a reviewed consequential plan."},
+			{Name: "--confirm", Description: "Exact consequential confirmation token.", TakesValue: true},
+		},
+		inputSchema:   blastSendInputSchema(),
+		successSchema: blastSendSuccessSchema(),
 		failureTypes: []string{
 			"auth.required",
 			"auth.expired",
@@ -1493,6 +1526,8 @@ func Execute(ctx context.Context, request Request, dependencies Dependencies) Re
 				return executeEventUpdate(ctx, request, definition, argv, dependencies, pretty)
 			case eventsCancelCommand:
 				return executeEventCancel(ctx, request, definition, argv, dependencies, pretty)
+			case blastsSendCommand:
+				return executeBlastSend(ctx, request, definition, argv, dependencies, pretty)
 			case rsvpGetCommand:
 				return executeRSVPGet(ctx, definition, argv, dependencies, pretty)
 			case rsvpSetCommand:
@@ -1544,6 +1579,7 @@ func (definition commandDefinition) matches(argv []string) bool {
 		definition.kind == eventsCreateCommand ||
 		definition.kind == eventsUpdateCommand ||
 		definition.kind == eventsCancelCommand ||
+		definition.kind == blastsSendCommand ||
 		definition.kind == rsvpGetCommand ||
 		definition.kind == rsvpSetCommand ||
 		definition.kind == cohostsInviteCommand ||

--- a/internal/app/blasts.go
+++ b/internal/app/blasts.go
@@ -1,0 +1,622 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"slices"
+	"time"
+	"unicode/utf8"
+
+	"github.com/KalebCole/partiful-cli/internal/mutation"
+	"github.com/KalebCole/partiful-cli/internal/remote"
+)
+
+const (
+	blastAudienceAllGuests      = "all-guests"
+	blastOperation              = "createTextBlast"
+	blastMessageMaximumRunes    = 480
+	blastInviteLimitForAudience = 100
+	blastOldEventGraceDays      = 67
+	blastNoEndGraceHours        = 6
+)
+
+type blastMessageSummary struct {
+	SHA256 string `json:"sha256"`
+	Length int    `json:"length"`
+}
+
+type blastSendPublicInput struct {
+	Audience        string              `json:"audience"`
+	ShowOnEventPage bool                `json:"showOnEventPage"`
+	Message         blastMessageSummary `json:"message"`
+}
+
+type blastSendPublicRequest struct {
+	EventID string                        `json:"eventId"`
+	Message blastSendPublicRequestMessage `json:"message"`
+}
+
+type blastSendPublicRequestMessage struct {
+	TextSHA256      string   `json:"textSha256"`
+	TextLength      int      `json:"textLength"`
+	To              []string `json:"to"`
+	ShowOnEventPage bool     `json:"showOnEventPage"`
+}
+
+type blastSendPlan struct {
+	Operation        string                 `json:"operation"`
+	EventID          string                 `json:"eventId"`
+	Input            blastSendPublicInput   `json:"input"`
+	Request          blastSendPublicRequest `json:"request"`
+	Effects          []string               `json:"effects"`
+	Preconditions    map[string]string      `json:"preconditions"`
+	ExpiresInSeconds int                    `json:"expiresInSeconds"`
+	PlanToken        string                 `json:"planToken"`
+}
+
+type blastSendSubmitted struct {
+	EventID         string `json:"eventId"`
+	Submitted       bool   `json:"submitted"`
+	Audience        string `json:"audience"`
+	ShowOnEventPage bool   `json:"showOnEventPage"`
+	RecipientStatus string `json:"recipientStatus"`
+}
+
+type blastSendOptions struct {
+	EventID         string
+	Audience        string
+	MessageFile     string
+	ShowOnEventPage bool
+	Apply           bool
+	ConfirmToken    string
+}
+
+type blastGuestSnapshot struct {
+	Total          int            `json:"total"`
+	CheckedInCount int            `json:"checkedInCount"`
+	StatusCounts   map[string]int `json:"statusCounts"`
+}
+
+type blastPrivatePreconditions struct {
+	OwnerIDs       eventFieldSnapshot `json:"ownerIds"`
+	StartDate      eventFieldSnapshot `json:"startDate"`
+	EndDate        eventFieldSnapshot `json:"endDate"`
+	FindATime      eventFieldSnapshot `json:"findATime"`
+	GuestAction    eventFieldSnapshot `json:"guestAction"`
+	EnableWaitlist eventFieldSnapshot `json:"enableWaitlist"`
+	Guests         blastGuestSnapshot `json:"guests"`
+	TextBlastCount int                `json:"textBlastCount"`
+}
+
+type blastPreparedMessage struct {
+	Text   string
+	Digest blastMessageSummary
+}
+
+func executeBlastSend(
+	ctx context.Context,
+	request Request,
+	definition commandDefinition,
+	argv []string,
+	dependencies Dependencies,
+	pretty bool,
+) Result {
+	options, inputError := parseBlastSendOptions(request, definition, argv, dependencies)
+	if inputError != nil {
+		return failure(definition.path, exitCodeForType(inputError.Type), *inputError, pretty)
+	}
+	message, inputError := readBlastMessage(request, dependencies, options.MessageFile)
+	if inputError != nil {
+		return failure(definition.path, exitCodeForType(inputError.Type), *inputError, pretty)
+	}
+	publicInput := blastSendPublicInput{
+		Audience:        options.Audience,
+		ShowOnEventPage: options.ShowOnEventPage,
+		Message:         message.Digest,
+	}
+	inputDocument, _ := json.Marshal(publicInput)
+
+	session, sessionFailure := acquireProtectedSession(ctx, definition.path, dependencies, pretty)
+	if sessionFailure != nil {
+		return *sessionFailure
+	}
+	if session.AccountFingerprint == "" || session.UserID == "" {
+		return internalFailure(definition.path, pretty)
+	}
+	clock := time.Now
+	if dependencies.Now != nil {
+		clock = dependencies.Now
+	}
+	authority := mutation.Authority{Files: dependencies.Files, Path: eventMutationPath(dependencies), Now: clock, Random: dependencies.MutationRandom}
+	var inspected mutation.Record
+	if options.Apply {
+		var err error
+		inspected, err = authority.Inspect(options.ConfirmToken, definition.path, blastOperation, session.AccountFingerprint, inputDocument)
+		if err != nil {
+			if errors.Is(err, mutation.ErrStale) {
+				return eventPlanStaleFailure(definition.path, pretty)
+			}
+			return internalFailure(definition.path, pretty)
+		}
+	}
+	deviceID, err := randomDeviceID(dependencies.AuthRandom)
+	if err != nil {
+		return internalFailure(definition.path, pretty)
+	}
+	client := remote.Client{HTTP: dependencies.HTTP}
+	event, err := client.GetEventInfo(ctx, session.AccessToken, deviceID, options.EventID)
+	if err != nil {
+		switch {
+		case errors.Is(err, remote.ErrEventNotFound):
+			if options.Apply {
+				return eventPlanStaleFailure(definition.path, pretty)
+			}
+			return eventNotFoundFailure(definition.path, pretty)
+		case errors.Is(err, remote.ErrUnavailable):
+			return blastRemoteUnavailableFailure(definition.path, "The text blast could not read current event data.", "partiful: text blast unavailable\n", pretty)
+		default:
+			return blastProtocolChangedFailure(definition.path, "TEXT_BLAST_PROTOCOL_CHANGED", "The text blast flow no longer matches the reviewed remote contract.", "partiful: text blast protocol changed\n", pretty)
+		}
+	}
+	if !event.OwnerIDsPresent || !slices.Contains(event.OwnerIDs, session.UserID) {
+		return hostPermissionFailure(definition.path, pretty)
+	}
+	guests, err := client.ListEventGuests(ctx, session.AccessToken, options.EventID)
+	if err != nil {
+		if errors.Is(err, remote.ErrUnavailable) {
+			return blastRemoteUnavailableFailure(definition.path, "The text blast could not read current guest data.", "partiful: text blast unavailable\n", pretty)
+		}
+		return blastProtocolChangedFailure(definition.path, "TEXT_BLAST_PROTOCOL_CHANGED", "The text blast flow no longer matches the reviewed remote contract.", "partiful: text blast protocol changed\n", pretty)
+	}
+	textBlastCount, err := client.CountTextBlasts(ctx, session.AccessToken, options.EventID)
+	if err != nil {
+		if errors.Is(err, remote.ErrUnavailable) {
+			return blastRemoteUnavailableFailure(definition.path, "The text blast could not read current blast data.", "partiful: text blast unavailable\n", pretty)
+		}
+		return blastProtocolChangedFailure(definition.path, "TEXT_BLAST_PROTOCOL_CHANGED", "The text blast flow no longer matches the reviewed remote contract.", "partiful: text blast protocol changed\n", pretty)
+	}
+	toGroups, preconditions, conditionFailure := buildBlastPreconditions(
+		definition.path,
+		event,
+		guests,
+		textBlastCount,
+		clock(),
+		pretty,
+	)
+	if conditionFailure != nil {
+		return *conditionFailure
+	}
+	publicRequest := blastSendPublicRequest{
+		EventID: options.EventID,
+		Message: blastSendPublicRequestMessage{
+			TextSHA256:      message.Digest.SHA256,
+			TextLength:      message.Digest.Length,
+			To:              append([]string(nil), toGroups...),
+			ShowOnEventPage: options.ShowOnEventPage,
+		},
+	}
+	requestDocument, _ := json.Marshal(publicRequest)
+	preconditionDocument, _ := json.Marshal(preconditions)
+	binding := mutation.Binding{Command: definition.path, Operation: blastOperation, AccountFingerprint: session.AccountFingerprint, Input: inputDocument, Request: requestDocument, Preconditions: preconditionDocument}
+	if options.Apply {
+		if !bytes.Equal(inspected.Binding.Request, requestDocument) || !bytes.Equal(inspected.Binding.Preconditions, preconditionDocument) {
+			return eventPlanStaleFailure(definition.path, pretty)
+		}
+		if err := authority.Consume(options.ConfirmToken, binding); err != nil {
+			if errors.Is(err, mutation.ErrStale) {
+				return eventPlanStaleFailure(definition.path, pretty)
+			}
+			return internalFailure(definition.path, pretty)
+		}
+		if err := client.CreateTextBlast(ctx, session.AccessToken, deviceID, session.UserID, remote.CreateTextBlastParams{
+			EventID: options.EventID,
+			Message: remote.TextBlastMessage{
+				Text:            message.Text,
+				To:              append([]string(nil), toGroups...),
+				ShowOnEventPage: options.ShowOnEventPage,
+			},
+		}); err != nil {
+			if errors.Is(err, remote.ErrUnavailable) {
+				return blastSubmissionUnavailableFailure(definition.path, pretty)
+			}
+			return blastProtocolChangedFailure(definition.path, "TEXT_BLAST_PROTOCOL_CHANGED", "The text blast response no longer matches the reviewed remote contract.", "partiful: text blast protocol changed\n", pretty)
+		}
+		return success(definition.path, blastSendSubmitted{
+			EventID:         options.EventID,
+			Submitted:       true,
+			Audience:        options.Audience,
+			ShowOnEventPage: options.ShowOnEventPage,
+			RecipientStatus: "not-reported",
+		}, pretty)
+	}
+	token, err := authority.Create(binding)
+	if err != nil {
+		return internalFailure(definition.path, pretty)
+	}
+	effects := []string{"Contacts event guests with a text blast."}
+	if options.ShowOnEventPage {
+		effects = append(effects, "Shows the blast in the event activity feed.")
+	}
+	return success(definition.path, blastSendPlan{
+		Operation: blastOperation,
+		EventID:   options.EventID,
+		Input:     publicInput,
+		Request:   publicRequest,
+		Effects:   effects,
+		Preconditions: map[string]string{
+			"ownership":      "bound",
+			"eventTiming":    "bound",
+			"audience":       "bound",
+			"guestSnapshot":  "bound",
+			"existingBlasts": "bound",
+		},
+		ExpiresInSeconds: 300,
+		PlanToken:        token,
+	}, pretty)
+}
+
+func parseBlastSendOptions(
+	request Request,
+	definition commandDefinition,
+	argv []string,
+	dependencies Dependencies,
+) (blastSendOptions, *errorBody) {
+	eventID, inputError := parseEventID(definition, argv[:len(definition.invocation)+1])
+	if inputError != nil {
+		return blastSendOptions{}, inputError
+	}
+	allowed := make(map[string]flagDefinition, len(definition.flags))
+	for _, flag := range definition.flags {
+		allowed[flag.Name] = flag
+	}
+	options := blastSendOptions{EventID: eventID}
+	scalars := map[string]string{}
+	for index := len(definition.invocation) + 1; index < len(argv); index++ {
+		name := argv[index]
+		flag, ok := allowed[name]
+		if !ok {
+			return blastSendOptions{}, eventWriteInputFailure("FLAG_UNKNOWN", "The command contains an unknown flag.")
+		}
+		if _, repeated := scalars[name]; repeated {
+			return blastSendOptions{}, eventWriteInputFailureWithDetail("FLAG_REPEATED", "A scalar flag cannot be repeated.", "flag", name)
+		}
+		if !flag.TakesValue {
+			scalars[name] = "true"
+			continue
+		}
+		if index+1 >= len(argv) {
+			return blastSendOptions{}, eventWriteInputFailureWithDetail("FLAG_VALUE_REQUIRED", "A flag value is required.", "flag", name)
+		}
+		index++
+		scalars[name] = argv[index]
+	}
+	options.Audience = scalars["--audience"]
+	if options.Audience == "" {
+		return blastSendOptions{}, eventWriteInputFailure("AUDIENCE_REQUIRED", "--audience is required.")
+	}
+	if options.Audience != blastAudienceAllGuests {
+		return blastSendOptions{}, eventWriteInputFailure("AUDIENCE_INVALID", "Only all-guests is supported.")
+	}
+	options.MessageFile = scalars["--message-file"]
+	if options.MessageFile == "" {
+		return blastSendOptions{}, eventWriteInputFailure("MESSAGE_FILE_REQUIRED", "--message-file is required.")
+	}
+	_, options.ShowOnEventPage = scalars["--show-on-event-page"]
+	_, options.Apply = scalars["--apply"]
+	options.ConfirmToken = scalars["--confirm"]
+	if options.Apply && options.ConfirmToken == "" {
+		return blastSendOptions{}, confirmationRequiredErrorBody()
+	}
+	if !options.Apply && options.ConfirmToken != "" {
+		return blastSendOptions{}, eventWriteInputFailure("APPLY_REQUIRED", "--confirm requires --apply.")
+	}
+	_ = request
+	_ = dependencies
+	return options, nil
+}
+
+func readBlastMessage(
+	request Request,
+	dependencies Dependencies,
+	messageFile string,
+) (blastPreparedMessage, *errorBody) {
+	var (
+		document []byte
+		err      error
+	)
+	switch messageFile {
+	case "-":
+		if request.Stdin == nil {
+			document = []byte{}
+		} else {
+			document, err = io.ReadAll(request.Stdin)
+		}
+	default:
+		if dependencies.Files == nil {
+			return blastPreparedMessage{}, eventWriteInputFailure("MESSAGE_FILE_UNREADABLE", "The message file could not be read.")
+		}
+		document, err = dependencies.Files.ReadFile(messageFile)
+	}
+	if err != nil {
+		return blastPreparedMessage{}, eventWriteInputFailure("MESSAGE_FILE_UNREADABLE", "The message file could not be read.")
+	}
+	if !utf8.Valid(document) {
+		return blastPreparedMessage{}, eventWriteInputFailure("MESSAGE_INVALID_UTF8", "The message must be valid UTF-8 text.")
+	}
+	text := string(document)
+	length := utf8.RuneCountInString(text)
+	if length == 0 {
+		return blastPreparedMessage{}, eventWriteInputFailure("MESSAGE_EMPTY", "The message must not be empty.")
+	}
+	if length > blastMessageMaximumRunes {
+		return blastPreparedMessage{}, eventWriteInputFailure("MESSAGE_TOO_LONG", "The message exceeds the reviewed maximum length.")
+	}
+	digest := sha256.Sum256(document)
+	return blastPreparedMessage{
+		Text: text,
+		Digest: blastMessageSummary{
+			SHA256: hex.EncodeToString(digest[:]),
+			Length: length,
+		},
+	}, nil
+}
+
+func buildBlastPreconditions(
+	command string,
+	event remote.Event,
+	guests []remote.EventGuest,
+	textBlastCount int,
+	now time.Time,
+	pretty bool,
+) ([]string, blastPrivatePreconditions, *Result) {
+	expired, err := blastEventExpired(event, now)
+	if err != nil {
+		result := blastProtocolChangedFailure(command, "TEXT_BLAST_PROTOCOL_CHANGED", "The text blast flow no longer matches the reviewed remote contract.", "partiful: text blast protocol changed\n", pretty)
+		return nil, blastPrivatePreconditions{}, &result
+	}
+	if expired {
+		result := eventPreconditionFailure(command, pretty)
+		return nil, blastPrivatePreconditions{}, &result
+	}
+	snapshot := buildBlastGuestSnapshot(guests)
+	toGroups, err := deriveBlastAudience(event, snapshot)
+	if err != nil {
+		result := blastProtocolChangedFailure(command, "TEXT_BLAST_PROTOCOL_CHANGED", "The text blast flow no longer matches the reviewed remote contract.", "partiful: text blast protocol changed\n", pretty)
+		return nil, blastPrivatePreconditions{}, &result
+	}
+	if len(toGroups) == 0 || snapshot.Total == 0 || textBlastCount > 10 {
+		result := eventPreconditionFailure(command, pretty)
+		return nil, blastPrivatePreconditions{}, &result
+	}
+	return toGroups, blastPrivatePreconditions{
+		OwnerIDs:       rawEventField(event, "ownerIds"),
+		StartDate:      rawEventField(event, "startDate"),
+		EndDate:        rawEventField(event, "endDate"),
+		FindATime:      rawEventField(event, "findATime"),
+		GuestAction:    rawEventField(event, "guestAction"),
+		EnableWaitlist: rawEventField(event, "enableWaitlist"),
+		Guests:         snapshot,
+		TextBlastCount: textBlastCount,
+	}, nil
+}
+
+func buildBlastGuestSnapshot(guests []remote.EventGuest) blastGuestSnapshot {
+	counts := make(map[string]int)
+	checkedInCount := 0
+	for _, guest := range guests {
+		counts[guest.Status]++
+		if guest.CheckedIn {
+			checkedInCount++
+		}
+	}
+	return blastGuestSnapshot{Total: len(guests), CheckedInCount: checkedInCount, StatusCounts: counts}
+}
+
+func deriveBlastAudience(event remote.Event, guests blastGuestSnapshot) ([]string, error) {
+	mode, err := blastAudienceMode(event)
+	if err != nil {
+		return nil, err
+	}
+	groups := make([]string, 0, 7)
+	invitedCount := 0
+	for status, count := range guests.StatusCounts {
+		if remoteInvitedGuestStatus(status) {
+			invitedCount += count
+		}
+	}
+	if invitedCount > 0 && invitedCount <= blastInviteLimitForAudience {
+		groups = append(groups, "invited")
+	}
+	if guests.CheckedInCount > 0 {
+		groups = append(groups, "checkedIn")
+	}
+	switch mode {
+	case "apply":
+		for _, status := range []string{"APPROVED", "PENDING_APPROVAL", "WAITLISTED_FOR_APPROVAL", "WITHDRAWN", "REJECTED"} {
+			if guests.StatusCounts[status] > 0 {
+				groups = append(groups, status)
+			}
+		}
+	case "find-a-time":
+		if guests.StatusCounts["RESPONDED_TO_FIND_A_TIME"] > 0 {
+			groups = append(groups, "RESPONDED_TO_FIND_A_TIME")
+		}
+	default:
+		for _, status := range []string{"GOING", "MAYBE", "DECLINED"} {
+			if guests.StatusCounts[status] > 0 {
+				groups = append(groups, status)
+			}
+		}
+		if event.Safeguards.EnableWaitlist.State == remote.FieldValue && event.Safeguards.EnableWaitlist.Value && guests.StatusCounts["WAITLIST"] > 0 {
+			groups = append(groups, "WAITLIST")
+		}
+	}
+	return groups, nil
+}
+
+func blastAudienceMode(event remote.Event) (string, error) {
+	if event.Safeguards.GuestAction.State == remote.FieldValue && event.Safeguards.GuestAction.Value == "APPLY" {
+		return "apply", nil
+	}
+	active, err := blastFindATimeActive(event)
+	if err != nil {
+		return "", err
+	}
+	if active {
+		return "find-a-time", nil
+	}
+	return "rsvp", nil
+}
+
+func blastFindATimeActive(event remote.Event) (bool, error) {
+	raw, ok := event.RawFields["findATime"]
+	if !ok {
+		return false, fmt.Errorf("findATime is missing")
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if bytes.Equal(trimmed, []byte("null")) {
+		return false, nil
+	}
+	object, err := blastDecodeObject(trimmed)
+	if err != nil {
+		return false, err
+	}
+	enabled := false
+	if rawEnabled, ok := object["enabled"]; ok {
+		if json.Unmarshal(rawEnabled, &enabled) != nil {
+			return false, fmt.Errorf("findATime.enabled is invalid")
+		}
+	}
+	rawOptionMap, optionMapPresent := object["optionMap"]
+	optionMapActive := optionMapPresent && !bytes.Equal(bytes.TrimSpace(rawOptionMap), []byte("null"))
+	selectedRaw, selectedPresent := object["selectedOptionId"]
+	selectedActive := selectedPresent && !bytes.Equal(bytes.TrimSpace(selectedRaw), []byte("null"))
+	return enabled && optionMapActive && !selectedActive, nil
+}
+
+func blastDecodeObject(raw []byte) (map[string]json.RawMessage, error) {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	var object map[string]json.RawMessage
+	if decoder.Decode(&object) != nil || object == nil {
+		return nil, fmt.Errorf("object is invalid")
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return nil, fmt.Errorf("object is invalid")
+	}
+	return object, nil
+}
+
+func blastEventExpired(event remote.Event, now time.Time) (bool, error) {
+	if event.Start == nil || *event.Start == "TBD" {
+		return false, fmt.Errorf("startDate is invalid")
+	}
+	start, err := time.Parse(time.RFC3339, *event.Start)
+	if err != nil {
+		return false, err
+	}
+	expiryBase := start.Add(blastNoEndGraceHours * time.Hour)
+	if event.End != nil && *event.End != "" {
+		end, err := time.Parse(time.RFC3339, *event.End)
+		if err != nil {
+			return false, err
+		}
+		expiryBase = end
+	}
+	return expiryBase.AddDate(0, 0, blastOldEventGraceDays).Before(now), nil
+}
+
+func remoteInvitedGuestStatus(status string) bool {
+	return status == "READY_TO_SEND" ||
+		status == "SENDING" ||
+		status == "SENT" ||
+		status == "SEND_ERROR" ||
+		status == "DELIVERY_ERROR"
+}
+
+func blastSendInputSchema() jsonSchema {
+	one := 1
+	return objectSchema(
+		[]string{"audience", "messageFile"},
+		map[string]jsonSchema{
+			"audience":        {Type: "string", Enum: []string{blastAudienceAllGuests}},
+			"messageFile":     {Type: "string", MinLength: &one},
+			"showOnEventPage": {Type: "boolean"},
+		},
+	)
+}
+
+func blastSendSuccessSchema() jsonSchema {
+	one := 1
+	threeHundred := 300
+	plan := objectSchema(
+		[]string{"operation", "eventId", "input", "request", "effects", "preconditions", "expiresInSeconds", "planToken"},
+		map[string]jsonSchema{
+			"operation": {Type: "string", Enum: []string{blastOperation}},
+			"eventId":   {Type: "string", MinLength: &one},
+			"input": objectSchema(
+				[]string{"audience", "showOnEventPage", "message"},
+				map[string]jsonSchema{
+					"audience":        {Type: "string", Enum: []string{blastAudienceAllGuests}},
+					"showOnEventPage": {Type: "boolean"},
+					"message": objectSchema([]string{"sha256", "length"}, map[string]jsonSchema{
+						"sha256": {Type: "string", MinLength: &one},
+						"length": {Type: "integer"},
+					}),
+				},
+			),
+			"request": objectSchema(
+				[]string{"eventId", "message"},
+				map[string]jsonSchema{
+					"eventId": {Type: "string", MinLength: &one},
+					"message": objectSchema([]string{"textSha256", "textLength", "to", "showOnEventPage"}, map[string]jsonSchema{
+						"textSha256":      {Type: "string", MinLength: &one},
+						"textLength":      {Type: "integer"},
+						"to":              {Type: "array", Items: pointerSchema(jsonSchema{Type: "string"})},
+						"showOnEventPage": {Type: "boolean"},
+					}),
+				},
+			),
+			"effects":          {Type: "array", Items: pointerSchema(jsonSchema{Type: "string"})},
+			"preconditions":    {Type: "object"},
+			"expiresInSeconds": {Type: "integer", Minimum: &threeHundred, Maximum: &threeHundred},
+			"planToken":        {Type: "string", MinLength: &one},
+		},
+	)
+	submitted := objectSchema(
+		[]string{"eventId", "submitted", "audience", "showOnEventPage", "recipientStatus"},
+		map[string]jsonSchema{
+			"eventId":         {Type: "string", MinLength: &one},
+			"submitted":       {Type: "boolean", Const: true},
+			"audience":        {Type: "string", Enum: []string{blastAudienceAllGuests}},
+			"showOnEventPage": {Type: "boolean"},
+			"recipientStatus": {Type: "string", Enum: []string{"not-reported"}},
+		},
+	)
+	return jsonSchema{Type: "object", OneOf: []jsonSchema{plan, submitted}}
+}
+
+func blastRemoteUnavailableFailure(command, message, stderr string, pretty bool) Result {
+	result := failure(command, 8, errorBody{Type: "remote.unavailable", Code: "TEXT_BLAST_UNAVAILABLE", Message: message, Retryable: true, Details: map[string]any{}}, pretty)
+	result.Stderr = stderr
+	return result
+}
+
+func blastProtocolChangedFailure(command, code, message, stderr string, pretty bool) Result {
+	result := failure(command, 9, errorBody{Type: "contract.protocol_changed", Code: code, Message: message, Retryable: false, Details: map[string]any{}}, pretty)
+	result.Stderr = stderr
+	return result
+}
+
+func blastSubmissionUnavailableFailure(command string, pretty bool) Result {
+	result := failure(command, 8, errorBody{Type: "remote.unavailable", Code: "TEXT_BLAST_SUBMISSION_UNCERTAIN", Message: "Text blast submission could not be confirmed. Create a new plan before another attempt.", Retryable: false, Details: map[string]any{}}, pretty)
+	result.Stderr = "partiful: text blast submission uncertain\n"
+	return result
+}

--- a/internal/app/blasts.go
+++ b/internal/app/blasts.go
@@ -390,7 +390,7 @@ func buildBlastPreconditions(
 		result := blastProtocolChangedFailure(command, "TEXT_BLAST_PROTOCOL_CHANGED", "The text blast flow no longer matches the reviewed remote contract.", "partiful: text blast protocol changed\n", pretty)
 		return nil, blastPrivatePreconditions{}, &result
 	}
-	if len(toGroups) == 0 || snapshot.Total == 0 || textBlastCount > 10 {
+	if len(toGroups) == 0 || snapshot.Total == 0 || textBlastCount >= 10 {
 		result := eventPreconditionFailure(command, pretty)
 		return nil, blastPrivatePreconditions{}, &result
 	}

--- a/internal/app/blasts_test.go
+++ b/internal/app/blasts_test.go
@@ -196,6 +196,50 @@ func TestExecuteBlastSendSupportsStdinAndRejectsArgvMessage(t *testing.T) {
 	}
 }
 
+func TestExecuteBlastSendRejectsTheEleventhBlast(t *testing.T) {
+	files := &memoryFilesystem{files: map[string][]byte{
+		eventWriteCredentialsPath: []byte(eventWriteCredentials),
+		"message.txt":             []byte("Private body"),
+	}}
+	dependencies := eventWriteDependencies(files)
+	hostMessages := make([]map[string]any, 0, 10)
+	for index := range 10 {
+		hostMessages = append(hostMessages, firestoreDocument(
+			fmt.Sprintf("projects/getpartiful/databases/(default)/documents/events/event-example/hostMessages/m%d", index),
+			map[string]any{},
+		))
+	}
+	call := 0
+	dependencies.HTTP = scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+		call++
+		switch call {
+		case 1:
+			return jsonResponse(http.StatusOK, eventResponse(t, compatibleBlastEvent())), nil
+		case 2:
+			return jsonResponse(http.StatusOK, firestoreListResponse(t,
+				firestoreDocument(
+					"projects/getpartiful/databases/(default)/documents/events/event-example/guests/g1",
+					map[string]any{"status": firestoreString("GOING")},
+				),
+			)), nil
+		case 3:
+			return jsonResponse(http.StatusOK, firestoreListResponse(t, hostMessages...)), nil
+		default:
+			return nil, errors.New("must not submit an eleventh blast")
+		}
+	}}
+
+	result := app.Execute(context.Background(), app.Request{
+		Argv: []string{"blasts", "send", "event-example", "--audience", "all-guests", "--message-file", "message.txt"},
+	}, dependencies)
+	if result.ExitCode != 6 || !strings.Contains(result.Stdout, `"code":"EVENT_PRECONDITION_FAILED"`) {
+		t.Fatalf("result = %#v, want blast limit precondition failure", result)
+	}
+	if call != 3 {
+		t.Fatalf("request count = %d, want read-only precondition checks", call)
+	}
+}
+
 func TestExecuteBlastSendFailsClosedOnProtocolAndSubmissionUncertainty(t *testing.T) {
 	files := &memoryFilesystem{files: map[string][]byte{
 		eventWriteCredentialsPath: []byte(eventWriteCredentials),

--- a/internal/app/blasts_test.go
+++ b/internal/app/blasts_test.go
@@ -1,0 +1,279 @@
+package app_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/KalebCole/partiful-cli/internal/app"
+)
+
+func firestoreListResponse(t *testing.T, documents ...map[string]any) string {
+	t.Helper()
+	entries := make([]map[string]any, 0, len(documents))
+	entries = append(entries, documents...)
+	body, err := json.Marshal(map[string]any{"documents": entries})
+	if err != nil {
+		t.Fatalf("encode firestore list response: %v", err)
+	}
+	return string(body)
+}
+
+func firestoreDocument(name string, fields map[string]any) map[string]any {
+	return map[string]any{
+		"name":   name,
+		"fields": fields,
+	}
+}
+
+func firestoreString(value string) map[string]any {
+	return map[string]any{"stringValue": value}
+}
+
+func firestoreTimestamp(value string) map[string]any {
+	return map[string]any{"timestampValue": value}
+}
+
+func assertFirestoreListRequest(t *testing.T, request *http.Request, collection string) {
+	t.Helper()
+	if request.Method != http.MethodGet {
+		t.Fatalf("request method = %s, want GET", request.Method)
+	}
+	want := "https://firestore.googleapis.com/v1/projects/getpartiful/databases/(default)/documents/" + collection + "?pageSize=1000"
+	if request.URL.String() != want {
+		t.Fatalf("request URL = %s, want %s", request.URL.String(), want)
+	}
+	if auth := request.Header.Get("Authorization"); auth != "Bearer private-access-token" {
+		t.Fatalf("authorization = %q, want bearer token", auth)
+	}
+}
+
+func compatibleBlastEvent() map[string]any {
+	event := compatibleCancelEvent()
+	event["findATime"] = nil
+	delete(event, "guestAction")
+	delete(event, "enableWaitlist")
+	return event
+}
+
+func TestExecuteBlastSendPlansAndAppliesPrivacySafeAllGuests(t *testing.T) {
+	const messageText = "Keep this private"
+	messageDigest := sha256.Sum256([]byte(messageText))
+	files := &memoryFilesystem{files: map[string][]byte{
+		eventWriteCredentialsPath: []byte(eventWriteCredentials),
+		"message.txt":             []byte(messageText),
+	}}
+	dependencies := eventWriteDependencies(files)
+	dependencies.MutationRandom = strings.NewReader(strings.Repeat("b", 32))
+	call := 0
+	dependencies.HTTP = scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+		call++
+		switch call {
+		case 1, 4:
+			assertEventCallableRequest(t, request, "getEventInfo", `{"data":{"params":{"eventId":"event-example"},"amplitudeDeviceId":"MDEyMzQ1Njc4OWFiY2RlZg"}}`)
+			return jsonResponse(http.StatusOK, eventResponse(t, compatibleBlastEvent())), nil
+		case 2, 5:
+			assertFirestoreListRequest(t, request, "events/event-example/guests")
+			return jsonResponse(http.StatusOK, firestoreListResponse(t,
+				firestoreDocument("projects/getpartiful/databases/(default)/documents/events/event-example/guests/g1", map[string]any{"status": firestoreString("GOING"), "checkIn": firestoreTimestamp("2026-09-12T19:10:00Z")}),
+				firestoreDocument("projects/getpartiful/databases/(default)/documents/events/event-example/guests/g2", map[string]any{"status": firestoreString("MAYBE")}),
+				firestoreDocument("projects/getpartiful/databases/(default)/documents/events/event-example/guests/g3", map[string]any{"status": firestoreString("READY_TO_SEND")}),
+			)), nil
+		case 3, 6:
+			assertFirestoreListRequest(t, request, "events/event-example/hostMessages")
+			return jsonResponse(http.StatusOK, firestoreListResponse(t,
+				firestoreDocument("projects/getpartiful/databases/(default)/documents/events/event-example/hostMessages/h1", map[string]any{}),
+				firestoreDocument("projects/getpartiful/databases/(default)/documents/events/event-example/hostMessages/h2", map[string]any{"type": firestoreString("TEXT_BLAST")}),
+				firestoreDocument("projects/getpartiful/databases/(default)/documents/events/event-example/hostMessages/h3", map[string]any{"type": firestoreString("CANCELLATION_MESSAGE")}),
+			)), nil
+		case 7:
+			assertEventCallableRequest(t, request, "createTextBlast", `{"data":{"params":{"eventId":"event-example","message":{"text":"Keep this private","to":["invited","checkedIn","GOING","MAYBE"],"showOnEventPage":true}},"amplitudeDeviceId":"MDEyMzQ1Njc4OWFiY2RlZg","userId":"private-account"}}`)
+			return jsonResponse(http.StatusOK, `{"result":true}`), nil
+		default:
+			t.Fatalf("unexpected request %d: %s %s", call, request.Method, request.URL)
+			return nil, nil
+		}
+	}}
+
+	argv := []string{"blasts", "send", "event-example", "--audience", "all-guests", "--message-file", "message.txt", "--show-on-event-page"}
+	plan := app.Execute(context.Background(), app.Request{Argv: argv}, dependencies)
+	if plan.ExitCode != 0 || plan.Stderr != "" {
+		t.Fatalf("plan = %#v, want success", plan)
+	}
+	var envelope struct {
+		Data struct {
+			Operation string `json:"operation"`
+			EventID   string `json:"eventId"`
+			Input     struct {
+				Audience        string `json:"audience"`
+				ShowOnEventPage bool   `json:"showOnEventPage"`
+				Message         struct {
+					SHA256 string `json:"sha256"`
+					Length int    `json:"length"`
+				} `json:"message"`
+			} `json:"input"`
+			Request struct {
+				Message struct {
+					TextSHA256      string   `json:"textSha256"`
+					TextLength      int      `json:"textLength"`
+					To              []string `json:"to"`
+					ShowOnEventPage bool     `json:"showOnEventPage"`
+				} `json:"message"`
+			} `json:"request"`
+			PlanToken string `json:"planToken"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(plan.Stdout), &envelope); err != nil {
+		t.Fatalf("decode plan: %v\n%s", err, plan.Stdout)
+	}
+	if envelope.Data.Operation != "createTextBlast" || envelope.Data.EventID != "event-example" || envelope.Data.Input.Audience != "all-guests" || !envelope.Data.Input.ShowOnEventPage || envelope.Data.Input.Message.SHA256 != hex.EncodeToString(messageDigest[:]) || envelope.Data.Input.Message.Length != len([]rune(messageText)) {
+		t.Fatalf("plan input = %#v, want blast plan summary", envelope.Data)
+	}
+	if got := envelope.Data.Request.Message.To; fmt.Sprint(got) != fmt.Sprint([]string{"invited", "checkedIn", "GOING", "MAYBE"}) || !envelope.Data.Request.Message.ShowOnEventPage || envelope.Data.Request.Message.TextSHA256 != hex.EncodeToString(messageDigest[:]) || envelope.Data.Request.Message.TextLength != len([]rune(messageText)) {
+		t.Fatalf("plan request = %#v, want exact reviewed audience mapping", envelope.Data.Request.Message)
+	}
+	if strings.Contains(plan.Stdout+plan.Stderr, messageText) {
+		t.Fatal("plan output exposed private message text")
+	}
+	if strings.Contains(string(files.files[eventWriteMutationPath]), messageText) {
+		t.Fatal("stored mutation plan exposed private message text")
+	}
+
+	applied := app.Execute(context.Background(), app.Request{Argv: append(append([]string{}, argv...), "--apply", "--confirm", envelope.Data.PlanToken)}, dependencies)
+	if applied.ExitCode != 0 || applied.Stderr != "" || strings.Contains(applied.Stdout, messageText) {
+		t.Fatalf("applied = %#v, want private submitted result", applied)
+	}
+	if !strings.Contains(applied.Stdout, `"recipientStatus":"not-reported"`) || !strings.Contains(applied.Stdout, `"audience":"all-guests"`) || !strings.Contains(applied.Stdout, `"showOnEventPage":true`) {
+		t.Fatalf("applied stdout = %s, want submitted blast result", applied.Stdout)
+	}
+	if reused := app.Execute(context.Background(), app.Request{Argv: append(append([]string{}, argv...), "--apply", "--confirm", envelope.Data.PlanToken)}, dependencies); reused.ExitCode != 7 {
+		t.Fatalf("reused = %#v, want stale consumed plan", reused)
+	}
+}
+
+func TestExecuteBlastSendSupportsStdinAndRejectsArgvMessage(t *testing.T) {
+	files := &memoryFilesystem{files: map[string][]byte{eventWriteCredentialsPath: []byte(eventWriteCredentials)}}
+	dependencies := eventWriteDependencies(files)
+	dependencies.MutationRandom = strings.NewReader(strings.Repeat("c", 32))
+	call := 0
+	dependencies.HTTP = scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+		call++
+		switch call {
+		case 1:
+			assertEventCallableRequest(t, request, "getEventInfo", `{"data":{"params":{"eventId":"event-example"},"amplitudeDeviceId":"MDEyMzQ1Njc4OWFiY2RlZg"}}`)
+			event := compatibleBlastEvent()
+			event["guestAction"] = "APPLY"
+			return jsonResponse(http.StatusOK, eventResponse(t, event)), nil
+		case 2:
+			assertFirestoreListRequest(t, request, "events/event-example/guests")
+			return jsonResponse(http.StatusOK, firestoreListResponse(t,
+				firestoreDocument("projects/getpartiful/databases/(default)/documents/events/event-example/guests/g1", map[string]any{"status": firestoreString("APPROVED")}),
+				firestoreDocument("projects/getpartiful/databases/(default)/documents/events/event-example/guests/g2", map[string]any{"status": firestoreString("READY_TO_SEND")}),
+			)), nil
+		case 3:
+			assertFirestoreListRequest(t, request, "events/event-example/hostMessages")
+			return jsonResponse(http.StatusOK, firestoreListResponse(t)), nil
+		default:
+			t.Fatalf("unexpected request %d", call)
+			return nil, nil
+		}
+	}}
+
+	result := app.Execute(context.Background(), app.Request{Argv: []string{"blasts", "send", "event-example", "--message", "bad"}}, dependencies)
+	if result.ExitCode != 2 || !strings.Contains(result.Stdout, `"code":"FLAG_UNKNOWN"`) {
+		t.Fatalf("argv message result = %#v, want unknown flag", result)
+	}
+
+	stdinPlan := app.Execute(context.Background(), app.Request{Argv: []string{"blasts", "send", "event-example", "--audience", "all-guests", "--message-file", "-"}, Stdin: strings.NewReader("stdin secret")}, dependencies)
+	if stdinPlan.ExitCode != 0 || strings.Contains(stdinPlan.Stdout, "stdin secret") || !strings.Contains(stdinPlan.Stdout, `"to":["invited","APPROVED"]`) {
+		t.Fatalf("stdin plan = %#v, want stdin-based blast plan", stdinPlan)
+	}
+}
+
+func TestExecuteBlastSendFailsClosedOnProtocolAndSubmissionUncertainty(t *testing.T) {
+	files := &memoryFilesystem{files: map[string][]byte{
+		eventWriteCredentialsPath: []byte(eventWriteCredentials),
+		"message.txt":             []byte("Private body"),
+	}}
+	dependencies := eventWriteDependencies(files)
+	dependencies.MutationRandom = strings.NewReader(strings.Repeat("d", 32))
+
+	cases := []struct {
+		name     string
+		event    map[string]any
+		hostBody string
+		postErr  error
+		postBody string
+		exitCode int
+		contains string
+	}{
+		{name: "missing find a time", event: func() map[string]any { e := compatibleBlastEvent(); delete(e, "findATime"); return e }(), exitCode: 9, contains: `"type":"contract.protocol_changed"`},
+		{name: "old event", event: func() map[string]any { e := compatibleBlastEvent(); e["endDate"] = "2026-05-01T01:00:00Z"; return e }(), exitCode: 6, contains: `"code":"EVENT_PRECONDITION_FAILED"`},
+		{name: "malformed completion", event: compatibleBlastEvent(), hostBody: firestoreListResponse(t), postBody: `{"result":null}`, exitCode: 9, contains: `"type":"contract.protocol_changed"`},
+		{name: "submission uncertain", event: compatibleBlastEvent(), hostBody: firestoreListResponse(t), postErr: errors.New("network failure"), exitCode: 8, contains: `"code":"TEXT_BLAST_SUBMISSION_UNCERTAIN"`},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			deps := dependencies
+			deps.MutationRandom = strings.NewReader(strings.Repeat("d", 32))
+			call := 0
+			deps.HTTP = scriptedHTTP{do: func(request *http.Request) (*http.Response, error) {
+				call++
+				switch call {
+				case 1:
+					assertEventCallableRequest(t, request, "getEventInfo", `{"data":{"params":{"eventId":"event-example"},"amplitudeDeviceId":"MDEyMzQ1Njc4OWFiY2RlZg"}}`)
+					return jsonResponse(http.StatusOK, eventResponse(t, testCase.event)), nil
+				case 2:
+					assertFirestoreListRequest(t, request, "events/event-example/guests")
+					return jsonResponse(http.StatusOK, firestoreListResponse(t, firestoreDocument("projects/getpartiful/databases/(default)/documents/events/event-example/guests/g1", map[string]any{"status": firestoreString("GOING")}))), nil
+				case 3:
+					assertFirestoreListRequest(t, request, "events/event-example/hostMessages")
+					return jsonResponse(http.StatusOK, firestoreListResponse(t)), nil
+				case 4:
+					assertEventCallableRequest(t, request, "getEventInfo", `{"data":{"params":{"eventId":"event-example"},"amplitudeDeviceId":"MDEyMzQ1Njc4OWFiY2RlZg"}}`)
+					return jsonResponse(http.StatusOK, eventResponse(t, compatibleBlastEvent())), nil
+				case 5:
+					assertFirestoreListRequest(t, request, "events/event-example/guests")
+					return jsonResponse(http.StatusOK, firestoreListResponse(t, firestoreDocument("projects/getpartiful/databases/(default)/documents/events/event-example/guests/g1", map[string]any{"status": firestoreString("GOING")}))), nil
+				case 6:
+					assertFirestoreListRequest(t, request, "events/event-example/hostMessages")
+					return jsonResponse(http.StatusOK, testCase.hostBody), nil
+				case 7:
+					if testCase.postErr != nil {
+						return nil, testCase.postErr
+					}
+					return jsonResponse(http.StatusOK, testCase.postBody), nil
+				default:
+					t.Fatalf("unexpected request %d", call)
+					return nil, nil
+				}
+			}}
+			argv := []string{"blasts", "send", "event-example", "--audience", "all-guests", "--message-file", "message.txt"}
+			if testCase.postBody == "" && testCase.postErr == nil {
+				result := app.Execute(context.Background(), app.Request{Argv: argv}, deps)
+				if result.ExitCode != testCase.exitCode || !strings.Contains(result.Stdout, testCase.contains) {
+					t.Fatalf("result = %#v, want exit %d containing %q", result, testCase.exitCode, testCase.contains)
+				}
+				return
+			}
+			plan := app.Execute(context.Background(), app.Request{Argv: argv}, deps)
+			if plan.ExitCode != 0 {
+				t.Fatalf("plan = %#v", plan)
+			}
+			token := rsvpPlanToken(t, plan)
+			applied := app.Execute(context.Background(), app.Request{Argv: append(append([]string{}, argv...), "--apply", "--confirm", token)}, deps)
+			if applied.ExitCode != testCase.exitCode || !strings.Contains(applied.Stdout, testCase.contains) {
+				t.Fatalf("applied = %#v, want exit %d containing %q", applied, testCase.exitCode, testCase.contains)
+			}
+			if reused := app.Execute(context.Background(), app.Request{Argv: append(append([]string{}, argv...), "--apply", "--confirm", token)}, deps); reused.ExitCode != 7 {
+				t.Fatalf("reused = %#v, want stale consumed plan", reused)
+			}
+		})
+	}
+}

--- a/internal/app/execute_test.go
+++ b/internal/app/execute_test.go
@@ -112,7 +112,7 @@ func TestExecuteEventsListProjectsReviewedUpcomingEventWithoutPrompting(t *testi
 		}},
 	})
 
-	const want = `{"ok":true,"data":{"items":[{"eventId":"event-example","title":"Example event","start":"2026-09-12T19:00:00-07:00","end":null,"timezone":"America/Los_Angeles","state":"active","userRole":"host","myRsvp":"going"}]},"meta":{"command":"events.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
+	const want = `{"ok":true,"data":{"items":[{"eventId":"event-example","title":"Example event","start":"2026-09-12T19:00:00-07:00","end":null,"timezone":"America/Los_Angeles","state":"active","userRole":"host","myRsvp":"going"}]},"meta":{"command":"events.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
 	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want reviewed upcoming event projection", result)
 	}
@@ -184,7 +184,7 @@ func TestExecuteEventsListRefreshesAndUsesTokenIdentityWithoutPrompting(t *testi
 		}},
 	})
 
-	const want = `{"ok":true,"data":{"items":[{"eventId":"event-example","title":null,"start":null,"end":null,"timezone":null,"state":null,"userRole":"host","myRsvp":null}]},"meta":{"command":"events.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
+	const want = `{"ok":true,"data":{"items":[{"eventId":"event-example","title":null,"start":null,"end":null,"timezone":null,"state":null,"userRole":"host","myRsvp":null}]},"meta":{"command":"events.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
 	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want refreshed identity projection", result)
 	}
@@ -747,7 +747,7 @@ func TestExecuteEventsGetProjectsReviewedDetailAndNullUnavailableFields(t *testi
 		}},
 	})
 
-	const want = `{"ok":true,"data":{"eventId":"event-example","title":"Example event","start":"2026-09-12T19:00:00-07:00","end":"2026-09-12T22:00:00-07:00","timezone":"America/Los_Angeles","state":"cancelled","userRole":null,"myRsvp":null,"description":null,"location":null,"address":null,"visibility":null,"guestLimit":null,"poster":null,"links":null},"meta":{"command":"events.get","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"eventId":"event-example","title":"Example event","start":"2026-09-12T19:00:00-07:00","end":"2026-09-12T22:00:00-07:00","timezone":"America/Los_Angeles","state":"cancelled","userRole":null,"myRsvp":null,"description":null,"location":null,"address":null,"visibility":null,"guestLimit":null,"poster":null,"links":null},"meta":{"command":"events.get","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want reviewed nullable event detail", result)
 	}
@@ -1115,7 +1115,7 @@ func TestExecutePostersListReturnsFirstLocalPage(t *testing.T) {
 		}},
 	}))
 
-	const want = `{"ok":true,"data":{"items":[{"posterId":"first","name":"First","url":"https://example.invalid/first.png","contentType":"image/png","width":1200,"height":630,"tags":["party"],"categories":["fun"]},{"posterId":"duplicate","name":"Duplicate","url":"https://example.invalid/duplicate.gif","contentType":"image/gif","width":null,"height":null,"tags":["dance"],"categories":[]},{"posterId":"duplicate","name":"Duplicate Again","url":"https://example.invalid/duplicate-2.gif","contentType":"image/gif","width":640,"height":480,"tags":[],"categories":["night"]}]},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
+	const want = `{"ok":true,"data":{"items":[{"posterId":"first","name":"First","url":"https://example.invalid/first.png","contentType":"image/png","width":1200,"height":630,"tags":["party"],"categories":["fun"]},{"posterId":"duplicate","name":"Duplicate","url":"https://example.invalid/duplicate.gif","contentType":"image/gif","width":null,"height":null,"tags":["dance"],"categories":[]},{"posterId":"duplicate","name":"Duplicate Again","url":"https://example.invalid/duplicate-2.gif","contentType":"image/gif","width":640,"height":480,"tags":[],"categories":["night"]}]},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -1521,7 +1521,7 @@ func TestExecutePostersListRejectsCursorWhenPayloadChanges(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, dependencies)
 
-	const want = `{"ok":false,"error":{"type":"state.conflict","code":"CURSOR_SNAPSHOT_CHANGED","message":"The poster catalog changed after this cursor was issued.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"state.conflict","code":"CURSOR_SNAPSHOT_CHANGED","message":"The poster catalog changed after this cursor was issued.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7"}}` + "\n"
 	if result.ExitCode != 6 {
 		t.Fatalf("exit code = %d, want 6", result.ExitCode)
 	}
@@ -1666,7 +1666,7 @@ func TestExecutePostersListRejectsUnexpectedSuccessContentType(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7"}}` + "\n"
 	const wantStderr = "partiful: poster catalog protocol changed\n"
 	if result.ExitCode != 9 {
 		t.Fatalf("exit code = %d, want 9", result.ExitCode)
@@ -1692,7 +1692,7 @@ func TestExecutePostersListRejectsMalformedCursorBeforeRemoteFailure(t *testing.
 		}},
 	}))
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_INVALID","message":"The cursor is malformed.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_INVALID","message":"The cursor is malformed.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -1747,7 +1747,7 @@ func TestExecutePostersSearchRejectsCursorWithDifferentNormalizedFilter(t *testi
 		Stdin: strings.NewReader(""),
 	}, dependencies)
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_FILTER_MISMATCH","message":"The cursor does not match this command and filters.","retryable":false,"details":{}},"meta":{"command":"posters.search","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_FILTER_MISMATCH","message":"The cursor does not match this command and filters.","retryable":false,"details":{}},"meta":{"command":"posters.search","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -1770,7 +1770,7 @@ func TestExecutePostersListMapsNetworkFailureToRemoteUnavailable(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"remote.unavailable","code":"POSTER_CATALOG_UNAVAILABLE","message":"The poster catalog is unavailable.","retryable":true,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"remote.unavailable","code":"POSTER_CATALOG_UNAVAILABLE","message":"The poster catalog is unavailable.","retryable":true,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7"}}` + "\n"
 	const wantStderr = "partiful: poster catalog unavailable\n"
 	if result.ExitCode != 8 {
 		t.Fatalf("exit code = %d, want 8", result.ExitCode)
@@ -1800,7 +1800,7 @@ func TestExecutePostersListFailsClosedOnReceivedNon200(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7"}}` + "\n"
 	const wantStderr = "partiful: poster catalog protocol changed\n"
 	if result.ExitCode != 9 {
 		t.Fatalf("exit code = %d, want 9", result.ExitCode)
@@ -1878,7 +1878,7 @@ func TestExecutePostersListFailsClosedOnMalformed200Body(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"POSTER_CATALOG_PROTOCOL_CHANGED","message":"The poster catalog no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7"}}` + "\n"
 	if result.ExitCode != 9 {
 		t.Fatalf("exit code = %d, want 9", result.ExitCode)
 	}
@@ -1943,7 +1943,7 @@ func TestExecutePostersListRequiresMaxItemsWithAll(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"MAX_ITEMS_REQUIRED","message":"--all requires --max-items.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"MAX_ITEMS_REQUIRED","message":"--all requires --max-items.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -1965,7 +1965,7 @@ func TestExecutePostersListRejectsLimitWithAll(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"LIMIT_WITH_ALL","message":"--limit cannot be combined with --all.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"LIMIT_WITH_ALL","message":"--limit cannot be combined with --all.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -1983,7 +1983,7 @@ func TestExecutePostersListRejectsLimitAboveMaximum(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"LIMIT_INVALID","message":"Limit must be an integer from 1 to 100.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"LIMIT_INVALID","message":"Limit must be an integer from 1 to 100.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -1998,7 +1998,7 @@ func TestExecutePostersListRejectsEmptyCursor(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_INVALID","message":"The cursor is malformed.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"CURSOR_INVALID","message":"The cursor is malformed.","retryable":false,"details":{}},"meta":{"command":"posters.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -2016,7 +2016,7 @@ func TestExecutePostersSearchRequiresNonEmptyQuery(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"QUERY_REQUIRED","message":"Search query must not be empty.","retryable":false,"details":{}},"meta":{"command":"posters.search","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"QUERY_REQUIRED","message":"Search query must not be empty.","retryable":false,"details":{}},"meta":{"command":"posters.search","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -2031,7 +2031,7 @@ func TestExecuteVersion(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":true,"data":{"version":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"},"meta":{"command":"version","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"version":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7"},"meta":{"command":"version","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -2049,7 +2049,7 @@ func TestExecuteEventsListRequiresWhen(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"WHEN_INVALID","message":"--when must be upcoming or past.","retryable":false,"details":{}},"meta":{"command":"events.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"WHEN_INVALID","message":"--when must be upcoming or past.","retryable":false,"details":{}},"meta":{"command":"events.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -2071,14 +2071,14 @@ func TestExecutePrettyPrintsOneCompleteEnvelope(t *testing.T) {
   "ok": true,
   "data": {
     "version": "1.0.0",
-    "productContractRevision": "2026-08-12.6",
-    "remoteContractRevision": "2026-08-12.6"
+    "productContractRevision": "2026-08-12.7",
+    "remoteContractRevision": "2026-08-12.7"
   },
   "meta": {
     "command": "version",
     "cliVersion": "1.0.0",
-    "productContractRevision": "2026-08-12.6",
-    "remoteContractRevision": "2026-08-12.6",
+    "productContractRevision": "2026-08-12.7",
+    "remoteContractRevision": "2026-08-12.7",
     "warnings": []
   }
 }
@@ -2100,7 +2100,7 @@ func TestExecuteAcceptsNonInteractiveGlobalFlag(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":true,"data":{"version":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"},"meta":{"command":"version","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"version":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7"},"meta":{"command":"version","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -2132,8 +2132,8 @@ func TestExecuteRejectsRepeatedScalarFlag(t *testing.T) {
   "meta": {
     "command": "version",
     "cliVersion": "1.0.0",
-    "productContractRevision": "2026-08-12.6",
-    "remoteContractRevision": "2026-08-12.6"
+    "productContractRevision": "2026-08-12.7",
+    "remoteContractRevision": "2026-08-12.7"
   }
 }
 `
@@ -2154,7 +2154,7 @@ func TestExecuteSchemaListsOnlyCompletedCatalog(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":true,"data":{"commands":["auth.login","auth.logout","auth.status","cohosts.invite","cohosts.link.create","cohosts.link.revoke","cohosts.remove","cohosts.revoke-invite","contacts.list","doctor","events.cancel","events.create","events.get","events.list","events.update","guests.invite","guests.list","posters.list","posters.search","rsvp.get","rsvp.set","schema","version"]},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"commands":["auth.login","auth.logout","auth.status","blasts.send","cohosts.invite","cohosts.link.create","cohosts.link.revoke","cohosts.remove","cohosts.revoke-invite","contacts.list","doctor","events.cancel","events.create","events.get","events.list","events.update","guests.invite","guests.list","posters.list","posters.search","rsvp.get","rsvp.set","schema","version"]},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -2172,7 +2172,7 @@ func TestExecuteSchemaProjectsExecutableDefinition(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":true,"data":{"command":"auth.status","positionals":[],"flags":[],"inputSchema":{"type":"object","additionalProperties":false},"successSchema":{"type":"object","additionalProperties":false,"required":["authenticated","tokenState","expiresAt"],"properties":{"authenticated":{"type":"boolean"},"expiresAt":{"type":["string","null"],"format":"date-time"},"tokenState":{"type":"string","enum":["healthy","expiring","expired","missing"]}}},"failureTypes":["usage.invalid","input.invalid","auth.expired","remote.unavailable","contract.protocol_changed","internal.failure"],"safety":{"kind":"local-mutation","planRequired":false,"confirmationRequired":false}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"command":"auth.status","positionals":[],"flags":[],"inputSchema":{"type":"object","additionalProperties":false},"successSchema":{"type":"object","additionalProperties":false,"required":["authenticated","tokenState","expiresAt"],"properties":{"authenticated":{"type":"boolean"},"expiresAt":{"type":["string","null"],"format":"date-time"},"tokenState":{"type":"string","enum":["healthy","expiring","expired","missing"]}}},"failureTypes":["usage.invalid","input.invalid","auth.expired","remote.unavailable","contract.protocol_changed","internal.failure"],"safety":{"kind":"local-mutation","planRequired":false,"confirmationRequired":false}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -2230,7 +2230,7 @@ func TestExecuteRejectsUnknownSchemaPathWithoutEchoingInput(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_SCHEMA_NOT_FOUND","message":"No completed command has that schema path.","retryable":false,"details":{}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_SCHEMA_NOT_FOUND","message":"No completed command has that schema path.","retryable":false,"details":{}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -2261,7 +2261,7 @@ func TestExecuteAuthStatusWhenCredentialsAreMissing(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"missing","expiresAt":null},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"missing","expiresAt":null},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -2279,7 +2279,7 @@ func TestExecuteAuthLoginRequiresPrivateTerminal(t *testing.T) {
 		Stdin: strings.NewReader("private-stdin-value"),
 	}, app.Dependencies{})
 
-	const wantStdout = `{"ok":false,"error":{"type":"auth.human_required","code":"PRIVATE_TERMINAL_REQUIRED","message":"Authentication login requires a private terminal.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"auth.human_required","code":"PRIVATE_TERMINAL_REQUIRED","message":"Authentication login requires a private terminal.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7"}}` + "\n"
 	const wantStderr = "partiful: private terminal required\n"
 	if result.ExitCode != 3 {
 		t.Fatalf("exit code = %d, want 3", result.ExitCode)
@@ -2338,7 +2338,7 @@ func TestExecuteAuthLoginRejectsEmptyPrivateInputBeforeHTTP(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"input.invalid","code":"AUTH_INPUT_INVALID","message":"Authentication input is invalid.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"input.invalid","code":"AUTH_INPUT_INVALID","message":"Authentication input is invalid.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7"}}` + "\n"
 	if result.ExitCode != 2 || result.Stdout != wantStdout {
 		t.Fatalf("result = %#v, want invalid private input failure", result)
 	}
@@ -2480,7 +2480,7 @@ func TestExecuteAuthLoginPersistsReviewedSessionWithoutRevealingPrivateValues(t 
 		}},
 	})
 
-	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T01:10:00Z"},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T01:10:00Z"},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want redacted login success", result)
 	}
@@ -2553,7 +2553,7 @@ func TestExecuteAuthLoginMapsReviewedWrongCodeWithoutEchoingIt(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"input.invalid","code":"AUTH_CODE_REJECTED","message":"The verification code was rejected.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"input.invalid","code":"AUTH_CODE_REJECTED","message":"The verification code was rejected.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7"}}` + "\n"
 	const wantStderr = "partiful: authentication code rejected\n"
 	if result.ExitCode != 2 || result.Stdout != wantStdout || result.Stderr != wantStderr {
 		t.Fatalf("result = %#v, want reviewed wrong-code failure", result)
@@ -2694,7 +2694,7 @@ func TestExecuteAuthLoginMapsRejectedCustomTokenToExpired(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"INVALID_CUSTOM_TOKEN","message":"Authentication expired during login. Start login again.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"INVALID_CUSTOM_TOKEN","message":"Authentication expired during login. Start login again.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7"}}` + "\n"
 	const wantStderr = "partiful: authentication expired\n"
 	if result.ExitCode != 3 || result.Stdout != wantStdout || result.Stderr != wantStderr {
 		t.Fatalf("result = %#v, want reviewed custom-token failure", result)
@@ -2881,7 +2881,7 @@ func TestExecuteAuthLoginFailsClosedOnMalformedReviewedSuccess(t *testing.T) {
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"AUTH_PROTOCOL_CHANGED","message":"Authentication no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"contract.protocol_changed","code":"AUTH_PROTOCOL_CHANGED","message":"Authentication no longer matches the reviewed remote contract.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7"}}` + "\n"
 	const wantStderr = "partiful: authentication protocol changed\n"
 	if result.ExitCode != 9 || result.Stdout != wantStdout || result.Stderr != wantStderr {
 		t.Fatalf("result = %#v, want protocol drift failure", result)
@@ -2978,7 +2978,7 @@ func TestExecuteAuthLoginMapsNoResponseWithoutLeakingTransportError(t *testing.T
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"remote.unavailable","code":"AUTH_SERVICE_UNAVAILABLE","message":"The authentication service is unavailable.","retryable":true,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"remote.unavailable","code":"AUTH_SERVICE_UNAVAILABLE","message":"The authentication service is unavailable.","retryable":true,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7"}}` + "\n"
 	const wantStderr = "partiful: authentication service unavailable\n"
 	if result.ExitCode != 8 || result.Stdout != wantStdout || result.Stderr != wantStderr {
 		t.Fatalf("result = %#v, want auth unavailable failure", result)
@@ -3032,7 +3032,7 @@ func TestExecuteAuthLoginAtomicPersistenceFailurePreservesExistingCredentials(t 
 		Argv: []string{"auth", "login"},
 	}, dependencies)
 
-	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIAL_STORE_UNAVAILABLE","message":"Local credential storage is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIAL_STORE_UNAVAILABLE","message":"Local credential storage is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.login","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7"}}` + "\n"
 	if result.ExitCode != 10 || result.Stdout != wantStdout {
 		t.Fatalf("result = %#v, want atomic persistence failure", result)
 	}
@@ -3144,7 +3144,7 @@ func TestExecuteContactsListTraversesReviewedPagesAndReturnsOnlyPublicFields(t *
 		}},
 	})
 
-	const want = `{"ok":true,"data":{"items":[{"displayName":"Alice Example","sharedEventCount":2}]},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
+	const want = `{"ok":true,"data":{"items":[{"displayName":"Alice Example","sharedEventCount":2}]},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
 	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want reviewed public contact collection", result)
 	}
@@ -3199,7 +3199,7 @@ func TestExecuteContactsListFiltersLocallyAfterFirstIdentityOccurrenceWins(t *te
 		}},
 	})
 
-	const want = `{"ok":true,"data":{"items":[{"displayName":"Alice First","sharedEventCount":1},{"displayName":"Second ALICE","sharedEventCount":3}]},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
+	const want = `{"ok":true,"data":{"items":[{"displayName":"Alice First","sharedEventCount":1},{"displayName":"Second ALICE","sharedEventCount":3}]},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
 	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want locally filtered first-occurrence contacts", result)
 	}
@@ -3509,7 +3509,7 @@ func TestExecuteContactsListAcceptsOpenReviewedResponseFields(t *testing.T) {
 		}},
 	})
 
-	const want = `{"ok":true,"data":{"items":[{"displayName":"Open Contact","sharedEventCount":4}]},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
+	const want = `{"ok":true,"data":{"items":[{"displayName":"Open Contact","sharedEventCount":4}]},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
 	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want reviewed open response traversal", result)
 	}
@@ -3622,7 +3622,7 @@ func TestExecuteContactsListAcceptsUnknownUnauthenticatedErrorFields(t *testing.
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"REMOTE_SESSION_UNAUTHENTICATED","message":"Stored authentication is no longer accepted. Log in again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"REMOTE_SESSION_UNAUTHENTICATED","message":"Stored authentication is no longer accepted. Log in again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7"}}` + "\n"
 	if result.ExitCode != 3 || result.Stdout != wantStdout {
 		t.Fatalf("result = %#v, want reviewed unauthenticated mapping", result)
 	}
@@ -3655,7 +3655,7 @@ func TestExecuteContactsListMapsReviewedUnauthenticatedResponseToExpired(t *test
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"REMOTE_SESSION_UNAUTHENTICATED","message":"Stored authentication is no longer accepted. Log in again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"REMOTE_SESSION_UNAUTHENTICATED","message":"Stored authentication is no longer accepted. Log in again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7"}}` + "\n"
 	if result.ExitCode != 3 || result.Stdout != wantStdout {
 		t.Fatalf("result = %#v, want reviewed unauthenticated mapping", result)
 	}
@@ -3791,7 +3791,7 @@ func TestExecuteContactsListRejectsCursorWhenContactCatalogChanges(t *testing.T)
 		Stdin: strings.NewReader(""),
 	}, dependencies)
 
-	const want = `{"ok":false,"error":{"type":"state.conflict","code":"CURSOR_SNAPSHOT_CHANGED","message":"The contact catalog changed after this cursor was issued.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"state.conflict","code":"CURSOR_SNAPSHOT_CHANGED","message":"The contact catalog changed after this cursor was issued.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7"}}` + "\n"
 	if result.ExitCode != 6 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want contact snapshot conflict", result)
 	}
@@ -3937,7 +3937,7 @@ func TestExecuteContactsListMapsRejectedRefreshWithoutAttemptingRead(t *testing.
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"INVALID_REFRESH_TOKEN","message":"Stored authentication has expired. Log in again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"INVALID_REFRESH_TOKEN","message":"Stored authentication has expired. Log in again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7"}}` + "\n"
 	if result.ExitCode != 3 || result.Stdout != wantStdout {
 		t.Fatalf("result = %#v, want rejected refresh failure", result)
 	}
@@ -3998,7 +3998,7 @@ func TestExecuteContactsListReportsUnavailableConfigurationBeforeProtectedRead(t
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CONFIG_DIRECTORY_UNAVAILABLE","message":"Local configuration directory is unavailable.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CONFIG_DIRECTORY_UNAVAILABLE","message":"Local configuration directory is unavailable.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7"}}` + "\n"
 	if result.ExitCode != 10 || result.Stdout != wantStdout {
 		t.Fatalf("result = %#v, want unavailable configuration failure", result)
 	}
@@ -4027,7 +4027,7 @@ func TestExecuteContactsListRequiresAuthenticationWithoutRemoteCall(t *testing.T
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"auth.required","code":"AUTHENTICATION_REQUIRED","message":"Authentication is required. Log in and try again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"auth.required","code":"AUTHENTICATION_REQUIRED","message":"Authentication is required. Log in and try again.","retryable":false,"details":{}},"meta":{"command":"contacts.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7"}}` + "\n"
 	if result.ExitCode != 3 || result.Stdout != wantStdout {
 		t.Fatalf("result = %#v, want authentication requirement", result)
 	}
@@ -4178,7 +4178,7 @@ func TestExecuteAuthStatusRedactsHealthyCredentials(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T02:00:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T02:00:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -4212,7 +4212,7 @@ func TestExecuteAuthStatusReportsExpiringToken(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"expiring","expiresAt":"2026-08-11T00:04:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"expiring","expiresAt":"2026-08-11T00:04:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -4287,7 +4287,7 @@ func TestExecuteAuthStatusDeterministicallyRefreshesExpiringSession(t *testing.T
 	first := app.Execute(context.Background(), app.Request{
 		Argv: []string{"auth", "status"},
 	}, dependencies)
-	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T01:10:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":true,"tokenState":"healthy","expiresAt":"2026-08-11T01:10:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7","warnings":[]}}` + "\n"
 	if first.ExitCode != 0 || first.Stdout != want || first.Stderr != "" {
 		t.Fatalf("first status = %#v, want refreshed healthy session", first)
 	}
@@ -4461,7 +4461,7 @@ func TestExecuteAuthStatusMapsReviewedInvalidRefreshTokenToExpired(t *testing.T)
 		}},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"INVALID_REFRESH_TOKEN","message":"Stored authentication has expired. Log in again.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"auth.expired","code":"INVALID_REFRESH_TOKEN","message":"Stored authentication has expired. Log in again.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7"}}` + "\n"
 	const wantStderr = "partiful: authentication expired\n"
 	if result.ExitCode != 3 || result.Stdout != wantStdout || result.Stderr != wantStderr {
 		t.Fatalf("result = %#v, want reviewed invalid-refresh failure", result)
@@ -4580,7 +4580,7 @@ func TestExecuteAuthStatusReportsExpiredToken(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"expired","expiresAt":"2026-08-10T23:59:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"expired","expiresAt":"2026-08-10T23:59:00Z"},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -4609,7 +4609,7 @@ func TestExecuteAuthStatusFailureDoesNotRevealCredentialContents(t *testing.T) {
 		},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIALS_INVALID","message":"Local credentials are invalid.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIALS_INVALID","message":"Local credentials are invalid.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7"}}` + "\n"
 	const wantStderr = "partiful: local operation failed\n"
 	if result.ExitCode != 10 {
 		t.Fatalf("exit code = %d, want 10", result.ExitCode)
@@ -4645,7 +4645,7 @@ func TestExecuteAuthLogoutAtomicallyRemovesCredentials(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, dependencies)
 
-	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"missing","expiresAt":null},"meta":{"command":"auth.logout","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"authenticated":false,"tokenState":"missing","expiresAt":null},"meta":{"command":"auth.logout","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -4724,7 +4724,7 @@ func TestExecuteAuthLogoutFailureLeavesCredentialsAvailableAndRedactsError(t *te
 		Stdin: strings.NewReader(""),
 	}, dependencies)
 
-	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIAL_STORE_UNAVAILABLE","message":"Local credential storage is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.logout","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CREDENTIAL_STORE_UNAVAILABLE","message":"Local credential storage is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.logout","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7"}}` + "\n"
 	if result.ExitCode != 10 {
 		t.Fatalf("exit code = %d, want 10", result.ExitCode)
 	}
@@ -4761,7 +4761,7 @@ func TestExecuteDoctorReportsHealthyCredentialsWithoutPrivateData(t *testing.T) 
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":true,"checks":[{"name":"credentials","status":"pass","message":"Authentication credentials are available.","remediation":null}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":true,"checks":[{"name":"credentials","status":"pass","message":"Authentication credentials are available.","remediation":null}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -4794,7 +4794,7 @@ func TestExecuteDoctorReportsMissingCredentialsAsARedactedCheck(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials are missing.","remediation":"Establish authentication before using commands that require it."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials are missing.","remediation":"Establish authentication before using commands that require it."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -4823,7 +4823,7 @@ func TestExecuteDoctorWarnsWhenCredentialsExpireSoon(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":true,"checks":[{"name":"credentials","status":"warn","message":"Authentication credentials expire soon.","remediation":"Refresh authentication before the credentials expire."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":true,"checks":[{"name":"credentials","status":"warn","message":"Authentication credentials expire soon.","remediation":"Refresh authentication before the credentials expire."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -4852,7 +4852,7 @@ func TestExecuteDoctorFailsExpiredCredentialsCheck(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials have expired.","remediation":"Re-establish authentication."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials have expired.","remediation":"Re-establish authentication."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -4881,7 +4881,7 @@ func TestExecuteDoctorRedactsInvalidCredentialFile(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials are invalid.","remediation":"Remove the invalid credentials and re-establish authentication."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Authentication credentials are invalid.","remediation":"Remove the invalid credentials and re-establish authentication."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -4913,7 +4913,7 @@ func TestExecuteDoctorRedactsCredentialStorageFailure(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Credential storage is unavailable.","remediation":"Check local credential file permissions."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Credential storage is unavailable.","remediation":"Check local credential file permissions."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
@@ -5021,7 +5021,7 @@ func TestExecuteUsesDefinitionForFlagFailureCommandMetadata(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"input.invalid","code":"FLAG_REPEATED","message":"A scalar flag cannot be repeated.","retryable":false,"details":{"flag":"--non-interactive"}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"input.invalid","code":"FLAG_REPEATED","message":"A scalar flag cannot be repeated.","retryable":false,"details":{"flag":"--non-interactive"}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -5065,7 +5065,7 @@ func TestExecuteUsesKnownCommandMetadataForInvalidArity(t *testing.T) {
 		Stdin: strings.NewReader(""),
 	}, app.Dependencies{})
 
-	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_NOT_FOUND","message":"Unknown command.","retryable":false,"details":{}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"usage.invalid","code":"COMMAND_NOT_FOUND","message":"Unknown command.","retryable":false,"details":{}},"meta":{"command":"schema","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7"}}` + "\n"
 	if result.ExitCode != 2 {
 		t.Fatalf("exit code = %d, want 2", result.ExitCode)
 	}
@@ -5090,7 +5090,7 @@ func TestExecuteAuthStatusReportsConfigurationDirectoryFailure(t *testing.T) {
 		},
 	})
 
-	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CONFIG_DIRECTORY_UNAVAILABLE","message":"Local configuration directory is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
+	const wantStdout = `{"ok":false,"error":{"type":"internal.failure","code":"CONFIG_DIRECTORY_UNAVAILABLE","message":"Local configuration directory is unavailable.","retryable":false,"details":{}},"meta":{"command":"auth.status","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7"}}` + "\n"
 	if result.ExitCode != 10 {
 		t.Fatalf("exit code = %d, want 10", result.ExitCode)
 	}
@@ -5115,7 +5115,7 @@ func TestExecuteDoctorDiagnosesConfigurationDirectoryFailure(t *testing.T) {
 		},
 	})
 
-	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Configuration directory is unavailable.","remediation":"Set a usable user configuration directory."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"healthy":false,"checks":[{"name":"credentials","status":"fail","message":"Configuration directory is unavailable.","remediation":"Set a usable user configuration directory."}]},"meta":{"command":"doctor","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7","warnings":[]}}` + "\n"
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}

--- a/internal/app/guests_execute_test.go
+++ b/internal/app/guests_execute_test.go
@@ -173,7 +173,7 @@ func TestExecuteGuestsListReturnsPermissionDeniedForAttendee(t *testing.T) {
 		}},
 	})
 
-	const want = `{"ok":false,"error":{"type":"permission.denied","code":"HOST_PERMISSION_REQUIRED","message":"This command requires host access to the event.","retryable":false,"details":{"requiredRole":"host"}},"meta":{"command":"guests.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6"}}` + "\n"
+	const want = `{"ok":false,"error":{"type":"permission.denied","code":"HOST_PERMISSION_REQUIRED","message":"This command requires host access to the event.","retryable":false,"details":{"requiredRole":"host"}},"meta":{"command":"guests.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7"}}` + "\n"
 	if result.ExitCode != 4 || result.Stdout != want || result.Stderr != "partiful: host access required\n" {
 		t.Fatalf("result = %#v, want host permission denial", result)
 	}
@@ -225,7 +225,7 @@ func TestExecuteGuestsListReturnsEmptyCollectionForHost(t *testing.T) {
 		}},
 	})
 
-	const want = `{"ok":true,"data":{"items":[]},"meta":{"command":"guests.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
+	const want = `{"ok":true,"data":{"items":[]},"meta":{"command":"guests.list","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7","warnings":[],"page":{"limit":25,"nextCursor":null,"hasMore":false}}}` + "\n"
 	if result.ExitCode != 0 || result.Stdout != want || result.Stderr != "" {
 		t.Fatalf("result = %#v, want empty host guest list", result)
 	}
@@ -276,7 +276,7 @@ func TestExecuteGuestsInviteBindsResolvedContactAndAppliesWithoutReResolvingName
 	applied := app.Execute(context.Background(), app.Request{
 		Argv: append(append([]string{}, argv...), "--apply", "--confirm", token),
 	}, dependencies)
-	const want = `{"ok":true,"data":{"eventId":"event-example","submitted":true},"meta":{"command":"guests.invite","cliVersion":"1.0.0","productContractRevision":"2026-08-12.6","remoteContractRevision":"2026-08-12.6","warnings":[]}}` + "\n"
+	const want = `{"ok":true,"data":{"eventId":"event-example","submitted":true},"meta":{"command":"guests.invite","cliVersion":"1.0.0","productContractRevision":"2026-08-12.7","remoteContractRevision":"2026-08-12.7","warnings":[]}}` + "\n"
 	if applied.ExitCode != 0 || applied.Stdout != want || applied.Stderr != "" {
 		t.Fatalf("applied = %#v, want submitted-only guest invite result", applied)
 	}

--- a/internal/remote/blasts.go
+++ b/internal/remote/blasts.go
@@ -1,0 +1,108 @@
+package remote
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"unicode/utf8"
+)
+
+const maximumTextBlastResponseBytes = 1 << 20
+
+type TextBlastMessage struct {
+	Text            string   `json:"text"`
+	To              []string `json:"to"`
+	ShowOnEventPage bool     `json:"showOnEventPage"`
+}
+
+type CreateTextBlastParams struct {
+	EventID string           `json:"eventId"`
+	Message TextBlastMessage `json:"message"`
+}
+
+type textBlastRequest struct {
+	Data textBlastRequestData `json:"data"`
+}
+
+type textBlastRequestData struct {
+	Params            CreateTextBlastParams `json:"params"`
+	AmplitudeDeviceID string                `json:"amplitudeDeviceId"`
+	UserID            string                `json:"userId"`
+}
+
+func (client Client) CreateTextBlast(
+	ctx context.Context,
+	accessToken string,
+	amplitudeDeviceID string,
+	userID string,
+	params CreateTextBlastParams,
+) error {
+	if client.HTTP == nil {
+		return fmt.Errorf("%w: text blast transport", ErrUnavailable)
+	}
+	payload, _ := json.Marshal(textBlastRequest{Data: textBlastRequestData{
+		Params:            params,
+		AmplitudeDeviceID: amplitudeDeviceID,
+		UserID:            userID,
+	}})
+	request, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		partifulCallableHost+"/createTextBlast",
+		bytes.NewReader(payload),
+	)
+	if err != nil {
+		return fmt.Errorf("%w: text blast request", ErrUnavailable)
+	}
+	request.Header.Set("Authorization", "Bearer "+accessToken)
+	request.Header.Set("Content-Type", "application/json")
+	response, err := client.HTTP.Do(request)
+	if err != nil {
+		return fmt.Errorf("%w: text blast request failed", ErrUnavailable)
+	}
+	if response == nil || response.Body == nil {
+		return fmt.Errorf("%w: text blast response", ErrProtocolChanged)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("%w: text blast status", ErrProtocolChanged)
+	}
+	if !eventJSONContentType(response.Header.Get("Content-Type")) {
+		return fmt.Errorf("%w: text blast content type", ErrProtocolChanged)
+	}
+	body, err := io.ReadAll(io.LimitReader(response.Body, maximumTextBlastResponseBytes+1))
+	if err != nil {
+		return fmt.Errorf("%w: text blast response read", ErrUnavailable)
+	}
+	if len(body) > maximumTextBlastResponseBytes || !utf8.Valid(body) {
+		return fmt.Errorf("%w: text blast response body", ErrProtocolChanged)
+	}
+	root, err := decodeEventObject(body)
+	if err != nil {
+		return fmt.Errorf("%w: text blast response body", ErrProtocolChanged)
+	}
+	if raw, ok := root["data"]; ok {
+		if err := validateNonNullCallableCompletion(raw); err != nil {
+			return fmt.Errorf("%w: text blast completion", ErrProtocolChanged)
+		}
+		return nil
+	}
+	if raw, ok := root["result"]; ok {
+		if err := validateNonNullCallableCompletion(raw); err != nil {
+			return fmt.Errorf("%w: text blast completion", ErrProtocolChanged)
+		}
+		return nil
+	}
+	return fmt.Errorf("%w: text blast completion", ErrProtocolChanged)
+}
+
+func validateNonNullCallableCompletion(raw json.RawMessage) error {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return fmt.Errorf("completion is null")
+	}
+	return nil
+}

--- a/internal/remote/firestore_list.go
+++ b/internal/remote/firestore_list.go
@@ -1,0 +1,317 @@
+package remote
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"sort"
+	"strings"
+	"unicode/utf8"
+)
+
+const (
+	maximumFirestoreListBytes = 8 << 20
+	firestorePageSize         = 1000
+)
+
+type EventGuest struct {
+	Status    string
+	CheckedIn bool
+}
+
+type firestoreDocumentRecord struct {
+	Name       string
+	Fields     map[string]json.RawMessage
+	CreateTime *string
+	UpdateTime *string
+}
+
+func (client Client) ListEventGuests(
+	ctx context.Context,
+	accessToken string,
+	eventID string,
+) ([]EventGuest, error) {
+	documents, err := client.listFirestoreDocuments(
+		ctx,
+		accessToken,
+		firestoreCollectionPath("events", eventID, "guests"),
+	)
+	if err != nil {
+		return nil, err
+	}
+	guests := make([]EventGuest, 0, len(documents))
+	for _, document := range documents {
+		status, err := firestoreRequiredString(document.Fields, "status")
+		if err != nil || !validGuestStatus(status) {
+			return nil, fmt.Errorf("%w: guest document status", ErrProtocolChanged)
+		}
+		checkedIn, err := firestoreHasNonNullField(document.Fields, "checkIn")
+		if err != nil {
+			return nil, fmt.Errorf("%w: guest document check-in", ErrProtocolChanged)
+		}
+		guests = append(guests, EventGuest{Status: status, CheckedIn: checkedIn})
+	}
+	return guests, nil
+}
+
+func (client Client) CountTextBlasts(
+	ctx context.Context,
+	accessToken string,
+	eventID string,
+) (int, error) {
+	documents, err := client.listFirestoreDocuments(
+		ctx,
+		accessToken,
+		firestoreCollectionPath("events", eventID, "hostMessages"),
+	)
+	if err != nil {
+		return 0, err
+	}
+	count := 0
+	for _, document := range documents {
+		typeValue, present, err := firestoreOptionalNullableString(document.Fields, "type")
+		if err != nil {
+			return 0, fmt.Errorf("%w: host message type", ErrProtocolChanged)
+		}
+		if !present || typeValue == nil || *typeValue == "TEXT_BLAST" {
+			count++
+		}
+	}
+	return count, nil
+}
+
+func (client Client) listFirestoreDocuments(
+	ctx context.Context,
+	accessToken string,
+	collectionPath string,
+) ([]firestoreDocumentRecord, error) {
+	if client.HTTP == nil {
+		return nil, fmt.Errorf("%w: firestore list transport", ErrUnavailable)
+	}
+	var documents []firestoreDocumentRecord
+	pageToken := ""
+	for {
+		page, nextToken, err := client.listFirestoreDocumentsPage(
+			ctx,
+			accessToken,
+			collectionPath,
+			pageToken,
+		)
+		if err != nil {
+			return nil, err
+		}
+		documents = append(documents, page...)
+		if nextToken == "" {
+			return documents, nil
+		}
+		pageToken = nextToken
+	}
+}
+
+func (client Client) listFirestoreDocumentsPage(
+	ctx context.Context,
+	accessToken string,
+	collectionPath string,
+	pageToken string,
+) ([]firestoreDocumentRecord, string, error) {
+	query := url.Values{}
+	query.Set("pageSize", fmt.Sprintf("%d", firestorePageSize))
+	if pageToken != "" {
+		query.Set("pageToken", pageToken)
+	}
+	request, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodGet,
+		firestoreDocumentsHost+"/v1/projects/getpartiful/databases/(default)/documents/"+collectionPath+"?"+query.Encode(),
+		nil,
+	)
+	if err != nil {
+		return nil, "", fmt.Errorf("%w: firestore list request", ErrUnavailable)
+	}
+	request.Header.Set("Authorization", "Bearer "+accessToken)
+	response, err := client.HTTP.Do(request)
+	if err != nil {
+		return nil, "", fmt.Errorf("%w: firestore list request failed", ErrUnavailable)
+	}
+	if response == nil || response.Body == nil {
+		return nil, "", fmt.Errorf("%w: firestore list response", ErrProtocolChanged)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		return nil, "", fmt.Errorf("%w: firestore list status", ErrProtocolChanged)
+	}
+	if !eventJSONContentType(response.Header.Get("Content-Type")) {
+		return nil, "", fmt.Errorf("%w: firestore list content type", ErrProtocolChanged)
+	}
+	body, err := io.ReadAll(io.LimitReader(response.Body, maximumFirestoreListBytes+1))
+	if err != nil {
+		return nil, "", fmt.Errorf("%w: firestore list response read", ErrUnavailable)
+	}
+	if len(body) > maximumFirestoreListBytes || !utf8.Valid(body) {
+		return nil, "", fmt.Errorf("%w: firestore list response body", ErrProtocolChanged)
+	}
+	return decodeFirestoreListResponse(body)
+}
+
+func decodeFirestoreListResponse(body []byte) ([]firestoreDocumentRecord, string, error) {
+	root, err := decodeEventObject(body)
+	if err != nil {
+		return nil, "", fmt.Errorf("%w: firestore list response body", ErrProtocolChanged)
+	}
+	nextToken := ""
+	if raw, ok := root["nextPageToken"]; ok {
+		if json.Unmarshal(raw, &nextToken) != nil {
+			return nil, "", fmt.Errorf("%w: firestore list next page token", ErrProtocolChanged)
+		}
+	}
+	rawDocuments, ok := root["documents"]
+	if !ok {
+		return []firestoreDocumentRecord{}, nextToken, nil
+	}
+	if !isEventJSONKind(rawDocuments, '[') {
+		return nil, "", fmt.Errorf("%w: firestore list documents", ErrProtocolChanged)
+	}
+	var entries []json.RawMessage
+	if json.Unmarshal(rawDocuments, &entries) != nil || entries == nil {
+		return nil, "", fmt.Errorf("%w: firestore list documents", ErrProtocolChanged)
+	}
+	documents := make([]firestoreDocumentRecord, 0, len(entries))
+	for _, entry := range entries {
+		document, err := decodeFirestoreDocumentRecord(entry)
+		if err != nil {
+			return nil, "", fmt.Errorf("%w: firestore list document", ErrProtocolChanged)
+		}
+		documents = append(documents, document)
+	}
+	return documents, nextToken, nil
+}
+
+func decodeFirestoreDocumentRecord(raw json.RawMessage) (firestoreDocumentRecord, error) {
+	if err := validateFirestoreDocument(raw); err != nil {
+		return firestoreDocumentRecord{}, err
+	}
+	root, err := decodeEventObject(raw)
+	if err != nil {
+		return firestoreDocumentRecord{}, err
+	}
+	document := firestoreDocumentRecord{Fields: map[string]json.RawMessage{}}
+	if rawName, ok := root["name"]; ok {
+		if json.Unmarshal(rawName, &document.Name) != nil {
+			return firestoreDocumentRecord{}, fmt.Errorf("invalid firestore document name")
+		}
+	}
+	for _, field := range []string{"createTime", "updateTime"} {
+		if rawTime, ok := root[field]; ok {
+			var value string
+			if json.Unmarshal(rawTime, &value) != nil {
+				return firestoreDocumentRecord{}, fmt.Errorf("invalid firestore timestamp")
+			}
+			if field == "createTime" {
+				document.CreateTime = &value
+			} else {
+				document.UpdateTime = &value
+			}
+		}
+	}
+	if rawFields, ok := root["fields"]; ok {
+		fields, err := decodeEventObject(rawFields)
+		if err != nil {
+			return firestoreDocumentRecord{}, err
+		}
+		keys := make([]string, 0, len(fields))
+		for key := range fields {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			document.Fields[key] = bytes.Clone(fields[key])
+		}
+	}
+	return document, nil
+}
+
+func firestoreCollectionPath(segments ...string) string {
+	encoded := make([]string, 0, len(segments))
+	for _, segment := range segments {
+		encoded = append(encoded, url.PathEscape(segment))
+	}
+	return path.Join(encoded...)
+}
+
+func firestoreRequiredString(fields map[string]json.RawMessage, name string) (string, error) {
+	value, present, err := firestoreOptionalNullableString(fields, name)
+	if err != nil || !present || value == nil || *value == "" {
+		return "", fmt.Errorf("field is invalid")
+	}
+	return *value, nil
+}
+
+func firestoreOptionalNullableString(fields map[string]json.RawMessage, name string) (*string, bool, error) {
+	raw, ok := fields[name]
+	if !ok {
+		return nil, false, nil
+	}
+	object, err := decodeEventObject(raw)
+	if err != nil || len(object) != 1 {
+		return nil, true, fmt.Errorf("field is invalid")
+	}
+	if rawNull, ok := object["nullValue"]; ok {
+		if !bytes.Equal(bytes.TrimSpace(rawNull), []byte("null")) {
+			return nil, true, fmt.Errorf("field is invalid")
+		}
+		return nil, true, nil
+	}
+	rawString, ok := object["stringValue"]
+	if !ok {
+		return nil, true, fmt.Errorf("field is invalid")
+	}
+	var value string
+	if json.Unmarshal(rawString, &value) != nil {
+		return nil, true, fmt.Errorf("field is invalid")
+	}
+	return &value, true, nil
+}
+
+func firestoreHasNonNullField(fields map[string]json.RawMessage, name string) (bool, error) {
+	raw, ok := fields[name]
+	if !ok {
+		return false, nil
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return false, fmt.Errorf("field is invalid")
+	}
+	object, err := decodeEventObject(trimmed)
+	if err != nil || len(object) != 1 {
+		return false, fmt.Errorf("field is invalid")
+	}
+	if rawNull, ok := object["nullValue"]; ok {
+		if !bytes.Equal(bytes.TrimSpace(rawNull), []byte("null")) {
+			return false, fmt.Errorf("field is invalid")
+		}
+		return false, nil
+	}
+	for _, variant := range []string{"booleanValue", "integerValue", "doubleValue", "timestampValue", "stringValue", "bytesValue", "referenceValue", "geoPointValue", "arrayValue", "mapValue"} {
+		if _, ok := object[variant]; ok {
+			return true, nil
+		}
+	}
+	return false, fmt.Errorf("field is invalid")
+}
+
+func invitedGuestStatus(status string) bool {
+	return status == "READY_TO_SEND" ||
+		status == "SENDING" ||
+		status == "SENT" ||
+		status == "SEND_ERROR" ||
+		status == "DELIVERY_ERROR"
+}
+
+func normalizeFirestorePath(value string) string {
+	return strings.TrimPrefix(value, "/")
+}

--- a/spec/partiful.api-evidence.json
+++ b/spec/partiful.api-evidence.json
@@ -1,6 +1,6 @@
 {
-  "contractRevision": "2026-08-12.6",
-  "ownerReviewedBaseline": "2026-08-12.3",
+  "contractRevision": "2026-08-12.7",
+  "ownerReviewedBaseline": "2026-08-12.6",
   "contractPath": "spec/partiful.openapi.json",
   "allowedClassifications": [
     "dated-live-observation",
@@ -67,7 +67,12 @@
     "publicCohostCallableTransport20260812": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#callable-transport",
     "publicCohostRequestDocs20260812": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#cohost-request-document-shape",
     "publicCohostLinkState20260812": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#link-document-shape-and-token-path",
-    "publicCohostOperations20260812": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    "publicCohostOperations20260812": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions",
+    "publicTextBlastMapping20260812": "docs/research/2026-08-12-text-blast-mapping-public-assets.md#scope-and-provenance",
+    "publicTextBlastCompletion20260812": "docs/research/2026-08-12-text-blast-mapping-public-assets.md#createtextblast-helper-and-completion",
+    "publicTextBlastAllGuests20260812": "docs/research/2026-08-12-text-blast-mapping-public-assets.md#group-derivation-for-all-guests",
+    "publicTextBlastPreconditions20260812": "docs/research/2026-08-12-text-blast-mapping-public-assets.md#host-only-precondition-reads",
+    "publicTextBlastSubmitted20260812": "docs/research/2026-08-12-text-blast-mapping-public-assets.md#submitted-only-boundary"
   },
   "operations": {
     "createEvent": {
@@ -147,8 +152,8 @@
       "citation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
     },
     "firestoreListDocuments": {
-      "classification": "typescript-derived-inference",
-      "citation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get"
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-12-text-blast-mapping-public-assets.md#host-only-precondition-reads"
     },
     "refreshToken": {
       "classification": "dated-live-observation",
@@ -219,10 +224,10 @@
     "createTextBlast": {
       "request": "dated-live-observation",
       "requestCitation": "docs/research/2026-08-10-contract-evidence-sources.md#dated-text-blast-observation",
-      "response": "explicit-unknown",
-      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
-      "status": "explicit-unknown",
-      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+      "response": "current-first-party-public-asset-research",
+      "responseCitation": "docs/research/2026-08-12-text-blast-mapping-public-assets.md#createtextblast-helper-and-completion",
+      "status": "official-protocol-specification",
+      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firebase-callable-protocol"
     },
     "addInvitedGuestsAsHost": {
       "request": "current-first-party-public-asset-research",
@@ -337,12 +342,12 @@
       "statusCitation": "docs/research/2026-08-11-event-contacts-read-observation.md#guest-and-firestore-observations"
     },
     "firestoreListDocuments": {
-      "request": "typescript-derived-inference",
-      "requestCitation": "spec/research/historical-27-operation-draft.json#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get",
-      "response": "explicit-unknown",
-      "responseCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision",
-      "status": "explicit-unknown",
-      "statusCitation": "docs/research/2026-08-10-contract-evidence-sources.md#unknown-status-decision"
+      "request": "official-protocol-specification",
+      "requestCitation": "docs/research/2026-08-12-text-blast-mapping-public-assets.md#host-only-precondition-reads",
+      "response": "official-protocol-specification",
+      "responseCitation": "docs/research/2026-08-12-text-blast-mapping-public-assets.md#host-only-precondition-reads",
+      "status": "official-protocol-specification",
+      "statusCitation": "docs/research/2026-08-12-text-blast-mapping-public-assets.md#host-only-precondition-reads"
     },
     "refreshToken": {
       "request": "typescript-derived-inference",
@@ -7573,6 +7578,30 @@
     "#/components/schemas/GenerateEventCohostLinkCompletionResponse/anyOf/1/additionalProperties": {
       "classification": "current-first-party-public-asset-research",
       "citation": "docs/research/2026-08-12-cohost-lifecycle-public-assets.md#operation-requests-and-completions"
+    },
+    "#/paths/~1createTextBlast/post/responses/200": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-10-contract-evidence-sources.md#official-firebase-callable-protocol"
+    },
+    "#/paths/~1createTextBlast/post/responses/200/content/application~1json": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-text-blast-mapping-public-assets.md#createtextblast-helper-and-completion"
+    },
+    "#/paths/~1createTextBlast/post/responses/200/content/application~1json/schema/$ref": {
+      "classification": "current-first-party-public-asset-research",
+      "citation": "docs/research/2026-08-12-text-blast-mapping-public-assets.md#createtextblast-helper-and-completion"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/responses/200": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-12-text-blast-mapping-public-assets.md#host-only-precondition-reads"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/responses/200/content/application~1json": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-12-text-blast-mapping-public-assets.md#host-only-precondition-reads"
+    },
+    "#/paths/~1v1~1projects~1getpartiful~1databases~1(default)~1documents~1{collectionPath}/get/responses/200/content/application~1json/schema/$ref": {
+      "classification": "official-protocol-specification",
+      "citation": "docs/research/2026-08-12-text-blast-mapping-public-assets.md#host-only-precondition-reads"
     }
   },
   "posterCatalogObservation": {

--- a/spec/partiful.openapi.json
+++ b/spec/partiful.openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Partiful remote API contract",
-    "version": "2026-08-12.6",
+    "version": "2026-08-12.7",
     "description": "Owner-reviewed remote-only transport snapshot. Evidence classifications and uncertainty are recorded in spec/partiful.api-evidence.json."
   },
   "servers": [
@@ -579,6 +579,16 @@
           }
         },
         "responses": {
+          "200": {
+            "description": "Generic callable protocol completion. The current client awaits the helper promise but inspects no endpoint business field or recipient report; delivery remains unreported.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallableCompletionResponse"
+                }
+              }
+            }
+          },
           "default": {
             "description": "Response status and body are unknown."
           }
@@ -1718,6 +1728,16 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "Official Firestore list-documents protocol completion for the selected collection path.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FirestoreListResponse"
+                }
+              }
+            }
+          },
           "default": {
             "description": "Response status and body are unknown."
           }

--- a/tests/remote-api-contract.test.js
+++ b/tests/remote-api-contract.test.js
@@ -483,8 +483,8 @@ function citationResolves(citation) {
 describe('remote API contract', () => {
   it('is a consistently versioned OpenAPI 3.1 document with unique operation IDs', () => {
     expect(spec.openapi).toBe('3.1.0');
-    expect(evidence.contractRevision).toBe('2026-08-12.6');
-    expect(evidence.ownerReviewedBaseline).toBe('2026-08-12.3');
+    expect(evidence.contractRevision).toBe('2026-08-12.7');
+    expect(evidence.ownerReviewedBaseline).toBe('2026-08-12.6');
     expect(spec.info.version).toBe(evidence.contractRevision);
     expect(evidence.status).toBe('owner-reviewed');
     expect(evidence.sources.publicEventWriteMapping20260812)
@@ -504,8 +504,8 @@ describe('remote API contract', () => {
       .toBe(`${guestAssetResearchPath}#scope-and-provenance`);
     expect(citationResolves(evidence.sources.publicGuestMapping20260812)).toBe(true);
     const appSource = fs.readFileSync('internal/app/app.go', 'utf8');
-    expect(appSource).toContain('ProductContractRevision = "2026-08-12.6"');
-    expect(appSource).toContain('RemoteContractRevision  = "2026-08-12.6"');
+    expect(appSource).toContain('ProductContractRevision = "2026-08-12.7"');
+    expect(appSource).toContain('RemoteContractRevision  = "2026-08-12.7"');
     const ids = operations().map(({ operation }) => operation.operationId);
     expect(ids).toHaveLength(28);
     expect(new Set(ids).size).toBe(ids.length);
@@ -545,7 +545,9 @@ describe('remote API contract', () => {
         'markEventInterest',
         'createEvent',
         'cancelEvent',
+        'createTextBlast',
         'getGuests',
+        'firestoreListDocuments',
         'firestorePatchEvent',
         'createCohostRequest',
         'deleteCohostRequest',
@@ -566,7 +568,7 @@ describe('remote API contract', () => {
       ...materialClaimPointers(spec.paths, '#/paths', 'paths'),
       ...materialClaimPointers(spec.components, '#/components', 'components'),
     ]);
-    expect(pointers).toHaveLength(1782);
+    expect(pointers).toHaveLength(1788);
     for (const pointer of pointers) {
       const claim = evidence.claims[pointer];
       expect(claim, pointer).toBeDefined();
@@ -609,8 +611,8 @@ describe('remote API contract', () => {
       .filter(({ operation }) => operation.responses['200']?.content)
       .map(({ operation }) => operation.operationId)
       .sort();
-    expect(with200).toHaveLength(24);
-    expect(withTyped200Body).toHaveLength(23);
+    expect(with200).toHaveLength(26);
+    expect(withTyped200Body).toHaveLength(25);
     expect(with200.filter((id) => !withTyped200Body.includes(id)))
       .toEqual(['sendAuthCodeTrusted']);
 
@@ -625,14 +627,14 @@ describe('remote API contract', () => {
       /Eleven of those\s+operations have a typed `200` response body\./,
     );
     expect(ledger).toContain(
-      'Ten callable operations have protocol-specified HTTP `200` completion',
+      'Eleven callable operations have protocol-specified HTTP `200` completion',
     );
     expect(ledger).toContain(
       '`firestorePatchEvent` uses the official Firestore PATCH path',
     );
-    expect(ledger.match(/The 1782 material claims/g)).toHaveLength(2);
+    expect(ledger.match(/The 1788 material claims/g)).toHaveLength(2);
     expect(ledger).toContain(
-      '**Proposed contract revision:** `2026-08-12.6`',
+      '**Proposed contract revision:** `2026-08-12.7`',
     );
     expect(ledger).toContain('**Status:** Owner-reviewed');
     expect(ledger).toContain('Current first-party public-asset research');
@@ -678,11 +680,13 @@ describe('remote API contract', () => {
       'markEventInterest',
       'createEvent',
       'cancelEvent',
+      'createTextBlast',
       'createCohostRequest',
       'deleteCohostRequest',
       'removeCohost',
       'generateEventCohostLink',
       'revokeEventCohostLink',
+      'firestoreListDocuments',
       'firestorePatchEvent',
     ]);
     const observedErrorOps = {
@@ -701,6 +705,8 @@ describe('remote API contract', () => {
       markEventInterest: ['200', 'default'],
       createEvent: ['200', 'default'],
       cancelEvent: ['200', 'default'],
+      createTextBlast: ['200', 'default'],
+      firestoreListDocuments: ['200', 'default'],
       firestorePatchEvent: ['200', 'default'],
     };
     for (const { operation } of operations()) {
@@ -750,11 +756,13 @@ describe('remote API contract', () => {
       'markEventInterest',
       'createEvent',
       'cancelEvent',
+      'createTextBlast',
       'createCohostRequest',
       'deleteCohostRequest',
       'removeCohost',
       'generateEventCohostLink',
       'revokeEventCohostLink',
+      'firestoreListDocuments',
       'firestorePatchEvent',
     ]);
     const observedResponseSources = new Map([
@@ -777,11 +785,13 @@ describe('remote API contract', () => {
       ['markEventInterest', evidence.sources.publicInterestCompletion20260812],
       ['createEvent', evidence.sources.publicCreateEventCompletion20260812],
       ['cancelEvent', evidence.sources.publicCancelEvent20260812],
+      ['createTextBlast', evidence.sources.publicTextBlastCompletion20260812],
       ['createCohostRequest', evidence.sources.publicCohostOperations20260812],
       ['deleteCohostRequest', evidence.sources.publicCohostOperations20260812],
       ['removeCohost', evidence.sources.publicCohostOperations20260812],
       ['generateEventCohostLink', evidence.sources.publicCohostOperations20260812],
       ['revokeEventCohostLink', evidence.sources.publicCohostOperations20260812],
+      ['firestoreListDocuments', evidence.sources.publicTextBlastPreconditions20260812],
       ['firestorePatchEvent', evidence.sources.officialFirestoreProtocol],
     ]);
     for (const { path, method, operation } of operations()) {
@@ -793,9 +803,10 @@ describe('remote API contract', () => {
         const expectedClassification = [
           'firestorePatchEvent',
           'addInvitedGuestsAsHost',
+          'firestoreListDocuments',
         ].includes(operation.operationId)
           ? 'official-protocol-specification'
-          : ['addGuest', 'getGuests', 'markEventInterest', 'createEvent', 'cancelEvent', 'createCohostRequest', 'deleteCohostRequest', 'removeCohost', 'generateEventCohostLink', 'revokeEventCohostLink']
+          : ['addGuest', 'createTextBlast', 'getGuests', 'markEventInterest', 'createEvent', 'cancelEvent', 'createCohostRequest', 'deleteCohostRequest', 'removeCohost', 'generateEventCohostLink', 'revokeEventCohostLink']
               .includes(operation.operationId)
             ? 'current-first-party-public-asset-research'
             : 'dated-live-observation';
@@ -1603,9 +1614,9 @@ describe('remote API contract', () => {
     const product = fs.readFileSync(productContractPath, 'utf8');
     for (const expected of [
       '**Status:** Approved product contract',
-      '**Product contract revision:** `2026-08-12.6`',
-      '**Remote API contract revision:** `2026-08-12.6`',
-      '**Currently shipped Go revisions:** product and remote `2026-08-12.6`',
+      '**Product contract revision:** `2026-08-12.7`',
+      '**Remote API contract revision:** `2026-08-12.7`',
+      '**Currently shipped Go revisions:** product and remote `2026-08-12.7`',
       '`PUBLISHED` → `active`',
       '`CANCELED` → `cancelled`',
       '`UNSAVED` exists in the current first-party client vocabulary',
@@ -1650,8 +1661,8 @@ describe('remote API contract', () => {
     );
 
     const appSource = fs.readFileSync('internal/app/app.go', 'utf8');
-    expect(appSource).toContain('ProductContractRevision = "2026-08-12.6"');
-    expect(appSource).toContain('RemoteContractRevision  = "2026-08-12.6"');
+    expect(appSource).toContain('ProductContractRevision = "2026-08-12.7"');
+    expect(appSource).toContain('RemoteContractRevision  = "2026-08-12.7"');
   });
 
   it('defines evidence-backed RSVP planning and submitted-only completion', () => {
@@ -2182,14 +2193,14 @@ describe('remote API contract', () => {
       /"remoteContractRevision": "([^"]+)"/g,
     )].map((match) => match[1]);
 
-    expect(shippedRevision).toBe('2026-08-12.6');
-    expect(documentedRevision).toBe('2026-08-12.6');
-    expect(documentedProductRevision).toBe('2026-08-12.6');
+    expect(shippedRevision).toBe('2026-08-12.7');
+    expect(documentedRevision).toBe('2026-08-12.7');
+    expect(documentedProductRevision).toBe('2026-08-12.7');
     expect(new Set(envelopeRevisions)).toEqual(new Set([documentedRevision]));
     expect(spec.info.version).toBe(documentedRevision);
     expect(evidence.status).toBe('owner-reviewed');
     expect(spec.info.version).toBe(shippedRevision);
-    expect(appSource).toContain('ProductContractRevision = "2026-08-12.6"');
+    expect(appSource).toContain('ProductContractRevision = "2026-08-12.7"');
     expect(productContract)
       .not.toContain('currently leaves every operation response status and body unknown');
     expect(contactResearch)


### PR DESCRIPTION
## Summary

Implements the evidence-backed Go text-blast slice for #170.

- adds host-only consequential `blasts send` with message input from file or stdin only
- binds message digest/length, exact all-guests recipient representation, page-display flag, account, event, and request in a five-minute single-use plan
- keeps message text out of argv, output, diagnostics, public plan tokens, and shared metadata
- re-reads host/event facts, consumes before one dispatch attempt, and never retries
- validates the reviewed nested `createTextBlast` request and generic completion
- reports submitted-only `recipientStatus: "not-reported"` without inferring delivery
- preserves merged `.5`/`.6` slices and advances the reviewed contract to `2026-08-12.7`

No live blast or credential capture was used.

## Validation

- `go test -race ./...`
- `go vet ./...`
- `go build ./...`
- `go mod verify`
- `npm test -- tests/remote-api-contract.test.js`
- `npm run typecheck`
- privacy guard and diff check

Closes #170.